### PR TITLE
Distance function should use salt

### DIFF
--- a/plugins/autopeering/instances/chosenneighbors/distance.go
+++ b/plugins/autopeering/instances/chosenneighbors/distance.go
@@ -13,7 +13,7 @@ var DISTANCE = func(anchor *peer.Peer) func(p *peer.Peer) uint64 {
 		copy(saltedIdentifier[0:], anchor.GetIdentity().Identifier)
 		copy(saltedIdentifier[len(anchor.GetIdentity().Identifier):], anchor.GetSalt().GetBytes())
 
-		return hash(anchor.GetIdentity().Identifier) ^ hash(p.GetIdentity().Identifier)
+		return hash(saltedIdentifier) ^ hash(p.GetIdentity().Identifier)
 	}
 }
 


### PR DESCRIPTION
This PR fixes a bug in the distance function that was not using the salt