### PR TITLE
Refactoring: opinion type made an enum

### DIFF
--- a/packages/fpc/fpc_test.go
+++ b/packages/fpc/fpc_test.go
@@ -14,8 +14,8 @@ func TestIsFinal(t *testing.T) {
 		want     bool
 	}
 	var tests = []testInput{
-		{Opinions{true, true, true, true}, 2, 2, true},
-		{Opinions{true, true, true, false}, 2, 2, false},
+		{Opinions{Like, Like, Like, Like}, 2, 2, true},
+		{Opinions{Like, Like, Like, Dislike}, 2, 2, false},
 	}
 
 	for _, test := range tests {
@@ -33,9 +33,9 @@ func TestGetLastOpinion(t *testing.T) {
 		err      error
 	}
 	var tests = []testInput{
-		{Opinions{true, true, true}, true, nil},
-		{Opinions{true, true, true, false}, false, nil},
-		{Opinions{}, false, errors.New("opinion is empty")},
+		{Opinions{Like, Like, Like}, Like, nil},
+		{Opinions{Like, Like, Like, Dislike}, Dislike, nil},
+		{Opinions{}, Undefined, errors.New("opinion is empty")},
 	}
 
 	for _, test := range tests {
@@ -63,7 +63,7 @@ func TestFPC(t *testing.T) {
 	}
 	for i := 0; i < N; i++ {
 		fpcInstance[i] = New(getKnownPeers, queryNode, NewParameters())
-		fpcInstance[i].VoteOnTxs(TxOpinion{1, true}, TxOpinion{2, false})
+		fpcInstance[i].VoteOnTxs(TxOpinion{1, Like}, TxOpinion{2, Dislike})
 	}
 
 	//ticker := time.NewTicker(300 * time.Millisecond)

--- a/plugins/fpc/instances/test/instance.go
+++ b/plugins/fpc/instances/test/instance.go
@@ -20,7 +20,7 @@ func Configure(plugin *node.Plugin) {
 	queryNode := func(txs []fpc.Hash, node int) []fpc.Opinion {
 		output := make([]fpc.Opinion, len(txs))
 		for tx := range txs {
-			output[tx] = true
+			output[tx] = fpc.Like
 		}
 		return output
 	}
@@ -36,7 +36,7 @@ func Run(plugin *node.Plugin) {
 	daemon.BackgroundWorker(func() {
 		ticker := time.NewTicker(5000 * time.Millisecond)
 		round := 0
-		INSTANCE.VoteOnTxs(fpc.TxOpinion{1, true})
+		INSTANCE.VoteOnTxs(fpc.TxOpinion{1, fpc.Like})
 		for {
 			select {
 			case <-ticker.C:


### PR DESCRIPTION
Opinion now is of type int described as an enum (apparently this is the "go" way). Funny thing is that I used the keyword iota! It is basically a counter that autoincrements when defining new enum.
I've updated fpc_test.go as well, but let's ignore it since one of the previous PR refactored that massively. 