### PR TITLE
Fix: bct_curl state constant too big on 32-bit systems

### DIFF
--- a/packages/curl/batch_hasher.go
+++ b/packages/curl/batch_hasher.go
@@ -43,7 +43,7 @@ func (this *BatchHasher) processHashes(tasks []batchworkerpool.Task) {
 		}
 
 		// calculate the hash
-		bctCurl := NewBCTCurl(this.hashLength, this.rounds)
+		bctCurl := NewBCTCurl(this.hashLength, this.rounds, strconv.IntSize)
 		bctCurl.Reset()
 		bctCurl.Absorb(bcTrits)
 

--- a/packages/curl/bct_curl.go
+++ b/packages/curl/bct_curl.go
@@ -3,22 +3,29 @@ package curl
 import "github.com/iotaledger/goshimmer/packages/ternary"
 
 const (
-	HIGH_LONG_BITS             = 0xFFFFFFFFFFFFFFFF
 	NUMBER_OF_TRITS_IN_A_TRYTE = 3
 )
 
 type BCTCurl struct {
 	hashLength     int
 	numberOfRounds int
+	highLongBits   uint
 	stateLength    int
 	state          ternary.BCTrits
 	cTransform     func()
 }
 
-func NewBCTCurl(hashLength int, numberOfRounds int) *BCTCurl {
+func NewBCTCurl(hashLength int, numberOfRounds int, batchSize int) *BCTCurl {
+
+	var highLongBits uint
+	for i := 0; i < batchSize; i++ {
+		highLongBits += 1 << uint(i)
+	}
+
 	this := &BCTCurl{
 		hashLength:     hashLength,
 		numberOfRounds: numberOfRounds,
+		highLongBits:   highLongBits,
 		stateLength:    NUMBER_OF_TRITS_IN_A_TRYTE * hashLength,
 		state: ternary.BCTrits{
 			Lo: make([]uint, NUMBER_OF_TRITS_IN_A_TRYTE*hashLength),
@@ -34,8 +41,8 @@ func NewBCTCurl(hashLength int, numberOfRounds int) *BCTCurl {
 
 func (this *BCTCurl) Reset() {
 	for i := 0; i < this.stateLength; i++ {
-		this.state.Lo[i] = HIGH_LONG_BITS
-		this.state.Hi[i] = HIGH_LONG_BITS
+		this.state.Lo[i] = this.highLongBits
+		this.state.Hi[i] = this.highLongBits
 	}
 }
 


### PR DESCRIPTION
GoShimmer was not able to compile on 32-bit systems.
With this fix another user reported he is able to build now.