### PR TITLE
Feat: Improve peer selection logic to avoid parallel connections

### DIFF
--- a/packages/autopeering/discover/common.go
+++ b/packages/autopeering/discover/common.go
@@ -42,20 +42,32 @@ type Parameters struct {
 	MaxReplacements  int           // maximum number of peers kept in the replacement list
 }
 
+// SetParameters sets the global parameters for this package.
+// This function cannot be used concurrently.
 func SetParameter(param Parameters) {
 	if param.ReverifyInterval > 0 {
 		reverifyInterval = param.ReverifyInterval
+	} else {
+		reverifyInterval = DefaultReverifyInterval
 	}
 	if param.ReverifyTries > 0 {
 		reverifyTries = param.ReverifyTries
+	} else {
+		reverifyTries = DefaultReverifyTries
 	}
 	if param.QueryInterval > 0 {
 		queryInterval = param.QueryInterval
+	} else {
+		queryInterval = DefaultQueryInterval
 	}
 	if param.MaxManaged > 0 {
 		maxManaged = param.MaxManaged
+	} else {
+		maxManaged = DefaultMaxManaged
 	}
 	if param.MaxReplacements > 0 {
 		maxReplacements = param.MaxReplacements
+	} else {
+		maxReplacements = DefaultMaxReplacements
 	}
 }

--- a/packages/autopeering/discover/common.go
+++ b/packages/autopeering/discover/common.go
@@ -4,46 +4,34 @@ import (
 	"time"
 
 	"github.com/iotaledger/goshimmer/packages/autopeering/peer"
-	"go.uber.org/zap"
+	"github.com/iotaledger/hive.go/logger"
 )
 
+// Default values for the global parameters
 const (
-	// PingExpiration is the time until a peer verification expires.
-	PingExpiration = 12 * time.Hour
-	// MaxPeersInResponse is the maximum number of peers returned in DiscoveryResponse.
-	MaxPeersInResponse = 6
-	// MaxServices is the maximum number of services a peer can support.
-	MaxServices = 5
+	DefaultReverifyInterval = 10 * time.Second
+	DefaultReverifyTries    = 2
+	DefaultQueryInterval    = 60 * time.Second
+	DefaultMaxManaged       = 1000
+	DefaultMaxReplacements  = 10
+)
 
-	// VersionNum specifies the expected version number for this Protocol.
-	VersionNum = 0
+var (
+	reverifyInterval = DefaultReverifyInterval // time interval after which the next peer is reverified
+	reverifyTries    = DefaultReverifyTries    // number of times a peer is pinged before it is removed
+	queryInterval    = DefaultQueryInterval    // time interval after which peers are queried for new peers
+	maxManaged       = DefaultMaxManaged       // maximum number of peers that can be managed
+	maxReplacements  = DefaultMaxReplacements  // maximum number of peers kept in the replacement list
 )
 
 // Config holds discovery related settings.
 type Config struct {
 	// These settings are required and configure the listener:
-	Log *zap.SugaredLogger
+	Log *logger.Logger
 
 	// These settings are optional:
 	MasterPeers []*peer.Peer // list of master peers used for bootstrapping
-	Param       *Parameters  // parameters
 }
-
-// default parameter values
-const (
-	// DefaultReverifyInterval is the default time interval after which a new peer is reverified.
-	DefaultReverifyInterval = 10 * time.Second
-	// DefaultReverifyTries is the default number of times a peer is pinged before it is removed.
-	DefaultReverifyTries = 2
-
-	// DefaultQueryInterval is the default time interval after which known peers are queried for new peers.
-	DefaultQueryInterval = 60 * time.Second
-
-	// DefaultMaxManaged is the default maximum number of peers that can be managed.
-	DefaultMaxManaged = 1000
-	// DefaultMaxReplacements is the default maximum number of peers kept in the replacement list.
-	DefaultMaxReplacements = 10
-)
 
 // Parameters holds the parameters that can be configured.
 type Parameters struct {
@@ -52,4 +40,22 @@ type Parameters struct {
 	QueryInterval    time.Duration // time interval after which peers are queried for new peers
 	MaxManaged       int           // maximum number of peers that can be managed
 	MaxReplacements  int           // maximum number of peers kept in the replacement list
+}
+
+func SetParameter(param Parameters) {
+	if param.ReverifyInterval > 0 {
+		reverifyInterval = param.ReverifyInterval
+	}
+	if param.ReverifyTries > 0 {
+		reverifyTries = param.ReverifyTries
+	}
+	if param.QueryInterval > 0 {
+		queryInterval = param.QueryInterval
+	}
+	if param.MaxManaged > 0 {
+		maxManaged = param.MaxManaged
+	}
+	if param.MaxReplacements > 0 {
+		maxReplacements = param.MaxReplacements
+	}
 }

--- a/packages/autopeering/discover/manager_test.go
+++ b/packages/autopeering/discover/manager_test.go
@@ -49,7 +49,7 @@ func newDummyPeer(name string) *peer.Peer {
 
 func newTestManager() (*manager, *NetworkMock, func()) {
 	networkMock := newNetworkMock()
-	mgr := newManager(networkMock, nil, log, nil)
+	mgr := newManager(networkMock, nil, log)
 	teardown := func() {
 		mgr.close()
 	}

--- a/packages/autopeering/discover/protocol.go
+++ b/packages/autopeering/discover/protocol.go
@@ -11,8 +11,8 @@ import (
 	peerpb "github.com/iotaledger/goshimmer/packages/autopeering/peer/proto"
 	"github.com/iotaledger/goshimmer/packages/autopeering/peer/service"
 	"github.com/iotaledger/goshimmer/packages/autopeering/server"
+	"github.com/iotaledger/hive.go/logger"
 	"github.com/pkg/errors"
-	"go.uber.org/zap"
 )
 
 // The Protocol handles the peer discovery.
@@ -20,8 +20,8 @@ import (
 type Protocol struct {
 	server.Protocol
 
-	loc *peer.Local        // local peer that runs the protocol
-	log *zap.SugaredLogger // logging
+	loc *peer.Local    // local peer that runs the protocol
+	log *logger.Logger // logging
 
 	mgr       *manager // the manager handles the actual peer discovery and re-verification
 	closeOnce sync.Once
@@ -34,7 +34,7 @@ func New(local *peer.Local, cfg Config) *Protocol {
 		loc:      local,
 		log:      cfg.Log,
 	}
-	p.mgr = newManager(p, cfg.MasterPeers, cfg.Log.Named("mgr"), cfg.Param)
+	p.mgr = newManager(p, cfg.MasterPeers, cfg.Log.Named("mgr"))
 
 	return p
 }

--- a/packages/autopeering/discover/protocol_test.go
+++ b/packages/autopeering/discover/protocol_test.go
@@ -20,10 +20,13 @@ var log = logger.NewExampleLogger("discover")
 
 func init() {
 	// decrease parameters to simplify and speed up tests
-	reverifyInterval = 500 * time.Millisecond
-	queryInterval = 1000 * time.Millisecond
-	maxManaged = 10
-	maxReplacements = 2
+	SetParameter(Parameters{
+		ReverifyInterval: 500 * time.Millisecond,
+		ReverifyTries:    1,
+		QueryInterval:    1000 * time.Millisecond,
+		MaxManaged:       10,
+		MaxReplacements:  2,
+	})
 }
 
 // newTest creates a new discovery server and also returns the teardown.

--- a/packages/autopeering/peer/mapdb.go
+++ b/packages/autopeering/peer/mapdb.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/iotaledger/goshimmer/packages/autopeering/peer/service"
-	"go.uber.org/zap"
+	"github.com/iotaledger/hive.go/logger"
 )
 
 // mapDB is a simple implementation of DB using a map.
@@ -15,7 +15,7 @@ type mapDB struct {
 	key      PrivateKey
 	services *service.Record
 
-	log *zap.SugaredLogger
+	log *logger.Logger
 
 	wg        sync.WaitGroup
 	closeOnce sync.Once
@@ -32,7 +32,7 @@ type peerPropEntry struct {
 }
 
 // NewMemoryDB creates a new DB that uses a GO map.
-func NewMemoryDB(log *zap.SugaredLogger) DB {
+func NewMemoryDB(log *logger.Logger) DB {
 	db := &mapDB{
 		m:        make(map[string]peerEntry),
 		services: service.New(),

--- a/packages/autopeering/peer/mapdb_test.go
+++ b/packages/autopeering/peer/mapdb_test.go
@@ -2,50 +2,41 @@ package peer
 
 import (
 	"crypto/ed25519"
-	"log"
 	"testing"
 	"time"
 
+	"github.com/iotaledger/hive.go/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 )
 
-var logger *zap.SugaredLogger
-
-func init() {
-	l, err := zap.NewDevelopment()
-	if err != nil {
-		log.Fatalf("cannot initialize logger: %v", err)
-	}
-	logger = l.Sugar()
-}
+var log = logger.NewExampleLogger("peer")
 
 func TestMapDBPing(t *testing.T) {
 	p := newTestPeer()
-	db := NewMemoryDB(logger)
+	db := NewMemoryDB(log)
 
-	time := time.Now()
-	err := db.UpdateLastPing(p.ID(), p.Address(), time)
+	now := time.Now()
+	err := db.UpdateLastPing(p.ID(), p.Address(), now)
 	require.NoError(t, err)
 
-	assert.Equal(t, time.Unix(), db.LastPing(p.ID(), p.Address()).Unix())
+	assert.Equal(t, now.Unix(), db.LastPing(p.ID(), p.Address()).Unix())
 }
 
 func TestMapDBPong(t *testing.T) {
 	p := newTestPeer()
-	db := NewMemoryDB(logger)
+	db := NewMemoryDB(log)
 
-	time := time.Now()
-	err := db.UpdateLastPong(p.ID(), p.Address(), time)
+	now := time.Now()
+	err := db.UpdateLastPong(p.ID(), p.Address(), now)
 	require.NoError(t, err)
 
-	assert.Equal(t, time.Unix(), db.LastPong(p.ID(), p.Address()).Unix())
+	assert.Equal(t, now.Unix(), db.LastPong(p.ID(), p.Address()).Unix())
 }
 
 func TestMapDBPeer(t *testing.T) {
 	p := newTestPeer()
-	db := NewMemoryDB(logger)
+	db := NewMemoryDB(log)
 
 	err := db.UpdatePeer(p)
 	require.NoError(t, err)
@@ -55,7 +46,7 @@ func TestMapDBPeer(t *testing.T) {
 
 func TestMapDBSeedPeers(t *testing.T) {
 	p := newTestPeer()
-	db := NewMemoryDB(logger)
+	db := NewMemoryDB(log)
 
 	require.NoError(t, db.UpdatePeer(p))
 	require.NoError(t, db.UpdateLastPong(p.ID(), p.Address(), time.Now()))
@@ -65,7 +56,7 @@ func TestMapDBSeedPeers(t *testing.T) {
 }
 
 func TestMapDBLocal(t *testing.T) {
-	db := NewMemoryDB(logger)
+	db := NewMemoryDB(log)
 
 	l1, err := NewLocal(testNetwork, testAddress, db)
 	require.NoError(t, err)

--- a/packages/autopeering/peer/peerdb.go
+++ b/packages/autopeering/peer/peerdb.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/iotaledger/goshimmer/packages/autopeering/peer/service"
 	"github.com/iotaledger/goshimmer/packages/database"
-	"go.uber.org/zap"
+	"github.com/iotaledger/hive.go/logger"
 )
 
 const (
@@ -57,7 +57,7 @@ type DB interface {
 
 type persistentDB struct {
 	db  database.Database
-	log *zap.SugaredLogger
+	log *logger.Logger
 
 	closeOnce sync.Once
 }
@@ -77,7 +77,7 @@ const (
 )
 
 // NewPersistentDB creates a new persistent DB.
-func NewPersistentDB(log *zap.SugaredLogger) DB {
+func NewPersistentDB(log *logger.Logger) DB {
 	db, err := database.Get("peer")
 	if err != nil {
 		panic(err)

--- a/packages/autopeering/salt/salt.go
+++ b/packages/autopeering/salt/salt.go
@@ -37,7 +37,7 @@ func NewSalt(lifetime time.Duration) (salt *Salt, err error) {
 func (s *Salt) GetBytes() []byte {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
-	return s.bytes
+	return append([]byte{}, s.bytes...)
 }
 
 func (s *Salt) GetExpiration() time.Time {

--- a/packages/autopeering/selection/common.go
+++ b/packages/autopeering/selection/common.go
@@ -27,7 +27,7 @@ const (
 	DefaultSaltLifetime = 30 * time.Minute
 
 	// DefaultUpdateOutboundInterval is the default time interval after which the outbound neighbors are checked.
-	DefaultUpdateOutboundInterval = 200 * time.Millisecond
+	DefaultUpdateOutboundInterval = 1 * time.Second
 )
 
 // Parameters holds the parameters that can be configured.

--- a/packages/autopeering/selection/common.go
+++ b/packages/autopeering/selection/common.go
@@ -9,17 +9,19 @@ import (
 
 // Default values for the global parameters
 const (
-	DefaultInboundNeighborSize    = 4
-	DefaultOutboundNeighborSize   = 4
-	DefaultSaltLifetime           = 30 * time.Minute
-	DefaultUpdateOutboundInterval = 10 * time.Second
+	DefaultInboundNeighborSize        = 4
+	DefaultOutboundNeighborSize       = 4
+	DefaultSaltLifetime               = 30 * time.Minute
+	DefaultOutboundUpdateInterval     = 1 * time.Second
+	DefaultFullOutboundUpdateInterval = 1 * time.Minute
 )
 
 var (
-	inboundNeighborSize    = DefaultInboundNeighborSize    // number of inbound neighbors
-	outboundNeighborSize   = DefaultOutboundNeighborSize   // number of outbound neighbors
-	saltLifetime           = DefaultSaltLifetime           // lifetime of the private and public local salt
-	updateOutboundInterval = DefaultUpdateOutboundInterval // time after which the outbound neighbors are updated
+	inboundNeighborSize        = DefaultInboundNeighborSize        // number of inbound neighbors
+	outboundNeighborSize       = DefaultOutboundNeighborSize       // number of outbound neighbors
+	saltLifetime               = DefaultSaltLifetime               // lifetime of the private and public local salt
+	outboundUpdateInterval     = DefaultOutboundUpdateInterval     // time after which out neighbors are updated
+	fullOutboundUpdateInterval = DefaultFullOutboundUpdateInterval // time after which full out neighbors are updated
 )
 
 // Config holds settings for the peer selection.
@@ -34,10 +36,11 @@ type Config struct {
 
 // Parameters holds the parameters that can be configured.
 type Parameters struct {
-	InboundNeighborSize    int           // number of inbound neighbors
-	OutboundNeighborSize   int           // number of outbound neighbors
-	SaltLifetime           time.Duration // lifetime of the private and public local salt
-	UpdateOutboundInterval time.Duration // time interval after which the outbound neighbors are checked
+	InboundNeighborSize        int           // number of inbound neighbors
+	OutboundNeighborSize       int           // number of outbound neighbors
+	SaltLifetime               time.Duration // lifetime of the private and public local salt
+	OutboundUpdateInterval     time.Duration // time interval after which the outbound neighbors are checked
+	FullOutboundUpdateInterval time.Duration // time after which the full outbound neighbors are updated
 }
 
 // SetParameters sets the global parameters for this package.
@@ -58,9 +61,14 @@ func SetParameters(param Parameters) {
 	} else {
 		saltLifetime = DefaultSaltLifetime
 	}
-	if param.UpdateOutboundInterval > 0 {
-		updateOutboundInterval = param.UpdateOutboundInterval
+	if param.OutboundUpdateInterval > 0 {
+		outboundUpdateInterval = param.OutboundUpdateInterval
 	} else {
-		updateOutboundInterval = DefaultUpdateOutboundInterval
+		outboundUpdateInterval = DefaultOutboundUpdateInterval
+	}
+	if param.FullOutboundUpdateInterval > 0 {
+		fullOutboundUpdateInterval = param.FullOutboundUpdateInterval
+	} else {
+		fullOutboundUpdateInterval = DefaultFullOutboundUpdateInterval
 	}
 }

--- a/packages/autopeering/selection/common.go
+++ b/packages/autopeering/selection/common.go
@@ -45,14 +45,22 @@ type Parameters struct {
 func SetParameters(param Parameters) {
 	if param.InboundNeighborSize > 0 {
 		inboundNeighborSize = param.InboundNeighborSize
+	} else {
+		inboundNeighborSize = DefaultInboundNeighborSize
 	}
 	if param.OutboundNeighborSize > 0 {
 		outboundNeighborSize = param.OutboundNeighborSize
+	} else {
+		outboundNeighborSize = DefaultOutboundNeighborSize
 	}
 	if param.SaltLifetime > 0 {
 		saltLifetime = param.SaltLifetime
+	} else {
+		saltLifetime = DefaultSaltLifetime
 	}
 	if param.UpdateOutboundInterval > 0 {
 		updateOutboundInterval = param.UpdateOutboundInterval
+	} else {
+		updateOutboundInterval = DefaultUpdateOutboundInterval
 	}
 }

--- a/packages/autopeering/selection/common.go
+++ b/packages/autopeering/selection/common.go
@@ -37,5 +37,5 @@ type Parameters struct {
 	SaltLifetime           time.Duration // lifetime of the private and public local salt
 	UpdateOutboundInterval time.Duration // time interval after which the outbound neighbors are checked
 	DropNeighborsOnUpdate  bool          // set true to drop all neighbors when the distance is updated
-	RequiredService        []service.Key // services required in order to select/be selected during autopeering
+	RequiredServices       []service.Key // services required in order to select/be selected during autopeering
 }

--- a/packages/autopeering/selection/common.go
+++ b/packages/autopeering/selection/common.go
@@ -4,31 +4,33 @@ import (
 	"time"
 
 	"github.com/iotaledger/goshimmer/packages/autopeering/peer/service"
-	"go.uber.org/zap"
+	"github.com/iotaledger/hive.go/logger"
+)
+
+// Default values for the global parameters
+const (
+	DefaultInboundNeighborSize    = 4
+	DefaultOutboundNeighborSize   = 4
+	DefaultSaltLifetime           = 30 * time.Minute
+	DefaultUpdateOutboundInterval = 10 * time.Second
+)
+
+var (
+	inboundNeighborSize    = DefaultInboundNeighborSize    // number of inbound neighbors
+	outboundNeighborSize   = DefaultOutboundNeighborSize   // number of outbound neighbors
+	saltLifetime           = DefaultSaltLifetime           // lifetime of the private and public local salt
+	updateOutboundInterval = DefaultUpdateOutboundInterval // time after which the outbound neighbors are updated
 )
 
 // Config holds settings for the peer selection.
 type Config struct {
 	// Logger
-	Log *zap.SugaredLogger
+	Log *logger.Logger
 
 	// These settings are optional:
-	Param *Parameters // parameters
+	DropOnUpdate     bool          // set true to drop all neighbors when the salt is updated
+	RequiredServices []service.Key // services required in order to select/be selected during autopeering
 }
-
-// default parameter values
-const (
-	// DefaultInboundNeighborSize is the default number of inbound neighbors.
-	DefaultInboundNeighborSize = 4
-	// DefaultOutboundNeighborSize is the default number of outbound neighbors.
-	DefaultOutboundNeighborSize = 4
-
-	// DefaultSaltLifetime is the default lifetime of the private and public local salt.
-	DefaultSaltLifetime = 30 * time.Minute
-
-	// DefaultUpdateOutboundInterval is the default time interval after which the outbound neighbors are checked.
-	DefaultUpdateOutboundInterval = 1 * time.Second
-)
 
 // Parameters holds the parameters that can be configured.
 type Parameters struct {
@@ -36,6 +38,21 @@ type Parameters struct {
 	OutboundNeighborSize   int           // number of outbound neighbors
 	SaltLifetime           time.Duration // lifetime of the private and public local salt
 	UpdateOutboundInterval time.Duration // time interval after which the outbound neighbors are checked
-	DropNeighborsOnUpdate  bool          // set true to drop all neighbors when the distance is updated
-	RequiredServices       []service.Key // services required in order to select/be selected during autopeering
+}
+
+// SetParameters sets the global parameters for this package.
+// This function cannot be used concurrently.
+func SetParameters(param Parameters) {
+	if param.InboundNeighborSize > 0 {
+		inboundNeighborSize = param.InboundNeighborSize
+	}
+	if param.OutboundNeighborSize > 0 {
+		outboundNeighborSize = param.OutboundNeighborSize
+	}
+	if param.SaltLifetime > 0 {
+		saltLifetime = param.SaltLifetime
+	}
+	if param.UpdateOutboundInterval > 0 {
+		updateOutboundInterval = param.UpdateOutboundInterval
+	}
 }

--- a/packages/autopeering/selection/events.go
+++ b/packages/autopeering/selection/events.go
@@ -2,25 +2,34 @@ package selection
 
 import (
 	"github.com/iotaledger/goshimmer/packages/autopeering/peer"
+	"github.com/iotaledger/goshimmer/packages/autopeering/salt"
 	"github.com/iotaledger/hive.go/events"
 )
 
 // Events contains all the events that are triggered during the neighbor selection.
 var Events = struct {
+	// A SaltUpdated event is triggered, when the private and public salt were updated.
+	SaltUpdated *events.Event
 	// An OutgoingPeering event is triggered, when a valid response of PeeringRequest has been received.
 	OutgoingPeering *events.Event
 	// An IncomingPeering event is triggered, when a valid PeerRequest has been received.
 	IncomingPeering *events.Event
-
-	// A Dropped event is triggered, when a neigbhor is dropped or when a drop message is received.
+	// A Dropped event is triggered, when a neighbor is dropped or when a drop message is received.
 	Dropped *events.Event
 }{
+	SaltUpdated:     events.NewEvent(saltUpdatedCaller),
 	OutgoingPeering: events.NewEvent(peeringCaller),
 	IncomingPeering: events.NewEvent(peeringCaller),
 	Dropped:         events.NewEvent(droppedCaller),
 }
 
-// PeeringEvent bundles the information sent in a peering event.
+// SaltUpdatedEvent bundles the information sent in the SaltUpdated event.
+type SaltUpdatedEvent struct {
+	Self            peer.ID    // ID of the peer triggering the event.
+	Public, Private *salt.Salt // the updated salt
+}
+
+// PeeringEvent bundles the information sent in the OutgoingPeering and IncomingPeering event.
 type PeeringEvent struct {
 	Self   peer.ID    // ID of the peer triggering the event.
 	Peer   *peer.Peer // peering partner
@@ -31,6 +40,10 @@ type PeeringEvent struct {
 type DroppedEvent struct {
 	Self      peer.ID // ID of the peer triggering the event.
 	DroppedID peer.ID // ID of the peer that gets dropped.
+}
+
+func saltUpdatedCaller(handler interface{}, params ...interface{}) {
+	handler.(func(*SaltUpdatedEvent))(params[0].(*SaltUpdatedEvent))
 }
 
 func peeringCaller(handler interface{}, params ...interface{}) {

--- a/packages/autopeering/selection/manager.go
+++ b/packages/autopeering/selection/manager.go
@@ -16,7 +16,7 @@ const (
 	reject = false
 
 	// buffer size of the channels handling inbound requests and drops.
-	queueSize = 100
+	queueSize = 10
 )
 
 // A network represents the communication layer for the manager.
@@ -80,10 +80,6 @@ func (m *manager) start() {
 func (m *manager) close() {
 	close(m.closing)
 	m.wg.Wait()
-
-	// close the channels, so that successive sends panic
-	close(m.requestChan)
-	close(m.dropChan)
 }
 
 func (m *manager) getID() peer.ID {

--- a/packages/autopeering/selection/manager.go
+++ b/packages/autopeering/selection/manager.go
@@ -49,8 +49,7 @@ type manager struct {
 	net       network
 	peersFunc func() []*peer.Peer
 
-	log           *logger.Logger
-	dropNeighbors bool
+	log *logger.Logger
 
 	inbound  *Neighborhood
 	outbound *Neighborhood
@@ -92,7 +91,6 @@ func newManager(net network, peersFunc func() []*peer.Peer, log *logger.Logger, 
 		net:                net,
 		peersFunc:          peersFunc,
 		log:                log,
-		dropNeighbors:      dropNeighborsOnUpdate,
 		closing:            make(chan struct{}),
 		rejectionFilter:    NewFilter(),
 		inboundRequestChan: make(chan peeringRequest, queueSize),

--- a/packages/autopeering/selection/manager.go
+++ b/packages/autopeering/selection/manager.go
@@ -196,9 +196,9 @@ Loop:
 }
 
 func (m *manager) getUpdateTimeout() time.Duration {
-	result := updateOutboundInterval
+	result := outboundUpdateInterval
 	if m.outbound.IsFull() {
-		result = time.Minute
+		result = fullOutboundUpdateInterval
 	}
 	saltExpiration := time.Until(m.getPublicSalt().GetExpiration())
 	if saltExpiration < result {

--- a/packages/autopeering/selection/manager.go
+++ b/packages/autopeering/selection/manager.go
@@ -140,7 +140,7 @@ Loop:
 		case <-updateTimer.C:
 			updateOutResultChan = make(chan peer.PeerDistance)
 			// check salt and update if necessary
-			if m.net.local().GetPublicSalt().Expired() {
+			if m.getPublicSalt().Expired() {
 				m.updateSalt()
 			}
 			// check for new peers to connect to in a separate go routine

--- a/packages/autopeering/selection/manager_test.go
+++ b/packages/autopeering/selection/manager_test.go
@@ -27,7 +27,7 @@ func TestMgrNoDuplicates(t *testing.T) {
 		OutboundNeighborSize:   nNeighbors,
 		InboundNeighborSize:    nNeighbors,
 		SaltLifetime:           testSaltLifetime,
-		UpdateOutboundInterval: testUpdateInterval,
+		OutboundUpdateInterval: testUpdateInterval,
 	})
 
 	mgrMap := make(map[peer.ID]*manager)
@@ -50,7 +50,7 @@ func TestEvents(t *testing.T) {
 		OutboundNeighborSize:   nNeighbors,
 		InboundNeighborSize:    nNeighbors,
 		SaltLifetime:           3 * testUpdateInterval,
-		UpdateOutboundInterval: testUpdateInterval,
+		OutboundUpdateInterval: testUpdateInterval,
 	})
 
 	e, teardown := newEventMock(t)
@@ -85,7 +85,7 @@ func runTestNetwork(n int, mgrMap map[peer.ID]*manager) {
 	}
 
 	// give the managers time to potentially connect all other peers
-	time.Sleep((time.Duration(n) - 1) * (updateOutboundInterval + graceTime))
+	time.Sleep((time.Duration(n) - 1) * (outboundUpdateInterval + graceTime))
 
 	// close all the managers
 	for _, mgr := range mgrMap {

--- a/packages/autopeering/selection/manager_test.go
+++ b/packages/autopeering/selection/manager_test.go
@@ -197,8 +197,8 @@ func (n *networkMock) local() *peer.Local {
 	return n.loc
 }
 
-func (n *networkMock) DropPeer(p *peer.Peer) {
-	n.mgr[p.ID()].dropPeering(n.local().ID())
+func (n *networkMock) SendPeeringDrop(p *peer.Peer) {
+	n.mgr[p.ID()].removeNeighbor(n.local().ID())
 }
 
 func (n *networkMock) RequestPeering(p *peer.Peer, s *salt.Salt) (bool, error) {

--- a/packages/autopeering/selection/manager_test.go
+++ b/packages/autopeering/selection/manager_test.go
@@ -24,6 +24,14 @@ type testPeer struct {
 	rand  *rand.Rand // random number generator
 }
 
+func init() {
+	// set global parameters for tests
+	SetParameters(Parameters{
+		SaltLifetime:           time.Hour,
+		UpdateOutboundInterval: 500 * time.Millisecond,
+	})
+}
+
 func newPeer(name string) testPeer {
 	log := log.Named(name)
 	db := peer.NewMemoryDB(log.Named("db"))
@@ -97,7 +105,7 @@ func TestSimManager(t *testing.T) {
 			self: p.peer,
 			rand: p.rand,
 		}
-		mgrMap[p.local.ID()] = newManager(net, net.GetKnownPeers, p.log, &Parameters{SaltLifetime: 100 * time.Second})
+		mgrMap[p.local.ID()] = newManager(net, net.GetKnownPeers, log, Config{})
 	}
 
 	// start all the managers

--- a/packages/autopeering/selection/manager_test.go
+++ b/packages/autopeering/selection/manager_test.go
@@ -2,46 +2,95 @@ package selection
 
 import (
 	"fmt"
-	"math/rand"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/iotaledger/goshimmer/packages/autopeering/peer"
 	"github.com/iotaledger/goshimmer/packages/autopeering/salt"
+	"github.com/iotaledger/hive.go/events"
 	"github.com/iotaledger/hive.go/logger"
 	"github.com/stretchr/testify/assert"
 )
 
-var (
-	allPeers []*peer.Peer
+const (
+	testSaltLifetime   = time.Hour     // disable salt updates
+	testUpdateInterval = 2 * graceTime // very short update interval to speed up tests
 )
 
-type testPeer struct {
-	local *peer.Local
-	peer  *peer.Peer
-	db    peer.DB
-	log   *logger.Logger
-	rand  *rand.Rand // random number generator
-}
-
-func init() {
-	// set global parameters for tests
+func TestMgrNoDuplicates(t *testing.T) {
+	const (
+		nNeighbors = 4
+		nNodes     = 2*nNeighbors + 1
+	)
 	SetParameters(Parameters{
-		SaltLifetime:           time.Hour,
-		UpdateOutboundInterval: 500 * time.Millisecond,
+		OutboundNeighborSize:   nNeighbors,
+		InboundNeighborSize:    nNeighbors,
+		SaltLifetime:           testSaltLifetime,
+		UpdateOutboundInterval: testUpdateInterval,
 	})
+
+	mgrMap := make(map[peer.ID]*manager)
+	runTestNetwork(nNodes, mgrMap)
+
+	for _, mgr := range mgrMap {
+		assert.NotEmpty(t, mgr.getOutNeighbors())
+		assert.NotEmpty(t, mgr.getInNeighbors())
+		assert.Empty(t, getDuplicates(mgr.getNeighbors()))
+	}
 }
 
-func newPeer(name string) testPeer {
-	log := log.Named(name)
-	db := peer.NewMemoryDB(log.Named("db"))
-	local, _ := peer.NewLocal("", name, db)
-	s, _ := salt.NewSalt(100 * time.Second)
-	local.SetPrivateSalt(s)
-	s, _ = salt.NewSalt(100 * time.Second)
-	local.SetPublicSalt(s)
-	p := &local.Peer
-	return testPeer{local, p, db, log, rand.New(rand.NewSource(time.Now().UnixNano()))}
+func TestEvents(t *testing.T) {
+	// we want many drops/connects
+	const (
+		nNeighbors = 2
+		nNodes     = 10
+	)
+	SetParameters(Parameters{
+		OutboundNeighborSize:   nNeighbors,
+		InboundNeighborSize:    nNeighbors,
+		SaltLifetime:           3 * testUpdateInterval,
+		UpdateOutboundInterval: testUpdateInterval,
+	})
+
+	e, teardown := newEventMock(t)
+	defer teardown()
+	mgrMap := make(map[peer.ID]*manager)
+	runTestNetwork(nNodes, mgrMap)
+
+	// the events should lead to exactly the same neighbors
+	for _, mgr := range mgrMap {
+		nc := e.m[mgr.getID()]
+		assert.ElementsMatchf(t, mgr.getOutNeighbors(), getValues(nc.out),
+			"out neighbors of %s do not match", mgr.getID())
+		assert.ElementsMatch(t, mgr.getInNeighbors(), getValues(nc.in),
+			"in neighbors of %s do not match", mgr.getID())
+	}
+}
+
+func getValues(m map[peer.ID]*peer.Peer) []*peer.Peer {
+	result := make([]*peer.Peer, 0, len(m))
+	for _, p := range m {
+		result = append(result, p)
+	}
+	return result
+}
+
+func runTestNetwork(n int, mgrMap map[peer.ID]*manager) {
+	for i := 0; i < n; i++ {
+		_ = newTestManager(fmt.Sprintf("%d", i), mgrMap)
+	}
+	for _, mgr := range mgrMap {
+		mgr.start()
+	}
+
+	// give the managers time to potentially connect all other peers
+	time.Sleep((time.Duration(n) - 1) * (updateOutboundInterval + graceTime))
+
+	// close all the managers
+	for _, mgr := range mgrMap {
+		mgr.close()
+	}
 }
 
 func getDuplicates(peers []*peer.Peer) []*peer.Peer {
@@ -59,74 +108,115 @@ func getDuplicates(peers []*peer.Peer) []*peer.Peer {
 	return result
 }
 
-type testNet struct {
-	loc  *peer.Local
-	self *peer.Peer
-	mgr  map[peer.ID]*manager
-	rand *rand.Rand
+type neighbors struct {
+	out, in map[peer.ID]*peer.Peer
 }
 
-func (n *testNet) local() *peer.Local {
+type eventMock struct {
+	t    *testing.T
+	lock sync.Mutex
+	m    map[peer.ID]neighbors
+}
+
+func newEventMock(t *testing.T) (*eventMock, func()) {
+	e := &eventMock{
+		t: t,
+		m: make(map[peer.ID]neighbors),
+	}
+
+	outgoingPeeringC := events.NewClosure(e.outgoingPeering)
+	incomingPeeringC := events.NewClosure(e.incomingPeering)
+	droppedC := events.NewClosure(e.dropped)
+
+	Events.OutgoingPeering.Attach(outgoingPeeringC)
+	Events.IncomingPeering.Attach(incomingPeeringC)
+	Events.Dropped.Attach(droppedC)
+
+	teardown := func() {
+		Events.OutgoingPeering.Detach(outgoingPeeringC)
+		Events.IncomingPeering.Detach(incomingPeeringC)
+		Events.Dropped.Detach(droppedC)
+	}
+	return e, teardown
+}
+
+func (e *eventMock) outgoingPeering(ev *PeeringEvent) {
+	if !ev.Status {
+		return
+	}
+	e.lock.Lock()
+	defer e.lock.Unlock()
+	s, ok := e.m[ev.Self]
+	if !ok {
+		s = neighbors{out: make(map[peer.ID]*peer.Peer), in: make(map[peer.ID]*peer.Peer)}
+		e.m[ev.Self] = s
+	}
+	assert.NotContains(e.t, s.out, ev.Peer)
+	s.out[ev.Peer.ID()] = ev.Peer
+}
+
+func (e *eventMock) incomingPeering(ev *PeeringEvent) {
+	if !ev.Status {
+		return
+	}
+	e.lock.Lock()
+	defer e.lock.Unlock()
+	s, ok := e.m[ev.Self]
+	if !ok {
+		s = neighbors{out: make(map[peer.ID]*peer.Peer), in: make(map[peer.ID]*peer.Peer)}
+		e.m[ev.Self] = s
+	}
+	assert.NotContains(e.t, s.in, ev.Peer)
+	s.in[ev.Peer.ID()] = ev.Peer
+}
+
+func (e *eventMock) dropped(ev *DroppedEvent) {
+	e.lock.Lock()
+	defer e.lock.Unlock()
+	if assert.Contains(e.t, e.m, ev.Self) {
+		s := e.m[ev.Self]
+		delete(s.out, ev.DroppedID)
+		delete(s.in, ev.DroppedID)
+	}
+}
+
+type networkMock struct {
+	loc *peer.Local
+	mgr map[peer.ID]*manager
+}
+
+func newNetworkMock(name string, mgrMap map[peer.ID]*manager, log *logger.Logger) *networkMock {
+	local, _ := peer.NewLocal("mock", name, peer.NewMemoryDB(log))
+	return &networkMock{
+		loc: local,
+		mgr: mgrMap,
+	}
+}
+
+func (n *networkMock) local() *peer.Local {
 	return n.loc
 }
 
-func (n *testNet) DropPeer(p *peer.Peer) {
+func (n *networkMock) DropPeer(p *peer.Peer) {
 	n.mgr[p.ID()].dropPeering(n.local().ID())
 }
 
-func (n *testNet) RequestPeering(p *peer.Peer, s *salt.Salt) (bool, error) {
-	return n.mgr[p.ID()].requestPeering(n.self, s), nil
+func (n *networkMock) RequestPeering(p *peer.Peer, s *salt.Salt) (bool, error) {
+	return n.mgr[p.ID()].requestPeering(&n.local().Peer, s), nil
 }
 
-func (n *testNet) GetKnownPeers() []*peer.Peer {
-	list := make([]*peer.Peer, 0, len(allPeers)-1)
-	for _, p := range allPeers {
-		if p.ID() == n.self.ID() {
-			continue
-		}
-		list = append(list, p)
+func (n *networkMock) GetKnownPeers() []*peer.Peer {
+	peers := make([]*peer.Peer, 0, len(n.mgr))
+	for _, m := range n.mgr {
+		peers = append(peers, &m.net.local().Peer)
 	}
-	return list
+	return peers
 }
 
-func TestSimManager(t *testing.T) {
-	const N = 9 // number of peers to generate
-
-	allPeers = make([]*peer.Peer, N)
-
-	mgrMap := make(map[peer.ID]*manager)
-	for i := range allPeers {
-		p := newPeer(fmt.Sprintf("%d", i))
-		allPeers[i] = p.peer
-
-		net := &testNet{
-			mgr:  mgrMap,
-			loc:  p.local,
-			self: p.peer,
-			rand: p.rand,
-		}
-		mgrMap[p.local.ID()] = newManager(net, net.GetKnownPeers, log, Config{})
-	}
-
-	// start all the managers
-	for _, mgr := range mgrMap {
-		mgr.start()
-	}
-
-	// give the managers time to potentially connect all other peers
-	time.Sleep((N - 1) * (updateOutboundInterval + graceTime))
-
-	// close all the managers
-	for _, mgr := range mgrMap {
-		mgr.close()
-	}
-
-	for i, p := range allPeers {
-		mgr := mgrMap[p.ID()]
-		log.Debugw("done", "peer", i, "#out", mgr.outbound, "#in", mgr.inbound)
-
-		assert.NotEmpty(t, mgr.getOutNeighbors(), "Peer %d has no out neighbors", i)
-		assert.NotEmpty(t, mgr.getInNeighbors(), "Peer %d has no in neighbors", i)
-		assert.Empty(t, getDuplicates(mgr.getNeighbors()), "Peer %d has non unique neighbors", i)
-	}
+func newTestManager(name string, mgrMap map[peer.ID]*manager) *manager {
+	l := log.Named(name)
+	net := newNetworkMock(name, mgrMap, l)
+	m := newManager(net, net.GetKnownPeers, l, Config{})
+	mgrMap[m.getID()] = m
+	return m
 }

--- a/packages/autopeering/selection/neighborhood.go
+++ b/packages/autopeering/selection/neighborhood.go
@@ -58,12 +58,16 @@ func (nh *Neighborhood) Select(candidates []peer.PeerDistance) peer.PeerDistance
 	return peer.PeerDistance{}
 }
 
-func (nh *Neighborhood) Add(toAdd peer.PeerDistance) {
+// Add tries to add a new peer with distance to the neighborhood.
+// It returns true, if the peer was added, or false if the neighborhood was full.
+func (nh *Neighborhood) Add(toAdd peer.PeerDistance) bool {
 	nh.mu.Lock()
 	defer nh.mu.Unlock()
-	if len(nh.neighbors) < nh.size {
-		nh.neighbors = append(nh.neighbors, toAdd)
+	if len(nh.neighbors) >= nh.size {
+		return false
 	}
+	nh.neighbors = append(nh.neighbors, toAdd)
+	return true
 }
 
 // RemovePeer removes the peer with the given ID from the neighborhood.

--- a/packages/autopeering/selection/neighborhood.go
+++ b/packages/autopeering/selection/neighborhood.go
@@ -105,14 +105,20 @@ func (nh *Neighborhood) UpdateDistance(anchor, salt []byte) {
 	}
 }
 
+func (nh *Neighborhood) IsFull() bool {
+	nh.mu.RLock()
+	defer nh.mu.RUnlock()
+	return len(nh.neighbors) >= nh.size
+}
+
 func (nh *Neighborhood) GetPeers() []*peer.Peer {
 	nh.mu.RLock()
 	defer nh.mu.RUnlock()
-	list := make([]*peer.Peer, len(nh.neighbors))
+	result := make([]*peer.Peer, len(nh.neighbors))
 	for i, n := range nh.neighbors {
-		list[i] = n.Remote
+		result[i] = n.Remote
 	}
-	return list
+	return result
 }
 
 func (nh *Neighborhood) GetNumPeers() int {

--- a/packages/autopeering/selection/neighborhood_test.go
+++ b/packages/autopeering/selection/neighborhood_test.go
@@ -26,8 +26,8 @@ func TestGetFurthest(t *testing.T) {
 	tests := []testCase{
 		{
 			input: &Neighborhood{
-				Neighbors: []peer.PeerDistance{d[0]},
-				Size:      4},
+				neighbors: []peer.PeerDistance{d[0]},
+				size:      4},
 			expected: peer.PeerDistance{
 				Remote:   nil,
 				Distance: distance.Max},
@@ -35,15 +35,15 @@ func TestGetFurthest(t *testing.T) {
 		},
 		{
 			input: &Neighborhood{
-				Neighbors: []peer.PeerDistance{d[0], d[1], d[2], d[3]},
-				Size:      4},
+				neighbors: []peer.PeerDistance{d[0], d[1], d[2], d[3]},
+				size:      4},
 			expected: d[3],
 			index:    3,
 		},
 		{
 			input: &Neighborhood{
-				Neighbors: []peer.PeerDistance{d[0], d[1], d[4], d[2]},
-				Size:      4},
+				neighbors: []peer.PeerDistance{d[0], d[1], d[4], d[2]},
+				size:      4},
 			expected: d[4],
 			index:    2,
 		},
@@ -72,22 +72,22 @@ func TestGetPeerIndex(t *testing.T) {
 	tests := []testCase{
 		{
 			input: &Neighborhood{
-				Neighbors: []peer.PeerDistance{d[0]},
-				Size:      4},
+				neighbors: []peer.PeerDistance{d[0]},
+				size:      4},
 			target: d[0].Remote,
 			index:  0,
 		},
 		{
 			input: &Neighborhood{
-				Neighbors: []peer.PeerDistance{d[0], d[1], d[2], d[3]},
-				Size:      4},
+				neighbors: []peer.PeerDistance{d[0], d[1], d[2], d[3]},
+				size:      4},
 			target: d[3].Remote,
 			index:  3,
 		},
 		{
 			input: &Neighborhood{
-				Neighbors: []peer.PeerDistance{d[0], d[1], d[4], d[2]},
-				Size:      4},
+				neighbors: []peer.PeerDistance{d[0], d[1], d[4], d[2]},
+				size:      4},
 			target: d[3].Remote,
 			index:  -1,
 		},
@@ -115,22 +115,22 @@ func TestRemove(t *testing.T) {
 	tests := []testCase{
 		{
 			input: &Neighborhood{
-				Neighbors: []peer.PeerDistance{d[0]},
-				Size:      4},
+				neighbors: []peer.PeerDistance{d[0]},
+				size:      4},
 			toRemove: d[0].Remote,
 			expected: []peer.PeerDistance{},
 		},
 		{
 			input: &Neighborhood{
-				Neighbors: []peer.PeerDistance{d[0], d[1], d[3]},
-				Size:      4},
+				neighbors: []peer.PeerDistance{d[0], d[1], d[3]},
+				size:      4},
 			toRemove: d[1].Remote,
 			expected: []peer.PeerDistance{d[0], d[3]},
 		},
 		{
 			input: &Neighborhood{
-				Neighbors: []peer.PeerDistance{d[0], d[1], d[4], d[2]},
-				Size:      4},
+				neighbors: []peer.PeerDistance{d[0], d[1], d[4], d[2]},
+				size:      4},
 			toRemove: d[2].Remote,
 			expected: []peer.PeerDistance{d[0], d[1], d[4]},
 		},
@@ -138,7 +138,7 @@ func TestRemove(t *testing.T) {
 
 	for _, test := range tests {
 		test.input.RemovePeer(test.toRemove.ID())
-		assert.Equal(t, test.expected, test.input.Neighbors, "Remove")
+		assert.Equal(t, test.expected, test.input.neighbors, "Remove")
 	}
 }
 
@@ -158,22 +158,22 @@ func TestAdd(t *testing.T) {
 	tests := []testCase{
 		{
 			input: &Neighborhood{
-				Neighbors: []peer.PeerDistance{d[0]},
-				Size:      4},
+				neighbors: []peer.PeerDistance{d[0]},
+				size:      4},
 			toAdd:    d[2],
 			expected: []peer.PeerDistance{d[0], d[2]},
 		},
 		{
 			input: &Neighborhood{
-				Neighbors: []peer.PeerDistance{d[0], d[1], d[3]},
-				Size:      4},
+				neighbors: []peer.PeerDistance{d[0], d[1], d[3]},
+				size:      4},
 			toAdd:    d[2],
 			expected: []peer.PeerDistance{d[0], d[1], d[3], d[2]},
 		},
 		{
 			input: &Neighborhood{
-				Neighbors: []peer.PeerDistance{d[0], d[1], d[4], d[2]},
-				Size:      4},
+				neighbors: []peer.PeerDistance{d[0], d[1], d[4], d[2]},
+				size:      4},
 			toAdd:    d[3],
 			expected: []peer.PeerDistance{d[0], d[1], d[4], d[2]},
 		},
@@ -181,7 +181,7 @@ func TestAdd(t *testing.T) {
 
 	for _, test := range tests {
 		test.input.Add(test.toAdd)
-		assert.Equal(t, test.expected, test.input.Neighbors, "Add")
+		assert.Equal(t, test.expected, test.input.neighbors, "Add")
 	}
 }
 
@@ -201,12 +201,12 @@ func TestUpdateDistance(t *testing.T) {
 	}
 
 	neighborhood := Neighborhood{
-		Neighbors: d[1:],
-		Size:      4}
+		neighbors: d[1:],
+		size:      4}
 
 	neighborhood.UpdateDistance(d[0].Remote.ID().Bytes(), s.GetBytes())
 
-	assert.Equal(t, d2, neighborhood.Neighbors, "UpdateDistance")
+	assert.Equal(t, d2, neighborhood.neighbors, "UpdateDistance")
 }
 
 func TestGetPeers(t *testing.T) {
@@ -227,20 +227,20 @@ func TestGetPeers(t *testing.T) {
 	tests := []testCase{
 		{
 			input: &Neighborhood{
-				Neighbors: []peer.PeerDistance{},
-				Size:      4},
+				neighbors: []peer.PeerDistance{},
+				size:      4},
 			expected: []*peer.Peer{},
 		},
 		{
 			input: &Neighborhood{
-				Neighbors: []peer.PeerDistance{d[0]},
-				Size:      4},
+				neighbors: []peer.PeerDistance{d[0]},
+				size:      4},
 			expected: []*peer.Peer{peers[0]},
 		},
 		{
 			input: &Neighborhood{
-				Neighbors: []peer.PeerDistance{d[0], d[1], d[3], d[2]},
-				Size:      4},
+				neighbors: []peer.PeerDistance{d[0], d[1], d[3], d[2]},
+				size:      4},
 			expected: []*peer.Peer{peers[0], peers[1], peers[3], peers[2]},
 		},
 	}

--- a/packages/autopeering/selection/protocol.go
+++ b/packages/autopeering/selection/protocol.go
@@ -162,7 +162,7 @@ func (p *Protocol) RequestPeering(to *peer.Peer, salt *salt.Salt) (bool, error) 
 
 // DropPeer sends a PeeringDrop to the given peer.
 func (p *Protocol) DropPeer(to *peer.Peer) {
-	p.mgr.dropNeighbor(to.ID())
+	p.mgr.dropPeering(to.ID())
 
 	toAddr := to.Address()
 	drop := newPeeringDrop(toAddr)
@@ -282,7 +282,7 @@ func (p *Protocol) handlePeeringRequest(s *server.Server, fromAddr string, fromI
 		return
 	}
 
-	res := newPeeringResponse(rawData, p.mgr.acceptRequest(from, salt))
+	res := newPeeringResponse(rawData, p.mgr.requestPeering(from, salt))
 
 	p.log.Debugw("send message",
 		"type", res.Name(),
@@ -334,5 +334,5 @@ func (p *Protocol) validatePeeringDrop(s *server.Server, fromAddr string, m *pb.
 }
 
 func (p *Protocol) handlePeeringDrop(fromID peer.ID) {
-	p.mgr.dropNeighbor(fromID)
+	p.mgr.dropPeering(fromID)
 }

--- a/packages/autopeering/selection/protocol.go
+++ b/packages/autopeering/selection/protocol.go
@@ -86,6 +86,13 @@ func (p *Protocol) GetOutgoingNeighbors() []*peer.Peer {
 	return p.mgr.getOutNeighbors()
 }
 
+// RemoveNeighbor removes the peer with the given id from the incoming and outgoing neighbors.
+// If such a peer was actually contained in anyone of the neighbor sets, the corresponding event is triggered
+// and the corresponding peering drop is sent. Otherwise the call is ignored.
+func (p *Protocol) RemoveNeighbor(id peer.ID) {
+	p.mgr.removeNeighbor(id)
+}
+
 // HandleMessage responds to incoming neighbor selection messages.
 func (p *Protocol) HandleMessage(s *server.Server, fromAddr string, fromID peer.ID, fromKey peer.PublicKey, data []byte) (bool, error) {
 	switch pb.MType(data[0]) {
@@ -160,10 +167,8 @@ func (p *Protocol) RequestPeering(to *peer.Peer, salt *salt.Salt) (bool, error) 
 	return status, err
 }
 
-// DropPeer sends a PeeringDrop to the given peer.
-func (p *Protocol) DropPeer(to *peer.Peer) {
-	p.mgr.dropPeering(to.ID())
-
+// SendPeeringDrop sends a peering drop to the given peer and does not wait for any responses.
+func (p *Protocol) SendPeeringDrop(to *peer.Peer) {
 	toAddr := to.Address()
 	drop := newPeeringDrop(toAddr)
 
@@ -334,5 +339,5 @@ func (p *Protocol) validatePeeringDrop(s *server.Server, fromAddr string, m *pb.
 }
 
 func (p *Protocol) handlePeeringDrop(fromID peer.ID) {
-	p.mgr.dropPeering(fromID)
+	p.mgr.removeNeighbor(fromID)
 }

--- a/packages/autopeering/selection/protocol.go
+++ b/packages/autopeering/selection/protocol.go
@@ -10,8 +10,8 @@ import (
 	"github.com/iotaledger/goshimmer/packages/autopeering/salt"
 	pb "github.com/iotaledger/goshimmer/packages/autopeering/selection/proto"
 	"github.com/iotaledger/goshimmer/packages/autopeering/server"
+	"github.com/iotaledger/hive.go/logger"
 	"github.com/pkg/errors"
-	"go.uber.org/zap"
 )
 
 // DiscoverProtocol specifies the methods from the peer discovery that are required.
@@ -28,9 +28,9 @@ type DiscoverProtocol interface {
 type Protocol struct {
 	server.Protocol
 
-	disc DiscoverProtocol   // reference to the peer discovery to query verified peers
-	loc  *peer.Local        // local peer that runs the protocol
-	log  *zap.SugaredLogger // logging
+	disc DiscoverProtocol // reference to the peer discovery to query verified peers
+	loc  *peer.Local      // local peer that runs the protocol
+	log  *logger.Logger   // logging
 
 	mgr       *manager // the manager handles the actual neighbor selection
 	closeOnce sync.Once
@@ -44,7 +44,7 @@ func New(local *peer.Local, disc DiscoverProtocol, cfg Config) *Protocol {
 		disc:     disc,
 		log:      cfg.Log,
 	}
-	p.mgr = newManager(p, disc.GetVerifiedPeers, cfg.Log.Named("mgr"), cfg.Param)
+	p.mgr = newManager(p, disc.GetVerifiedPeers, cfg.Log.Named("mgr"), cfg)
 
 	return p
 }

--- a/packages/autopeering/selection/protocol.go
+++ b/packages/autopeering/selection/protocol.go
@@ -78,12 +78,12 @@ func (p *Protocol) GetNeighbors() []*peer.Peer {
 
 // GetIncomingNeighbors returns the current incoming neighbors.
 func (p *Protocol) GetIncomingNeighbors() []*peer.Peer {
-	return p.mgr.getIncomingNeighbors()
+	return p.mgr.getInNeighbors()
 }
 
 // GetOutgoingNeighbors returns the current outgoing neighbors.
 func (p *Protocol) GetOutgoingNeighbors() []*peer.Peer {
-	return p.mgr.getOutgoingNeighbors()
+	return p.mgr.getOutNeighbors()
 }
 
 // HandleMessage responds to incoming neighbor selection messages.

--- a/packages/autopeering/selection/protocol_test.go
+++ b/packages/autopeering/selection/protocol_test.go
@@ -106,7 +106,7 @@ func TestProtocol(t *testing.T) {
 		assert.EqualError(t, err, server.ErrTimeout.Error())
 	})
 
-	t.Run("DropPeer", func(t *testing.T) {
+	t.Run("PeeringDrop", func(t *testing.T) {
 		p2p := transport.P2P()
 		defer p2p.Close()
 
@@ -127,7 +127,7 @@ func TestProtocol(t *testing.T) {
 		require.Contains(t, protB.GetNeighbors(), peerA)
 
 		// drop peer A
-		protA.DropPeer(peerB)
+		protA.SendPeeringDrop(peerB)
 		time.Sleep(graceTime)
 		require.NotContains(t, protB.GetNeighbors(), peerA)
 	})

--- a/packages/autopeering/selection/protocol_test.go
+++ b/packages/autopeering/selection/protocol_test.go
@@ -58,7 +58,7 @@ func TestProtPeeringRequest(t *testing.T) {
 	// set test parameters
 	SetParameters(Parameters{
 		SaltLifetime:           testSaltLifetime,
-		UpdateOutboundInterval: testUpdateInterval,
+		OutboundUpdateInterval: testUpdateInterval,
 	})
 	p2p := transport.P2P()
 	defer p2p.Close()
@@ -91,7 +91,7 @@ func TestProtExpiredSalt(t *testing.T) {
 	// set test parameters
 	SetParameters(Parameters{
 		SaltLifetime:           testSaltLifetime,
-		UpdateOutboundInterval: testUpdateInterval,
+		OutboundUpdateInterval: testUpdateInterval,
 	})
 	p2p := transport.P2P()
 	defer p2p.Close()
@@ -113,7 +113,7 @@ func TestProtDropPeer(t *testing.T) {
 	// set test parameters
 	SetParameters(Parameters{
 		SaltLifetime:           testSaltLifetime,
-		UpdateOutboundInterval: testUpdateInterval,
+		OutboundUpdateInterval: testUpdateInterval,
 	})
 	p2p := transport.P2P()
 	defer p2p.Close()
@@ -173,7 +173,7 @@ func TestProtFull(t *testing.T) {
 	// set test parameters
 	SetParameters(Parameters{
 		SaltLifetime:           testSaltLifetime,
-		UpdateOutboundInterval: testUpdateInterval,
+		OutboundUpdateInterval: testUpdateInterval,
 	})
 	p2p := transport.P2P()
 	defer p2p.Close()
@@ -186,7 +186,7 @@ func TestProtFull(t *testing.T) {
 	srvB, protB, closeB := newFullTest(t, p2p.B, getPeer(srvA))
 	defer closeB()
 
-	time.Sleep(updateOutboundInterval + graceTime) // wait for the next outbound cycle
+	time.Sleep(outboundUpdateInterval + graceTime) // wait for the next outbound cycle
 
 	// the two peers should be peered
 	assert.ElementsMatch(t, []*peer.Peer{getPeer(srvB)}, protA.GetNeighbors())

--- a/packages/autopeering/selection/protocol_test.go
+++ b/packages/autopeering/selection/protocol_test.go
@@ -38,10 +38,7 @@ func newTest(t require.TestingT, trans transport.Transport) (*server.Server, *Pr
 	// add the new peer to the global map for dummyDiscovery
 	peerMap[local.ID()] = &local.Peer
 
-	cfg := Config{
-		Log: l,
-	}
-	prot := New(local, dummyDiscovery{}, cfg)
+	prot := New(local, dummyDiscovery{}, Config{Log: l})
 	srv := server.Listen(local, trans, l.Named("srv"), prot)
 	prot.Start(srv)
 
@@ -58,6 +55,11 @@ func getPeer(s *server.Server) *peer.Peer {
 }
 
 func TestProtPeeringRequest(t *testing.T) {
+	// set test parameters
+	SetParameters(Parameters{
+		SaltLifetime:           testSaltLifetime,
+		UpdateOutboundInterval: testUpdateInterval,
+	})
 	p2p := transport.P2P()
 	defer p2p.Close()
 
@@ -86,6 +88,11 @@ func TestProtPeeringRequest(t *testing.T) {
 }
 
 func TestProtExpiredSalt(t *testing.T) {
+	// set test parameters
+	SetParameters(Parameters{
+		SaltLifetime:           testSaltLifetime,
+		UpdateOutboundInterval: testUpdateInterval,
+	})
 	p2p := transport.P2P()
 	defer p2p.Close()
 
@@ -103,6 +110,11 @@ func TestProtExpiredSalt(t *testing.T) {
 }
 
 func TestProtDropPeer(t *testing.T) {
+	// set test parameters
+	SetParameters(Parameters{
+		SaltLifetime:           testSaltLifetime,
+		UpdateOutboundInterval: testUpdateInterval,
+	})
 	p2p := transport.P2P()
 	defer p2p.Close()
 
@@ -158,6 +170,11 @@ func newFullTest(t require.TestingT, trans transport.Transport, masterPeers ...*
 }
 
 func TestProtFull(t *testing.T) {
+	// set test parameters
+	SetParameters(Parameters{
+		SaltLifetime:           testSaltLifetime,
+		UpdateOutboundInterval: testUpdateInterval,
+	})
 	p2p := transport.P2P()
 	defer p2p.Close()
 

--- a/packages/autopeering/selection/selection_test.go
+++ b/packages/autopeering/selection/selection_test.go
@@ -146,26 +146,26 @@ func TestSelection(t *testing.T) {
 	tests := []testCase{
 		{
 			nh: &Neighborhood{
-				Neighbors: []peer.PeerDistance{d[0]},
-				Size:      4},
+				neighbors: []peer.PeerDistance{d[0]},
+				size:      4},
 			expCandidate: d[1].Remote,
 		},
 		{
 			nh: &Neighborhood{
-				Neighbors: []peer.PeerDistance{d[0], d[1], d[3]},
-				Size:      4},
+				neighbors: []peer.PeerDistance{d[0], d[1], d[3]},
+				size:      4},
 			expCandidate: d[2].Remote,
 		},
 		{
 			nh: &Neighborhood{
-				Neighbors: []peer.PeerDistance{d[0], d[1], d[4], d[2]},
-				Size:      4},
+				neighbors: []peer.PeerDistance{d[0], d[1], d[4], d[2]},
+				size:      4},
 			expCandidate: d[3].Remote,
 		},
 		{
 			nh: &Neighborhood{
-				Neighbors: []peer.PeerDistance{d[0], d[1], d[2], d[3]},
-				Size:      4},
+				neighbors: []peer.PeerDistance{d[0], d[1], d[2], d[3]},
+				size:      4},
 			expCandidate: nil,
 		},
 	}

--- a/packages/autopeering/server/server.go
+++ b/packages/autopeering/server/server.go
@@ -11,8 +11,8 @@ import (
 	"github.com/iotaledger/goshimmer/packages/autopeering/peer"
 	pb "github.com/iotaledger/goshimmer/packages/autopeering/server/proto"
 	"github.com/iotaledger/goshimmer/packages/autopeering/transport"
+	"github.com/iotaledger/hive.go/logger"
 	"github.com/pkg/errors"
-	"go.uber.org/zap"
 )
 
 const (
@@ -25,7 +25,7 @@ type Server struct {
 	local    *peer.Local
 	trans    transport.Transport
 	handlers []Handler
-	log      *zap.SugaredLogger
+	log      *logger.Logger
 	network  string
 	address  string
 
@@ -70,7 +70,7 @@ type reply struct {
 // Listen starts a new peer server using the given transport layer for communication.
 // Sent data is signed using the identity of the local peer,
 // received data with a valid peer signature is handled according to the provided Handler.
-func Listen(local *peer.Local, t transport.Transport, log *zap.SugaredLogger, h ...Handler) *Server {
+func Listen(local *peer.Local, t transport.Transport, log *logger.Logger, h ...Handler) *Server {
 	srv := &Server{
 		local:           local,
 		trans:           t,

--- a/plugins/autopeering/autopeering.go
+++ b/plugins/autopeering/autopeering.go
@@ -44,11 +44,8 @@ func configureAP() {
 	// enable peer selection only when gossip is enabled
 	if !node.IsSkipped(gossip.PLUGIN) {
 		Selection = selection.New(local.GetInstance(), Discovery, selection.Config{
-			Log: log.Named("sel"),
-			Param: &selection.Parameters{
-				SaltLifetime:     selection.DefaultSaltLifetime,
-				RequiredServices: []service.Key{service.GossipKey},
-			},
+			Log:              log.Named("sel"),
+			RequiredServices: []service.Key{service.GossipKey},
 		})
 	}
 }

--- a/plugins/autopeering/autopeering.go
+++ b/plugins/autopeering/autopeering.go
@@ -46,8 +46,8 @@ func configureAP() {
 		Selection = selection.New(local.GetInstance(), Discovery, selection.Config{
 			Log: log.Named("sel"),
 			Param: &selection.Parameters{
-				SaltLifetime:    selection.DefaultSaltLifetime,
-				RequiredService: []service.Key{service.GossipKey},
+				SaltLifetime:     selection.DefaultSaltLifetime,
+				RequiredServices: []service.Key{service.GossipKey},
 			},
 		})
 	}

--- a/plugins/autopeering/plugin.go
+++ b/plugins/autopeering/plugin.go
@@ -1,6 +1,8 @@
 package autopeering
 
 import (
+	"time"
+
 	"github.com/iotaledger/goshimmer/packages/autopeering/discover"
 	"github.com/iotaledger/goshimmer/packages/autopeering/peer"
 	"github.com/iotaledger/goshimmer/packages/autopeering/selection"
@@ -45,7 +47,7 @@ func configureEvents() {
 	}))
 
 	selection.Events.SaltUpdated.Attach(events.NewClosure(func(ev *selection.SaltUpdatedEvent) {
-		log.Infof("Salt updated: %v", ev.Public.GetExpiration())
+		log.Infof("Salt updated; expires=%s", ev.Public.GetExpiration().Format(time.RFC822))
 	}))
 	selection.Events.OutgoingPeering.Attach(events.NewClosure(func(ev *selection.PeeringEvent) {
 		log.Infof("Peering chosen: %s / %s", ev.Peer.Address(), ev.Peer.ID())

--- a/plugins/autopeering/plugin.go
+++ b/plugins/autopeering/plugin.go
@@ -33,10 +33,10 @@ func run(*node.Plugin) {
 func configureEvents() {
 	// notify the selection when a connection is closed or failed.
 	gossip.Events.ConnectionFailed.Attach(events.NewClosure(func(p *peer.Peer) {
-		Selection.DropPeer(p)
+		Selection.RemoveNeighbor(p.ID())
 	}))
 	gossip.Events.NeighborRemoved.Attach(events.NewClosure(func(p *peer.Peer) {
-		Selection.DropPeer(p)
+		Selection.RemoveNeighbor(p.ID())
 	}))
 
 	discover.Events.PeerDiscovered.Attach(events.NewClosure(func(ev *discover.DiscoveredEvent) {

--- a/plugins/autopeering/plugin.go
+++ b/plugins/autopeering/plugin.go
@@ -44,6 +44,9 @@ func configureEvents() {
 		log.Infof("Removed offline: %s / %s", ev.Peer.Address(), ev.Peer.ID())
 	}))
 
+	selection.Events.SaltUpdated.Attach(events.NewClosure(func(ev *selection.SaltUpdatedEvent) {
+		log.Infof("Salt updated: %v", ev.Public.GetExpiration())
+	}))
 	selection.Events.OutgoingPeering.Attach(events.NewClosure(func(ev *selection.PeeringEvent) {
 		log.Infof("Peering chosen: %s / %s", ev.Peer.Address(), ev.Peer.ID())
 	}))

--- a/plugins/gossip/plugin.go
+++ b/plugins/gossip/plugin.go
@@ -52,6 +52,9 @@ func configureEvents() {
 		}()
 	}))
 
+	gossip.Events.ConnectionFailed.Attach(events.NewClosure(func(p *peer.Peer) {
+		log.Infof("Connection to neighbor failed: %s / %s", gossip.GetAddress(p), p.ID())
+	}))
 	gossip.Events.NeighborAdded.Attach(events.NewClosure(func(n *gossip.Neighbor) {
 		log.Infof("Neighbor added: %s / %s", gossip.GetAddress(n.Peer), n.ID())
 	}))


### PR DESCRIPTION
- Improve `selection.manager` to only have a single loop that handles drops and connects. This reduces the chance for parallel in/out connections.
- Add tests that `selection.Events` are triggered correctly.
- Introduce `selection.Events.SaltUpdated` triggered on salt updates.