### PR TITLE
added total number to neighbor display

### DIFF
--- a/plugins/statusscreen/ui_header_bar.go
+++ b/plugins/statusscreen/ui_header_bar.go
@@ -80,7 +80,7 @@ func (headerBar *UIHeaderBar) Update() {
 
 	fmt.Fprintf(headerBar.InfoContainer, "[::b]Node ID: [::d]%40v  ", accountability.OwnId().StringIdentifier)
 	fmt.Fprintln(headerBar.InfoContainer)
-	fmt.Fprintf(headerBar.InfoContainer, "[::b]Neighbors: [::d]%40v  ", strconv.Itoa(len(chosenneighbors.INSTANCE.Peers))+" chosen / "+strconv.Itoa(len(acceptedneighbors.INSTANCE.Peers))+" accepted")
+	fmt.Fprintf(headerBar.InfoContainer, "[::b]Neighbors: [::d]%40v  ", strconv.Itoa(len(chosenneighbors.INSTANCE.Peers))+" chosen / "+strconv.Itoa(len(acceptedneighbors.INSTANCE.Peers))+" accepted / "+strconv.Itoa(len(chosenneighbors.INSTANCE.Peers)+len(acceptedneighbors.INSTANCE.Peers))+" total")
 	fmt.Fprintln(headerBar.InfoContainer)
 	fmt.Fprintf(headerBar.InfoContainer, "[::b]Known Peers: [::d]%40v  ", strconv.Itoa(len(knownpeers.INSTANCE.Peers))+" total / "+strconv.Itoa(len(neighborhood.INSTANCE.Peers))+" neighborhood")
 	fmt.Fprintln(headerBar.InfoContainer)


### PR DESCRIPTION
Changed the display of neigbors from "x chosen / y accepted" to "x chosen / y accepted / x+y total" to reduce confusion about the total neigbors a node is connected to. 