### PR TITLE
Adds database versioning

### DIFF
--- a/main.go
+++ b/main.go
@@ -39,9 +39,9 @@ func main() {
 	node.Run(
 		node.Plugins(
 			cli.PLUGIN,
+			tangle.PLUGIN,
 			autopeering.PLUGIN,
 			gossip.PLUGIN,
-			tangle.PLUGIN,
 			bundleprocessor.PLUGIN,
 			analysis.PLUGIN,
 			gracefulshutdown.PLUGIN,

--- a/plugins/tangle/db_version.go
+++ b/plugins/tangle/db_version.go
@@ -1,0 +1,70 @@
+package tangle
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/iotaledger/goshimmer/packages/database"
+	"github.com/iotaledger/goshimmer/packages/parameter"
+	"github.com/pkg/errors"
+)
+
+var (
+	ErrDBVersionIncompatible = errors.New("database version is not compatible. please delete your database folder and restart")
+)
+
+const (
+	// the database name
+	dbVersionDBName = "version"
+	// defines which version of the database schema this version of GoShimmer supports.
+	// everytime there's a breaking change regarding the stored data, this version flag should be adjusted.
+	DBVersion byte = 1
+)
+
+var (
+	// the key under which the database is stored
+	dbVersionKey = []byte{0}
+)
+
+func checkDatabaseVersion() {
+	var dbDirDoesntExist bool
+	// only check the version if there's actually a database folder.
+	// note that this check only works, if the tangle plugin is the first
+	// plugin which initializes a database, as otherwise any other call would automatically
+	// create the database folder.
+	directory := parameter.NodeConfig.GetString(database.CFG_DIRECTORY)
+	_, err := os.Stat(directory)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			panic(err)
+		}
+		dbDirDoesntExist = true
+	}
+
+	db, err := database.Get(dbVersionDBName)
+	if err != nil {
+		panic(err)
+	}
+
+	if dbDirDoesntExist {
+		// store db version for the first time in the new database
+		if err := db.Set(dbVersionKey, []byte{DBVersion}); err != nil {
+			panic(fmt.Sprintf("unable to persist db version number: %s", err.Error()))
+		}
+		log.Info("storing database version for the first time")
+		return
+	}
+
+	// db version must be available
+	version, err := db.Get(dbVersionKey)
+	if err != nil && err != database.ErrKeyNotFound {
+		panic(err)
+	}
+	if version == nil || err != nil {
+		panic(errors.Wrapf(ErrDBVersionIncompatible, "no database version was persisted"))
+	}
+	if version[0] != DBVersion {
+		panic(errors.Wrapf(ErrDBVersionIncompatible, "supported version: %d, version of database: %d", DBVersion, version[0]))
+	}
+	// database version compatible
+}

--- a/plugins/tangle/plugin.go
+++ b/plugins/tangle/plugin.go
@@ -17,6 +17,8 @@ var log *logger.Logger
 func configure(*node.Plugin) {
 	log = logger.NewLogger("Tangle")
 
+	checkDatabaseVersion()
+
 	configureTransactionDatabase()
 	configureTransactionMetaDataDatabase()
 	configureApproversDatabase()


### PR DESCRIPTION
Everytime the node starts up, now a flag is checked within the database to ensure that it is compatible with the given version of GoShimmer. If the schema of stored data somehow inflicts a breaking change, the database version can be adjusted to force users to delete their database folder (this is ok, because GoShimmer is just a prototype, people should never assume that their data persists over version jumps).

Old databases which were made pre v0.1.0 are not compatible and therefore also there a crash message instructing the user to delete the database is printed out.

Closes #130