### PR TITLE
Improve README about docker command

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ docker build -t iotaledger/goshimmer .
 ```
 and then run it with
 ```
-docker run --rm -it -v target/mainnetdb:/root/mainnetdb iotaledger/goshimmer
+docker run --rm -it -v "$(pwd)/mainnetdb:/app/mainnetdb" iotaledger/goshimmer
 ```
-You may replace `target/mainnetdb` with a custom path to the database folder.
+You may replace `$(pwd)/mainnetdb` with a custom path to the database folder.
 
 To start Shimmer in the background, you can also simply use [Docker Compose](https://docs.docker.com/compose/) by running
 ```


### PR DESCRIPTION
Since a while my previous PR has changed the /root work directory in the Dockerfile to /app (to allow unprivileged users to run as well). This PR updates the README to mount the DB path to the correct destination inside of the container.
In addition it makes use of $(pwd) to provide the full source path, as pointing to a "naked" path does not work as intended.