### PR TITLE
:hammer: refactor opinion and ID types

### DIFF
--- a/packages/fpc/fpc.go
+++ b/packages/fpc/fpc.go
@@ -80,10 +80,10 @@ func (fpc *Instance) GetInterimOpinion(txs ...ID) []Opinion {
 }
 
 // ID is the unique identifier of the querried object (e.g. a transaction Hash)
-type ID string
+type ID = string
 
 // Opinion is the like/dislike opinion of a given tx
-type Opinion bool
+type Opinion = bool
 
 // TxOpinion defines the current opinion of a tx
 // TxHash is the transaction hash
@@ -174,10 +174,8 @@ func (fpc *Instance) updateOpinion() {
 				threshold = runif(fpc.state.tick.x, fpc.state.parameters.beta, 1-fpc.state.parameters.beta)
 			}
 
-			newOpinion := Opinion(eta.value > threshold)
+			newOpinion := eta.value > threshold
 			fpc.state.opinionHistory.Store(tx, newOpinion)
-			history = append(history, newOpinion)
-
 		}
 	}
 }

--- a/plugins/fcob/fcob.go
+++ b/plugins/fcob/fcob.go
@@ -81,7 +81,7 @@ func makeRunProtocol(plugin *node.Plugin, tangle tangleAPI, voter fpc.Voter) Run
 				// converting tx into fpc TxOpinion
 				cTx := fpc.TxOpinion{
 					TxHash:  fpc.ID(tx),
-					Opinion: fpc.Opinion(txOpinion.isLiked),
+					Opinion: txOpinion.isLiked,
 				}
 				txsToSubmit = append(txsToSubmit, cTx)
 			}
@@ -99,7 +99,7 @@ func configureUpdateTxsVoted(plugin *node.Plugin, tangle tangleAPI) *events.Clos
 	return events.NewClosure(func(txs []fpc.TxOpinion) {
 		plugin.LogInfo(fmt.Sprintf("Voting Done for txs: %v", txs))
 		for _, tx := range txs {
-			err := setOpinion(ternary.Trytes(tx.TxHash), Opinion{bool(tx.Opinion), VOTED}, tangle)
+			err := setOpinion(ternary.Trytes(tx.TxHash), Opinion{tx.Opinion, VOTED}, tangle)
 			if err != nil {
 				plugin.LogFailure(fmt.Sprint(err))
 			}

--- a/plugins/fpc/network/queryNode.go
+++ b/plugins/fpc/network/queryNode.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"strconv"
 	"time"
-	"unsafe"
 
 	"github.com/iotaledger/goshimmer/packages/fpc"
 	"github.com/iotaledger/goshimmer/plugins/autopeering/instances/knownpeers"
@@ -25,7 +24,7 @@ func queryNode(txHash []fpc.ID, client pb.FPCQueryClient) (output []fpc.Opinion)
 
 	// Prepare query
 	query := &pb.QueryRequest{
-		TxHash: *(*[]string)(unsafe.Pointer(&txHash)),
+		TxHash: txHash,
 	}
 
 	opinions, err := client.GetOpinion(ctx, query)
@@ -34,10 +33,7 @@ func queryNode(txHash []fpc.ID, client pb.FPCQueryClient) (output []fpc.Opinion)
 		return output
 	}
 
-	// Converting QueryReply_Opinion to Opinion
-	output = *(*[]fpc.Opinion)(unsafe.Pointer(&opinions.Opinion))
-
-	return output
+	return opinions.GetOpinion()
 }
 
 // QueryNode sends a query to a node and returns a list of opinions

--- a/plugins/fpc/network/server/server.go
+++ b/plugins/fpc/network/server/server.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"net"
 	"strconv"
-	"unsafe"
 
 	"github.com/iotaledger/goshimmer/packages/daemon"
 	"github.com/iotaledger/goshimmer/packages/fpc"
@@ -33,12 +32,9 @@ func newServer(fpc *fpc.Instance) *queryServer {
 // GetOpinion returns the opinions of the given txs.
 // Currently, we only look for opinions by calling fpc.GetInterimOpinion
 func (s *queryServer) GetOpinion(ctx context.Context, req *pb.QueryRequest) (*pb.QueryReply, error) {
-	// converting QueryRequest strings to fpc.ID
-	requestedIDs := *(*[]fpc.ID)(unsafe.Pointer(&req.TxHash))
-
-	opinions := s.fpc.GetInterimOpinion(requestedIDs...)
+	opinions := s.fpc.GetInterimOpinion(req.TxHash...)
 	reply := &pb.QueryReply{
-		Opinion: *(*[]bool)(unsafe.Pointer(&opinions)),
+		Opinion: opinions,
 	}
 	return reply, nil
 }


### PR DESCRIPTION
This PR refactors the type definition of both

- fpc.Opinion
- fpc.ID

so that casting from Opinion to bool and from ID to string (and viceversa) is not required anymore