### PR TITLE
Feat: Add option for node identity seed

### DIFF
--- a/packages/autopeering/peer/mapdb.go
+++ b/packages/autopeering/peer/mapdb.go
@@ -67,6 +67,15 @@ func (db *mapDB) LocalPrivateKey() (PrivateKey, error) {
 	return db.key, nil
 }
 
+// UpdateLocalPrivateKey stores the provided key in the database.
+func (db *mapDB) UpdateLocalPrivateKey(key PrivateKey) error {
+	db.mutex.Lock()
+	defer db.mutex.Unlock()
+
+	db.key = key
+	return nil
+}
+
 // LastPing returns that property for the given peer ID and address.
 func (db *mapDB) LastPing(id ID, address string) time.Time {
 	db.mutex.RLock()

--- a/packages/autopeering/peer/peerdb.go
+++ b/packages/autopeering/peer/peerdb.go
@@ -28,6 +28,8 @@ const (
 type DB interface {
 	// LocalPrivateKey returns the private key stored in the database or creates a new one.
 	LocalPrivateKey() (PrivateKey, error)
+	// UpdateLocalPrivateKey stores the provided key in the database.
+	UpdateLocalPrivateKey(key PrivateKey) error
 
 	// Peer retrieves a peer from the database.
 	Peer(id ID) *Peer
@@ -175,7 +177,7 @@ func (db *persistentDB) LocalPrivateKey() (PrivateKey, error) {
 	if err == database.ErrKeyNotFound {
 		key, err = generatePrivateKey()
 		if err == nil {
-			err = db.db.Set(localFieldKey(dbLocalKey), key)
+			err = db.UpdateLocalPrivateKey(key)
 		}
 		return key, err
 	}
@@ -184,6 +186,11 @@ func (db *persistentDB) LocalPrivateKey() (PrivateKey, error) {
 	}
 
 	return key, nil
+}
+
+// UpdateLocalPrivateKey stores the provided key in the database.
+func (db *persistentDB) UpdateLocalPrivateKey(key PrivateKey) error {
+	return db.db.Set(localFieldKey(dbLocalKey), key)
 }
 
 // LastPing returns that property for the given peer ID and address.

--- a/plugins/autopeering/local/local.go
+++ b/plugins/autopeering/local/local.go
@@ -25,7 +25,7 @@ func configureLocal() *peer.Local {
 
 	ip := net.ParseIP(parameter.NodeConfig.GetString(CFG_ADDRESS))
 	if ip == nil {
-		log.Fatalf("Invalid IP address: %s", parameter.NodeConfig.GetString(CFG_ADDRESS))
+		log.Fatalf("Invalid %s address: %s", CFG_ADDRESS, parameter.NodeConfig.GetString(CFG_ADDRESS))
 	}
 	if ip.IsUnspecified() {
 		log.Info("Querying public IP ...")
@@ -52,10 +52,10 @@ func configureLocal() *peer.Local {
 		str := parameter.NodeConfig.GetString(CFG_SEED)
 		bytes, err := base64.StdEncoding.DecodeString(str)
 		if err != nil {
-			log.Fatalf("Invalid seed: %s", err)
+			log.Fatalf("Invalid %s: %s", CFG_SEED, err)
 		}
 		if l := len(bytes); l != ed25519.SeedSize {
-			log.Fatalf("Invalid seed length: %d, need %d", l, ed25519.SeedSize)
+			log.Fatalf("Invalid %s length: %d, need %d", CFG_SEED, l, ed25519.SeedSize)
 		}
 		seed = append(seed, bytes)
 	}

--- a/plugins/autopeering/local/parameters.go
+++ b/plugins/autopeering/local/parameters.go
@@ -7,9 +7,11 @@ import (
 const (
 	CFG_ADDRESS = "autopeering.address"
 	CFG_PORT    = "autopeering.port"
+	CFG_SEED    = "autopeering.seed"
 )
 
 func init() {
 	flag.String(CFG_ADDRESS, "0.0.0.0", "address to bind for incoming peering requests")
 	flag.Int(CFG_PORT, 14626, "udp port for incoming peering requests")
+	flag.BytesBase64(CFG_SEED, nil, "private key seed used to derive the node identity; optional Base64 encoded 256-bit string")
 }


### PR DESCRIPTION
- The new option `autopeering.seed` can be configured via flags or `config.json`.
- It takes any Base64 encoded 32-byte array to deterministically generate the private/public key used for the node idenity.

Closes: #140 