### PR TITLE
Removes sent counter as value in spammed transactions

### DIFF
--- a/packages/transactionspammer/transactionspammer.go
+++ b/packages/transactionspammer/transactionspammer.go
@@ -1,19 +1,21 @@
 package transactionspammer
 
 import (
+	"strings"
 	"sync"
 	"time"
-
-	"github.com/iotaledger/goshimmer/packages/shutdown"
-	"github.com/iotaledger/goshimmer/plugins/autopeering/local"
 
 	"github.com/iotaledger/goshimmer/packages/gossip"
 	"github.com/iotaledger/goshimmer/packages/model/meta_transaction"
 	"github.com/iotaledger/goshimmer/packages/model/value_transaction"
+	"github.com/iotaledger/goshimmer/packages/shutdown"
+	"github.com/iotaledger/goshimmer/plugins/autopeering/local"
 	"github.com/iotaledger/goshimmer/plugins/tipselection"
 	"github.com/iotaledger/hive.go/daemon"
 	"github.com/iotaledger/hive.go/logger"
 )
+
+const logEveryNTransactions = 5000
 
 var log *logger.Logger
 
@@ -23,14 +25,14 @@ var spammingMutex sync.Mutex
 var shutdownSignal chan struct{}
 var done chan struct{}
 
-var sentCounter = uint(0)
-
 func init() {
 	shutdownSignal = make(chan struct{})
 	done = make(chan struct{})
 }
 
-func Start(tps uint) {
+var targetAddress = strings.Repeat("SPAMMMMER", 9)
+
+func Start(tps uint64) {
 	log = logger.NewLogger("Transaction Spammer")
 	spammingMutex.Lock()
 	spamming = true
@@ -38,8 +40,11 @@ func Start(tps uint) {
 
 	daemon.BackgroundWorker("Transaction Spammer", func(daemonShutdownSignal <-chan struct{}) {
 		start := time.Now()
-		totalSentCounter := int64(0)
 
+		var totalSentCounter, currentSentCounter uint64
+
+		log.Infof("started spammer...will output sent count every %d transactions", logEveryNTransactions)
+		defer log.Infof("spammer stopped, spammed %d transactions", totalSentCounter)
 		for {
 			select {
 			case <-daemonShutdownSignal:
@@ -50,13 +55,13 @@ func Start(tps uint) {
 				return
 
 			default:
-				sentCounter++
+				currentSentCounter++
 				totalSentCounter++
 
 				tx := value_transaction.New()
 				tx.SetHead(true)
 				tx.SetTail(true)
-				tx.SetValue(totalSentCounter)
+				tx.SetAddress(targetAddress)
 				tx.SetBranchTransactionHash(tipselection.GetRandomTip())
 				tx.SetTrunkTransactionHash(tipselection.GetRandomTip())
 				tx.SetTimestamp(uint(time.Now().Unix()))
@@ -67,7 +72,12 @@ func Start(tps uint) {
 
 				gossip.Events.TransactionReceived.Trigger(&gossip.TransactionReceivedEvent{Data: tx.GetBytes(), Peer: &local.GetInstance().Peer})
 
-				if sentCounter >= tps {
+				if totalSentCounter%logEveryNTransactions == 0 {
+					log.Infof("spammed %d transactions", totalSentCounter)
+				}
+
+				// rate limit to the specified TPS
+				if currentSentCounter >= tps {
 					duration := time.Since(start)
 
 					if duration < time.Second {
@@ -75,8 +85,7 @@ func Start(tps uint) {
 					}
 
 					start = time.Now()
-
-					sentCounter = 0
+					currentSentCounter = 0
 				}
 			}
 		}

--- a/plugins/webapi/spammer/plugin.go
+++ b/plugins/webapi/spammer/plugin.go
@@ -61,5 +61,5 @@ type Response struct {
 
 type Request struct {
 	Cmd string `json:"cmd"`
-	Tps uint   `json:"tps"`
+	Tps uint64 `json:"tps"`
 }


### PR DESCRIPTION
* Logs the total sent txs counter every 5000 transactions
* Actually log when the spammer is started and stopped
* Little refactor
* Spammed transactions are targeted at address "SPAMMMER"*9

Fixes https://github.com/iotaledger/goshimmer/issues/152