### PR TITLE
Set new transactions as modified/Adjusts webapi endpoint methods

### DIFF
--- a/plugins/tangle/solidifier.go
+++ b/plugins/tangle/solidifier.go
@@ -181,7 +181,9 @@ func processMetaTransaction(metaTransaction *meta_transaction.MetaTransaction) {
 	if tx, err := GetTransaction(metaTransaction.GetHash(), func(transactionHash trinary.Trytes) *value_transaction.ValueTransaction {
 		newTransaction = true
 
-		return value_transaction.FromMetaTransaction(metaTransaction)
+		tx := value_transaction.FromMetaTransaction(metaTransaction)
+		tx.SetModified(true)
+		return tx
 	}); err != nil {
 		log.Errorf("Unable to load transaction %s: %s", metaTransaction.GetHash(), err.Error())
 	} else if newTransaction {

--- a/plugins/webapi/findTransactions/plugin.go
+++ b/plugins/webapi/findTransactions/plugin.go
@@ -16,7 +16,7 @@ var log *logger.Logger
 
 func configure(plugin *node.Plugin) {
 	log = logger.NewLogger("API-findTransactions")
-	webapi.Server.GET("findTransactions", findTransactions)
+	webapi.Server.POST("findTransactions", findTransactions)
 }
 
 // findTransactions returns the array of transaction hashes for the
@@ -24,7 +24,6 @@ func configure(plugin *node.Plugin) {
 // If a node doesn't have any transaction hash for a given address in its ledger,
 // the value at the index of that address is empty.
 func findTransactions(c echo.Context) error {
-
 	var request Request
 
 	if err := c.Bind(&request); err != nil {

--- a/plugins/webapi/getTransactions/plugin.go
+++ b/plugins/webapi/getTransactions/plugin.go
@@ -16,7 +16,7 @@ var log *logger.Logger
 
 func configure(plugin *node.Plugin) {
 	log = logger.NewLogger("API-getTransactions")
-	webapi.Server.GET("getTransactions", getTransactions)
+	webapi.Server.POST("getTransactions", getTransactions)
 }
 
 // getTransactions returns the array of transactions for the


### PR DESCRIPTION
* Fixes transactions not being persisted over restarts because new transactions were never flagged as modified
* Adjusts the webapi endpoints to POST where it was GET but the request was a JSON payload
* Adjusts the client lib to also check for StatusCreated http status codes as successful responses