### PR TITLE
Flush caches on shutdown and use a specific shutdown order

### DIFF
--- a/packages/shutdown/order.go
+++ b/packages/shutdown/order.go
@@ -1,0 +1,18 @@
+package shutdown
+
+const (
+	ShutdownPriorityTangle = iota
+	ShutdownPrioritySolidifier
+	ShutdownPriorityBundleProcessor
+	ShutdownPriorityAnalysis
+	ShutdownPriorityMetrics
+	ShutdownPriorityWebAPI
+	ShutdownPriorityGossip
+	ShutdownPriorityZMQ
+	ShutdownPriorityAutopeering
+	ShutdownPriorityGraph
+	ShutdownPriorityUI
+	ShutdownPriorityDashboard
+	ShutdownPriorityTangleSpammer
+	ShutdownPriorityStatusScreen
+)

--- a/packages/transactionspammer/transactionspammer.go
+++ b/packages/transactionspammer/transactionspammer.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/iotaledger/goshimmer/packages/shutdown"
 	"github.com/iotaledger/goshimmer/plugins/autopeering/local"
 
 	"github.com/iotaledger/goshimmer/packages/gossip"
@@ -79,7 +80,7 @@ func Start(tps uint) {
 				}
 			}
 		}
-	})
+	}, shutdown.ShutdownPriorityTangleSpammer)
 }
 
 func Stop() {

--- a/plugins/analysis/client/plugin.go
+++ b/plugins/analysis/client/plugin.go
@@ -8,6 +8,7 @@ import (
 	"github.com/iotaledger/goshimmer/packages/autopeering/selection"
 	"github.com/iotaledger/goshimmer/packages/network"
 	"github.com/iotaledger/goshimmer/packages/parameter"
+	"github.com/iotaledger/goshimmer/packages/shutdown"
 	"github.com/iotaledger/goshimmer/plugins/analysis/types/addnode"
 	"github.com/iotaledger/goshimmer/plugins/analysis/types/connectnodes"
 	"github.com/iotaledger/goshimmer/plugins/analysis/types/disconnectnodes"
@@ -50,7 +51,7 @@ func Run(plugin *node.Plugin) {
 				}
 			}
 		}
-	})
+	}, shutdown.ShutdownPriorityAnalysis)
 }
 
 func getEventDispatchers(conn *network.ManagedConnection) *EventDispatchers {

--- a/plugins/analysis/server/plugin.go
+++ b/plugins/analysis/server/plugin.go
@@ -7,6 +7,7 @@ import (
 	"github.com/iotaledger/goshimmer/packages/network"
 	"github.com/iotaledger/goshimmer/packages/network/tcp"
 	"github.com/iotaledger/goshimmer/packages/parameter"
+	"github.com/iotaledger/goshimmer/packages/shutdown"
 	"github.com/iotaledger/goshimmer/plugins/analysis/types/addnode"
 	"github.com/iotaledger/goshimmer/plugins/analysis/types/connectnodes"
 	"github.com/iotaledger/goshimmer/plugins/analysis/types/disconnectnodes"
@@ -45,7 +46,7 @@ func Run(plugin *node.Plugin) {
 		go server.Listen(parameter.NodeConfig.GetInt(CFG_SERVER_PORT))
 		<-shutdownSignal
 		Shutdown()
-	})
+	}, shutdown.ShutdownPriorityAnalysis)
 }
 
 func Shutdown() {

--- a/plugins/analysis/webinterface/httpserver/plugin.go
+++ b/plugins/analysis/webinterface/httpserver/plugin.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/iotaledger/goshimmer/packages/shutdown"
 	"github.com/iotaledger/hive.go/daemon"
 	"github.com/iotaledger/hive.go/node"
 	"golang.org/x/net/context"
@@ -30,5 +31,5 @@ func Run(plugin *node.Plugin) {
 		ctx, cancel := context.WithTimeout(context.Background(), 0*time.Second)
 		defer cancel()
 		httpServer.Shutdown(ctx)
-	})
+	}, shutdown.ShutdownPriorityAnalysis)
 }

--- a/plugins/autopeering/plugin.go
+++ b/plugins/autopeering/plugin.go
@@ -5,6 +5,7 @@ import (
 	"github.com/iotaledger/goshimmer/packages/autopeering/peer"
 	"github.com/iotaledger/goshimmer/packages/autopeering/selection"
 	"github.com/iotaledger/goshimmer/packages/gossip"
+	"github.com/iotaledger/goshimmer/packages/shutdown"
 	"github.com/iotaledger/hive.go/daemon"
 	"github.com/iotaledger/hive.go/events"
 	"github.com/iotaledger/hive.go/logger"
@@ -23,7 +24,7 @@ func configure(*node.Plugin) {
 }
 
 func run(*node.Plugin) {
-	if err := daemon.BackgroundWorker(name, start); err != nil {
+	if err := daemon.BackgroundWorker(name, start, shutdown.ShutdownPriorityAutopeering); err != nil {
 		log.Errorf("Failed to start as daemon: %s", err)
 	}
 }

--- a/plugins/bundleprocessor/plugin.go
+++ b/plugins/bundleprocessor/plugin.go
@@ -3,6 +3,7 @@ package bundleprocessor
 import (
 	"github.com/iotaledger/goshimmer/packages/errors"
 	"github.com/iotaledger/goshimmer/packages/model/value_transaction"
+	"github.com/iotaledger/goshimmer/packages/shutdown"
 	"github.com/iotaledger/goshimmer/plugins/tangle"
 	"github.com/iotaledger/hive.go/daemon"
 	"github.com/iotaledger/hive.go/events"
@@ -37,7 +38,7 @@ func run(*node.Plugin) {
 		log.Info("Stopping Bundle Processor ...")
 		workerPool.StopAndWait()
 		log.Info("Stopping Bundle Processor ... done")
-	})
+	}, shutdown.ShutdownPriorityBundleProcessor)
 
 	log.Info("Starting Value Bundle Processor ...")
 
@@ -48,5 +49,5 @@ func run(*node.Plugin) {
 		log.Info("Stopping Value Bundle Processor ...")
 		valueBundleProcessorWorkerPool.StopAndWait()
 		log.Info("Stopping Value Bundle Processor ... done")
-	})
+	}, shutdown.ShutdownPriorityBundleProcessor)
 }

--- a/plugins/dashboard/plugin.go
+++ b/plugins/dashboard/plugin.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/iotaledger/goshimmer/packages/shutdown"
 	"github.com/iotaledger/goshimmer/plugins/metrics"
 	"github.com/iotaledger/hive.go/daemon"
 	"github.com/iotaledger/hive.go/events"
@@ -48,5 +49,5 @@ func run(plugin *node.Plugin) {
 		ctx, cancel := context.WithTimeout(context.Background(), 0*time.Second)
 		defer cancel()
 		_ = server.Shutdown(ctx)
-	})
+	}, shutdown.ShutdownPriorityDashboard)
 }

--- a/plugins/gossip/plugin.go
+++ b/plugins/gossip/plugin.go
@@ -5,6 +5,7 @@ import (
 	"github.com/iotaledger/goshimmer/packages/autopeering/selection"
 	"github.com/iotaledger/goshimmer/packages/gossip"
 	"github.com/iotaledger/goshimmer/packages/model/value_transaction"
+	"github.com/iotaledger/goshimmer/packages/shutdown"
 	"github.com/iotaledger/goshimmer/plugins/tangle"
 	"github.com/iotaledger/hive.go/daemon"
 	"github.com/iotaledger/hive.go/events"
@@ -24,7 +25,7 @@ func configure(*node.Plugin) {
 }
 
 func run(*node.Plugin) {
-	if err := daemon.BackgroundWorker(name, start); err != nil {
+	if err := daemon.BackgroundWorker(name, start, shutdown.ShutdownPriorityGossip); err != nil {
 		log.Errorf("Failed to start as daemon: %s", err)
 	}
 }

--- a/plugins/graph/plugin.go
+++ b/plugins/graph/plugin.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/iotaledger/goshimmer/packages/model/value_transaction"
 	"github.com/iotaledger/goshimmer/packages/parameter"
+	"github.com/iotaledger/goshimmer/packages/shutdown"
 	"github.com/iotaledger/goshimmer/plugins/tangle"
 	"golang.org/x/net/context"
 
@@ -105,7 +106,7 @@ func run(plugin *node.Plugin) {
 		tangle.Events.TransactionStored.Detach(notifyNewTx)
 		newTxWorkerPool.Stop()
 		log.Info("Stopping Graph[NewTxWorker] ... done")
-	})
+	}, shutdown.ShutdownPriorityGraph)
 
 	daemon.BackgroundWorker("Graph Webserver", func(shutdownSignal <-chan struct{}) {
 		go socketioServer.Serve()
@@ -128,5 +129,5 @@ func run(plugin *node.Plugin) {
 
 		_ = server.Shutdown(ctx)
 		log.Info("Stopping Graph ... done")
-	})
+	}, shutdown.ShutdownPriorityGraph)
 }

--- a/plugins/metrics/plugin.go
+++ b/plugins/metrics/plugin.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/iotaledger/goshimmer/packages/gossip"
+	"github.com/iotaledger/goshimmer/packages/shutdown"
 	"github.com/iotaledger/hive.go/daemon"
 	"github.com/iotaledger/hive.go/events"
 	"github.com/iotaledger/hive.go/node"
@@ -21,5 +22,5 @@ func run(plugin *node.Plugin) {
 	// create a background worker that "measures" the TPS value every second
 	daemon.BackgroundWorker("Metrics TPS Updater", func(shutdownSignal <-chan struct{}) {
 		timeutil.Ticker(measureReceivedTPS, 1*time.Second, shutdownSignal)
-	})
+	}, shutdown.ShutdownPriorityMetrics)
 }

--- a/plugins/statusscreen-tps/plugin.go
+++ b/plugins/statusscreen-tps/plugin.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/iotaledger/goshimmer/packages/gossip"
 	"github.com/iotaledger/goshimmer/packages/model/value_transaction"
+	"github.com/iotaledger/goshimmer/packages/shutdown"
 	"github.com/iotaledger/goshimmer/plugins/statusscreen"
 	"github.com/iotaledger/goshimmer/plugins/tangle"
 	"github.com/iotaledger/hive.go/daemon"
@@ -51,5 +52,5 @@ var PLUGIN = node.NewPlugin("Statusscreen TPS", node.Enabled, func(plugin *node.
 				atomic.StoreUint64(&solidTpsCounter, 0)
 			}
 		}
-	})
+	}, shutdown.ShutdownPriorityStatusScreen)
 })

--- a/plugins/statusscreen/plugin.go
+++ b/plugins/statusscreen/plugin.go
@@ -3,6 +3,7 @@ package statusscreen
 import (
 	"time"
 
+	"github.com/iotaledger/goshimmer/packages/shutdown"
 	"github.com/iotaledger/hive.go/daemon"
 	"github.com/iotaledger/hive.go/events"
 	"github.com/iotaledger/hive.go/logger"
@@ -57,7 +58,7 @@ func run(*node.Plugin) {
 				return
 			}
 		}
-	}); err != nil {
+	}, shutdown.ShutdownPriorityStatusScreen); err != nil {
 		log.Errorf("Failed to start as daemon: %s", err)
 		return
 	}
@@ -72,7 +73,7 @@ func run(*node.Plugin) {
 		if err := app.SetRoot(frame, true).SetFocus(frame).Run(); err != nil {
 			log.Errorf("Error running application: %s", err)
 		}
-	}); err != nil {
+	}, shutdown.ShutdownPriorityStatusScreen); err != nil {
 		log.Errorf("Failed to start as daemon: %s", err)
 		close(stopped)
 	}

--- a/plugins/tangle/solidifier.go
+++ b/plugins/tangle/solidifier.go
@@ -10,6 +10,7 @@ import (
 	"github.com/iotaledger/goshimmer/packages/model/meta_transaction"
 	"github.com/iotaledger/goshimmer/packages/model/transactionmetadata"
 	"github.com/iotaledger/goshimmer/packages/model/value_transaction"
+	"github.com/iotaledger/goshimmer/packages/shutdown"
 	"github.com/iotaledger/goshimmer/packages/workerpool"
 	"github.com/iotaledger/hive.go/daemon"
 	"github.com/iotaledger/hive.go/events"
@@ -62,7 +63,7 @@ func runSolidifier() {
 		log.Info("Stopping Solidifier ...")
 		workerPool.StopAndWait()
 		log.Info("Stopping Solidifier ... done")
-	})
+	}, shutdown.ShutdownPrioritySolidifier)
 }
 
 // endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/plugins/tangle/transaction_metadata.go
+++ b/plugins/tangle/transaction_metadata.go
@@ -2,9 +2,9 @@ package tangle
 
 import (
 	"github.com/iotaledger/goshimmer/packages/database"
-	"github.com/iotaledger/goshimmer/packages/datastructure"
 	"github.com/iotaledger/goshimmer/packages/errors"
 	"github.com/iotaledger/goshimmer/packages/model/transactionmetadata"
+	"github.com/iotaledger/hive.go/lru_cache"
 	"github.com/iotaledger/hive.go/typeutils"
 	"github.com/iotaledger/iota.go/trinary"
 )
@@ -51,18 +51,24 @@ func StoreTransactionMetadata(transactionMetadata *transactionmetadata.Transacti
 
 // region lru cache ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-var transactionMetadataCache = datastructure.NewLRUCache(TRANSACTION_METADATA_CACHE_SIZE, &datastructure.LRUCacheOptions{
-	EvictionCallback: onEvictTransactionMetadata,
+var transactionMetadataCache = lru_cache.NewLRUCache(TRANSACTION_METADATA_CACHE_SIZE, &lru_cache.LRUCacheOptions{
+	EvictionCallback:  onEvictTransactionMetadatas,
+	EvictionBatchSize: 200,
 })
 
-func onEvictTransactionMetadata(_ interface{}, value interface{}) {
-	if evictedTransactionMetadata := value.(*transactionmetadata.TransactionMetadata); evictedTransactionMetadata.GetModified() {
-		go func(evictedTransactionMetadata *transactionmetadata.TransactionMetadata) {
-			if err := storeTransactionMetadataInDatabase(evictedTransactionMetadata); err != nil {
+func onEvictTransactionMetadatas(_ interface{}, values interface{}) {
+	// TODO: replace with apply
+	for _, obj := range values.([]interface{}) {
+		if txMetadata := obj.(*transactionmetadata.TransactionMetadata); txMetadata.GetModified() {
+			if err := storeTransactionMetadataInDatabase(txMetadata); err != nil {
 				panic(err)
 			}
-		}(evictedTransactionMetadata)
+		}
 	}
+}
+
+func FlushTransactionMetadata() {
+	transactionCache.DeleteAll()
 }
 
 const (

--- a/plugins/ui/ui.go
+++ b/plugins/ui/ui.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/iotaledger/goshimmer/packages/gossip"
 	"github.com/iotaledger/goshimmer/packages/model/value_transaction"
+	"github.com/iotaledger/goshimmer/packages/shutdown"
 	"github.com/iotaledger/goshimmer/plugins/tangle"
 	"github.com/iotaledger/goshimmer/plugins/webapi"
 	"github.com/iotaledger/hive.go/daemon"
@@ -86,7 +87,7 @@ func run(plugin *node.Plugin) {
 				wsMutex.Unlock()
 			}
 		}
-	})
+	}, shutdown.ShutdownPriorityUI)
 }
 
 // PLUGIN plugs the UI into the main program

--- a/plugins/webapi/plugin.go
+++ b/plugins/webapi/plugin.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/iotaledger/goshimmer/packages/shutdown"
 	"github.com/iotaledger/hive.go/daemon"
 	"github.com/iotaledger/hive.go/logger"
 	"github.com/iotaledger/hive.go/node"
@@ -43,5 +44,5 @@ func run(plugin *node.Plugin) {
 		if err := Server.Shutdown(ctx); err != nil {
 			log.Errorf("Couldn't stop server cleanly: %s", err.Error())
 		}
-	})
+	}, shutdown.ShutdownPriorityWebAPI)
 }

--- a/plugins/webauth/webauth.go
+++ b/plugins/webauth/webauth.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/iotaledger/goshimmer/packages/shutdown"
 	"github.com/iotaledger/goshimmer/plugins/webapi"
 	"github.com/iotaledger/hive.go/daemon"
 	"github.com/iotaledger/hive.go/node"
@@ -66,7 +67,7 @@ func run(plugin *node.Plugin) {
 				"token": t,
 			})
 		})
-	})
+	}, shutdown.ShutdownPriorityWebAPI)
 }
 
 // PLUGIN plugs the UI into the main program

--- a/plugins/zeromq/plugin.go
+++ b/plugins/zeromq/plugin.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/iotaledger/goshimmer/packages/model/value_transaction"
 	"github.com/iotaledger/goshimmer/packages/parameter"
+	"github.com/iotaledger/goshimmer/packages/shutdown"
 	"github.com/iotaledger/goshimmer/plugins/tangle"
 	"github.com/iotaledger/hive.go/daemon"
 	"github.com/iotaledger/hive.go/events"
@@ -53,7 +54,7 @@ func run(plugin *node.Plugin) {
 		} else {
 			log.Info("Stopping ZeroMQ Publisher ... done")
 		}
-	})
+	}, shutdown.ShutdownPriorityZMQ)
 }
 
 // Start the zmq publisher.


### PR DESCRIPTION
* Replaces all LRU caches with the implementation from hive.go with batched evictions.
* All LRU caches are now actually flushed up on shutdown.
* The actual badger database instance is now closed when the node is shutdown, otherwise there's data loss.
* Every background worker now has a shutdown priority order set, to ensure that stuff gets shutdown in an order which makes sense.

Fixes #115 #114 