### PR TITLE
Add config keys to make bind addresses configurable

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,7 +1,14 @@
 {
   "analysis": {
-    "serverAddress": "ressims.iota.cafe:188",
-    "serverPort": 0
+    "client": {
+      "serverAddress": "ressims.iota.cafe:188"
+    },
+    "server": {
+      "port": 0
+    },
+    "httpServer": {
+      "bindAddress": "0.0.0.0:80"
+    }
   },
   "autopeering": {
     "entryNodes": [

--- a/config.json
+++ b/config.json
@@ -23,10 +23,9 @@
     "port": 14666
   },
   "graph": {
+    "bindAddress": "127.0.0.1:8083",
     "domain": "",
-    "bindAddress": "127.0.0.1",
     "networkName": "GoShimmer",
-    "port": 8083,
     "socketIOPath": "socket.io-client/dist/socket.io.js",
     "webrootPath": "IOTAtangle/webroot"
   },

--- a/config.json
+++ b/config.json
@@ -16,6 +16,9 @@
     ],
     "port": 14626
   },
+  "dashboard": {
+    "bindAddress": "0.0.0.0:8081"
+  },
   "database": {
     "directory": "mainnetdb"
   },

--- a/config.json
+++ b/config.json
@@ -1,11 +1,10 @@
 {
   "analysis": {
-    "serveraddress": "ressims.iota.cafe:188",
-    "serverport": 0
+    "serverAddress": "ressims.iota.cafe:188",
+    "serverPort": 0
   },
   "autopeering": {
-    "address": "0.0.0.0",
-    "entrynodes": [
+    "entryNodes": [
       "V8LYtWWcPYYDTTXLeIEFjJEuWlsjDiI0+Pq/Cx9ai6g=@116.202.49.178:14626"
     ],
     "port": 14626
@@ -16,34 +15,41 @@
   "gossip": {
     "port": 14666
   },
-  "webapi": {
-    "bindAddress": "0.0.0.0:8080",
-    "auth": {
-      "username": "goshimmer",
-      "password": "goshimmer",
-      "privateKey": "uUUavNbdr32jE9CqnSMCKt4HMu9AZ2K4rKekUSPx9jk83eyeM7xewv5CqUKYMC9"
-    }
-  },
   "graph": {
-    "webrootPath": "./IOTAtangle/webroot",
-    "socketioPath": "./socket.io-client/dist/socket.io.js",
     "domain": "",
-    "host": "127.0.0.1",
+    "bindAddress": "127.0.0.1",
+    "networkName": "GoShimmer",
     "port": 8083,
-    "networkName": "GoShimmer"
+    "socketIOPath": "socket.io-client/dist/socket.io.js",
+    "webrootPath": "IOTAtangle/webroot"
   },
   "logger": {
-    "Level": "info",
-    "DisableCaller": false,
-    "DisableStacktrace": false,
-    "Encoding": "console",
-    "OutputPaths": [
+    "level": "info",
+    "disableCaller": false,
+    "disableStacktrace": false,
+    "encoding": "console",
+    "outputPaths": [
       "goshimmer.log"
-    ]
+    ],
+    "disableEvents": false
+  },
+  "network": {
+    "bindAddress": "0.0.0.0",
+    "externalAddress": "auto"
   },
   "node": {
-    "disableplugins": "",
-    "enableplugins": [],
-    "loglevel": 0
+    "disablePlugins": [],
+    "enablePlugins": []
+  },
+  "webapi": {
+    "auth": {
+      "password": "goshimmer",
+      "privateKey": "",
+      "username": "goshimmer"
+    },
+    "bindAddress": "0.0.0.0:8080"
+  },
+  "zeromq": {
+    "port": 5556
   }
 }

--- a/packages/autopeering/discover/manager_test.go
+++ b/packages/autopeering/discover/manager_test.go
@@ -33,7 +33,9 @@ func (m *NetworkMock) DiscoveryRequest(p *peer.Peer) ([]*peer.Peer, error) {
 }
 
 func newNetworkMock() *NetworkMock {
-	local, _ := peer.NewLocal("mock", "0", peer.NewMemoryDB(log))
+	services := service.New()
+	services.Update(service.PeeringKey, "mock", "local")
+	local, _ := peer.NewLocal(services, peer.NewMemoryDB(log))
 	return &NetworkMock{
 		// no database needed
 		loc: local,

--- a/packages/autopeering/peer/local.go
+++ b/packages/autopeering/peer/local.go
@@ -44,7 +44,7 @@ func newLocal(key PrivateKey, serviceRecord *service.Record, db DB) *Local {
 // NewLocal creates a new local peer linked to the provided db.
 // If an optional seed is provided, the seed is used to generate the private key. Without a seed,
 // the provided key is loaded from the provided database and generated if not stored there.
-func NewLocal(network string, address string, db DB, seed ...[]byte) (*Local, error) {
+func NewLocal(serviceRecord *service.Record, db DB, seed ...[]byte) (*Local, error) {
 	var key PrivateKey
 	if len(seed) > 0 {
 		key = PrivateKey(ed25519.NewKeyFromSeed(seed[0]))
@@ -62,10 +62,6 @@ func NewLocal(network string, address string, db DB, seed ...[]byte) (*Local, er
 	if l := len(key); l != ed25519.PrivateKeySize {
 		return nil, fmt.Errorf("invalid key length: %d, need %d", l, ed25519.PrivateKeySize)
 	}
-	// update the external address used for the peering
-	serviceRecord := service.New()
-	serviceRecord.Update(service.PeeringKey, network, address)
-
 	return newLocal(key, serviceRecord, db), nil
 }
 

--- a/packages/autopeering/peer/local_test.go
+++ b/packages/autopeering/peer/local_test.go
@@ -28,36 +28,45 @@ func TestPublicKey(t *testing.T) {
 	assert.EqualValues(t, pub, local.PublicKey())
 }
 
-func newTestLocal(t require.TestingT) *Local {
-	priv, err := generatePrivateKey()
-	require.NoError(t, err)
-	return newLocal(priv, newTestServiceRecord(), nil)
-}
-
 func TestAddress(t *testing.T) {
-	local := newTestLocal(t)
+	local := newTestLocal(t, nil)
 
 	address := local.Services().Get(service.PeeringKey).String()
 	assert.EqualValues(t, address, local.Address())
 }
 
 func TestPrivateSalt(t *testing.T) {
-	p := newTestLocal(t)
+	p := newTestLocal(t, nil)
 
-	salt, _ := salt.NewSalt(time.Second * 10)
-	p.SetPrivateSalt(salt)
+	s, _ := salt.NewSalt(time.Second * 10)
+	p.SetPrivateSalt(s)
 
 	got := p.GetPrivateSalt()
-	assert.Equal(t, salt, got, "Private salt")
+	assert.Equal(t, s, got, "Private salt")
 }
 
 func TestPublicSalt(t *testing.T) {
-	p := newTestLocal(t)
+	p := newTestLocal(t, nil)
 
-	salt, _ := salt.NewSalt(time.Second * 10)
-	p.SetPublicSalt(salt)
+	s, _ := salt.NewSalt(time.Second * 10)
+	p.SetPublicSalt(s)
 
 	got := p.GetPublicSalt()
 
-	assert.Equal(t, salt, got, "Public salt")
+	assert.Equal(t, s, got, "Public salt")
+}
+
+func newTestLocal(t require.TestingT, db DB) *Local {
+	var priv PrivateKey
+	var err error
+	if db == nil {
+		priv, err = generatePrivateKey()
+		require.NoError(t, err)
+	} else {
+		priv, err = db.LocalPrivateKey()
+		require.NoError(t, err)
+	}
+	services := service.New()
+	services.Update(service.PeeringKey, testNetwork, testAddress)
+	return newLocal(priv, services, db)
 }

--- a/packages/autopeering/peer/mapdb_test.go
+++ b/packages/autopeering/peer/mapdb_test.go
@@ -58,12 +58,9 @@ func TestMapDBSeedPeers(t *testing.T) {
 func TestMapDBLocal(t *testing.T) {
 	db := NewMemoryDB(log)
 
-	l1, err := NewLocal(testNetwork, testAddress, db)
-	require.NoError(t, err)
+	l1 := newTestLocal(t, db)
 	assert.Equal(t, len(l1.PublicKey()), ed25519.PublicKeySize)
 
-	l2, err := NewLocal(testNetwork, testAddress, db)
-	require.NoError(t, err)
-
+	l2 := newTestLocal(t, db)
 	assert.Equal(t, l1, l2)
 }

--- a/packages/autopeering/selection/manager_test.go
+++ b/packages/autopeering/selection/manager_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/iotaledger/goshimmer/packages/autopeering/peer"
+	"github.com/iotaledger/goshimmer/packages/autopeering/peer/service"
 	"github.com/iotaledger/goshimmer/packages/autopeering/salt"
 	"github.com/iotaledger/hive.go/events"
 	"github.com/iotaledger/hive.go/logger"
@@ -186,7 +187,9 @@ type networkMock struct {
 }
 
 func newNetworkMock(name string, mgrMap map[peer.ID]*manager, log *logger.Logger) *networkMock {
-	local, _ := peer.NewLocal("mock", name, peer.NewMemoryDB(log))
+	services := service.New()
+	services.Update(service.PeeringKey, "mock", name)
+	local, _ := peer.NewLocal(services, peer.NewMemoryDB(log))
 	return &networkMock{
 		loc: local,
 		mgr: mgrMap,

--- a/packages/autopeering/server/server.go
+++ b/packages/autopeering/server/server.go
@@ -68,10 +68,10 @@ type reply struct {
 	matchedRequest chan<- bool // a matching request is indicated via this channel
 }
 
-// Listen starts a new peer server using the given transport layer for communication.
+// Serve starts a new peer server using the given transport layer for communication.
 // Sent data is signed using the identity of the local peer,
 // received data with a valid peer signature is handled according to the provided Handler.
-func Listen(local *peer.Local, t transport.Transport, log *logger.Logger, h ...Handler) *Server {
+func Serve(local *peer.Local, t transport.Transport, log *logger.Logger, h ...Handler) *Server {
 	srv := &Server{
 		local:           local,
 		trans:           t,
@@ -88,7 +88,10 @@ func Listen(local *peer.Local, t transport.Transport, log *logger.Logger, h ...H
 	go srv.replyLoop()
 	go srv.readLoop()
 
-	log.Debugw("server started", "addr", srv.LocalAddr(), "#handlers", len(h))
+	log.Debugw("server started",
+		"network", srv.LocalAddr().Network(),
+		"address", srv.LocalAddr().String(),
+		"#handlers", len(h))
 
 	return srv
 }

--- a/packages/gossip/manager_test.go
+++ b/packages/gossip/manager_test.go
@@ -27,46 +27,6 @@ var (
 
 func getTestTransaction([]byte) ([]byte, error) { return testTxData, nil }
 
-func getTCPAddress(t require.TestingT) string {
-	tcpAddr, err := net.ResolveTCPAddr("tcp", "localhost:0")
-	require.NoError(t, err)
-	lis, err := net.ListenTCP("tcp", tcpAddr)
-	require.NoError(t, err)
-
-	addr := lis.Addr().String()
-	require.NoError(t, lis.Close())
-
-	return addr
-}
-
-func newTestManager(t require.TestingT, name string) (*Manager, func(), *peer.Peer) {
-	l := log.Named(name)
-	db := peer.NewMemoryDB(l.Named("db"))
-	local, err := peer.NewLocal("peering", name, db)
-	require.NoError(t, err)
-
-	// enable TCP gossipping
-	require.NoError(t, local.UpdateService(service.GossipKey, "tcp", getTCPAddress(t)))
-
-	mgr := NewManager(local, getTestTransaction, l)
-
-	srv, err := server.ListenTCP(local, l)
-	require.NoError(t, err)
-
-	// update the service with the actual address
-	require.NoError(t, local.UpdateService(service.GossipKey, srv.LocalAddr().Network(), srv.LocalAddr().String()))
-
-	// start the actual gossipping
-	mgr.Start(srv)
-
-	detach := func() {
-		mgr.Close()
-		srv.Close()
-		db.Close()
-	}
-	return mgr, detach, &local.Peer
-}
-
 func TestClose(t *testing.T) {
 	_, detach := newEventMock(t)
 	defer detach()
@@ -407,6 +367,38 @@ func TestTxRequest(t *testing.T) {
 	time.Sleep(graceTime)
 
 	e.AssertExpectations(t)
+}
+
+func newTestManager(t require.TestingT, name string) (*Manager, func(), *peer.Peer) {
+	l := log.Named(name)
+
+	services := service.New()
+	services.Update(service.PeeringKey, "peering", name)
+	db := peer.NewMemoryDB(l.Named("db"))
+	local, err := peer.NewLocal(services, db)
+	require.NoError(t, err)
+
+	laddr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	lis, err := net.ListenTCP("tcp", laddr)
+	require.NoError(t, err)
+
+	// enable TCP gossipping
+	require.NoError(t, local.UpdateService(service.GossipKey, lis.Addr().Network(), lis.Addr().String()))
+
+	srv := server.ServeTCP(local, lis, l)
+
+	// start the actual gossipping
+	mgr := NewManager(local, getTestTransaction, l)
+	mgr.Start(srv)
+
+	detach := func() {
+		mgr.Close()
+		srv.Close()
+		_ = lis.Close()
+		db.Close()
+	}
+	return mgr, detach, &local.Peer
 }
 
 func newEventMock(t mock.TestingT) (*eventMock, func()) {

--- a/packages/gossip/server/server_test.go
+++ b/packages/gossip/server/server_test.go
@@ -17,48 +17,17 @@ const graceTime = 5 * time.Millisecond
 
 var log = logger.NewExampleLogger("server")
 
-func getTCPAddress(t require.TestingT) string {
-	laddr, err := net.ResolveTCPAddr("tcp", "localhost:0")
-	require.NoError(t, err)
-	lis, err := net.ListenTCP("tcp", laddr)
-	require.NoError(t, err)
-
-	addr := lis.Addr().String()
-	require.NoError(t, lis.Close())
-
-	return addr
-}
-
-func newTest(t require.TestingT, name string) (*TCP, func()) {
-	l := log.Named(name)
-	db := peer.NewMemoryDB(l.Named("db"))
-	local, err := peer.NewLocal("peering", name, db)
-	require.NoError(t, err)
-
-	// enable TCP gossipping
-	require.NoError(t, local.UpdateService(service.GossipKey, "tcp", getTCPAddress(t)))
-
-	trans, err := ListenTCP(local, l)
-	require.NoError(t, err)
-
-	teardown := func() {
-		trans.Close()
-		db.Close()
-	}
-	return trans, teardown
-}
-
 func getPeer(t *TCP) *peer.Peer {
 	return &t.local.Peer
 }
 
 func TestClose(t *testing.T) {
-	_, teardown := newTest(t, "A")
+	_, teardown := newTestServer(t, "A")
 	teardown()
 }
 
 func TestUnansweredAccept(t *testing.T) {
-	transA, closeA := newTest(t, "A")
+	transA, closeA := newTestServer(t, "A")
 	defer closeA()
 
 	_, err := transA.AcceptPeer(getPeer(transA))
@@ -66,7 +35,7 @@ func TestUnansweredAccept(t *testing.T) {
 }
 
 func TestCloseWhileAccepting(t *testing.T) {
-	transA, closeA := newTest(t, "A")
+	transA, closeA := newTestServer(t, "A")
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -82,7 +51,7 @@ func TestCloseWhileAccepting(t *testing.T) {
 }
 
 func TestUnansweredDial(t *testing.T) {
-	transA, closeA := newTest(t, "A")
+	transA, closeA := newTestServer(t, "A")
 	defer closeA()
 
 	// create peer with invalid gossip address
@@ -95,7 +64,7 @@ func TestUnansweredDial(t *testing.T) {
 }
 
 func TestNoHandshakeResponse(t *testing.T) {
-	transA, closeA := newTest(t, "A")
+	transA, closeA := newTestServer(t, "A")
 	defer closeA()
 
 	// accept and read incoming connections
@@ -119,7 +88,7 @@ func TestNoHandshakeResponse(t *testing.T) {
 }
 
 func TestNoHandshakeRequest(t *testing.T) {
-	transA, closeA := newTest(t, "A")
+	transA, closeA := newTestServer(t, "A")
 	defer closeA()
 
 	var wg sync.WaitGroup
@@ -140,9 +109,9 @@ func TestNoHandshakeRequest(t *testing.T) {
 }
 
 func TestConnect(t *testing.T) {
-	transA, closeA := newTest(t, "A")
+	transA, closeA := newTestServer(t, "A")
 	defer closeA()
-	transB, closeB := newTest(t, "B")
+	transB, closeB := newTestServer(t, "B")
 	defer closeB()
 
 	var wg sync.WaitGroup
@@ -153,7 +122,7 @@ func TestConnect(t *testing.T) {
 		c, err := transA.AcceptPeer(getPeer(transB))
 		assert.NoError(t, err)
 		if assert.NotNil(t, c) {
-			c.Close()
+			_ = c.Close()
 		}
 	}()
 	time.Sleep(graceTime)
@@ -162,7 +131,7 @@ func TestConnect(t *testing.T) {
 		c, err := transB.DialPeer(getPeer(transA))
 		assert.NoError(t, err)
 		if assert.NotNil(t, c) {
-			c.Close()
+			_ = c.Close()
 		}
 	}()
 
@@ -170,11 +139,11 @@ func TestConnect(t *testing.T) {
 }
 
 func TestWrongConnect(t *testing.T) {
-	transA, closeA := newTest(t, "A")
+	transA, closeA := newTestServer(t, "A")
 	defer closeA()
-	transB, closeB := newTest(t, "B")
+	transB, closeB := newTestServer(t, "B")
 	defer closeB()
-	transC, closeC := newTest(t, "C")
+	transC, closeC := newTestServer(t, "C")
 	defer closeC()
 
 	var wg sync.WaitGroup
@@ -193,4 +162,31 @@ func TestWrongConnect(t *testing.T) {
 	}()
 
 	wg.Wait()
+}
+
+func newTestServer(t require.TestingT, name string) (*TCP, func()) {
+	l := log.Named(name)
+
+	services := service.New()
+	services.Update(service.PeeringKey, "peering", name)
+	db := peer.NewMemoryDB(l.Named("db"))
+	local, err := peer.NewLocal(services, db)
+	require.NoError(t, err)
+
+	laddr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	lis, err := net.ListenTCP("tcp", laddr)
+	require.NoError(t, err)
+
+	// enable TCP gossipping
+	require.NoError(t, local.UpdateService(service.GossipKey, lis.Addr().Network(), lis.Addr().String()))
+
+	srv := ServeTCP(local, lis, l)
+
+	teardown := func() {
+		srv.Close()
+		_ = lis.Close()
+		db.Close()
+	}
+	return srv, teardown
 }

--- a/packages/parameter/parameter.go
+++ b/packages/parameter/parameter.go
@@ -1,6 +1,7 @@
 package parameter
 
 import (
+	"github.com/iotaledger/hive.go/logger"
 	"github.com/iotaledger/hive.go/parameter"
 	flag "github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -11,9 +12,25 @@ var (
 	configName    = flag.StringP("config", "c", "config", "Filename of the config file without the file extension")
 	configDirPath = flag.StringP("config-dir", "d", ".", "Path to the directory containing the config file")
 
-	// Viper
-	NodeConfig = viper.New()
+	// viper
+	NodeConfig *viper.Viper
+
+	// logger
+	defaultLoggerConfig = logger.Config{
+		Level:             "info",
+		DisableCaller:     false,
+		DisableStacktrace: false,
+		Encoding:          "console",
+		OutputPaths:       []string{"goshimmer.log"},
+		DisableEvents:     false,
+	}
 )
+
+func init() {
+	// set the default logger config
+	NodeConfig = viper.New()
+	NodeConfig.SetDefault(logger.ViperKey, defaultLoggerConfig)
+}
 
 // FetchConfig fetches config values from a dir defined via CLI flag --config-dir (or the current working dir if not set).
 //

--- a/plugins/analysis/client/parameters.go
+++ b/plugins/analysis/client/parameters.go
@@ -5,7 +5,7 @@ import (
 )
 
 const (
-	CFG_SERVER_ADDRESS = "analysis.serverAddress"
+	CFG_SERVER_ADDRESS = "analysis.client.serverAddress"
 )
 
 func init() {

--- a/plugins/analysis/server/parameters.go
+++ b/plugins/analysis/server/parameters.go
@@ -5,7 +5,7 @@ import (
 )
 
 const (
-	CFG_SERVER_PORT = "analysis.serverPort"
+	CFG_SERVER_PORT = "analysis.server.port"
 )
 
 func init() {

--- a/plugins/analysis/webinterface/httpserver/parameters.go
+++ b/plugins/analysis/webinterface/httpserver/parameters.go
@@ -1,0 +1,13 @@
+package httpserver
+
+import (
+	flag "github.com/spf13/pflag"
+)
+
+const (
+	CFG_BIND_ADDRESS = "analysis.httpServer.bindAddress"
+)
+
+func init() {
+	flag.String(CFG_BIND_ADDRESS, "0.0.0.0:80", "the bind address for the web API")
+}

--- a/plugins/analysis/webinterface/httpserver/plugin.go
+++ b/plugins/analysis/webinterface/httpserver/plugin.go
@@ -3,9 +3,9 @@ package httpserver
 import (
 	"errors"
 	"net/http"
-	"sync"
 	"time"
 
+	"github.com/iotaledger/goshimmer/packages/parameter"
 	"github.com/iotaledger/goshimmer/packages/shutdown"
 	"github.com/iotaledger/hive.go/daemon"
 	"github.com/iotaledger/hive.go/logger"
@@ -25,36 +25,46 @@ func Configure() {
 	log = logger.NewLogger(name)
 
 	router = http.NewServeMux()
-	httpServer = &http.Server{Addr: ":80", Handler: router}
+
+	httpServer = &http.Server{
+		Addr:    parameter.NodeConfig.GetString(CFG_BIND_ADDRESS),
+		Handler: router,
+	}
 
 	router.Handle("/datastream", websocket.Handler(dataStream))
 	router.HandleFunc("/", index)
 }
 
 func Run() {
+	log.Info("Starting " + name + " ...")
 	if err := daemon.BackgroundWorker(name, start, shutdown.ShutdownPriorityAnalysis); err != nil {
 		log.Errorf("Error starting as daemon: %s", err)
 	}
 }
 
 func start(shutdownSignal <-chan struct{}) {
-	var wg sync.WaitGroup
-	wg.Add(1)
+	stopped := make(chan struct{})
 	go func() {
-		defer wg.Done()
-		log.Infof(name+" started: address=%s", httpServer.Addr)
-		if err := httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			log.Warnf("Error listening: %s", err)
+		log.Infof("Started "+name+": http://%s", httpServer.Addr)
+		if err := httpServer.ListenAndServe(); err != nil {
+			if !errors.Is(err, http.ErrServerClosed) {
+				log.Errorf("Error serving: %s", err)
+			}
+			close(stopped)
 		}
 	}()
-	<-shutdownSignal
+
+	select {
+	case <-shutdownSignal:
+	case <-stopped:
+	}
+
 	log.Info("Stopping " + name + " ...")
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
 	if err := httpServer.Shutdown(ctx); err != nil {
-		log.Errorf("Error closing: %s", err)
+		log.Errorf("Error stopping: %s", err)
 	}
-	wg.Wait()
 	log.Info("Stopping " + name + " ... done")
 }

--- a/plugins/analysis/webinterface/httpserver/plugin.go
+++ b/plugins/analysis/webinterface/httpserver/plugin.go
@@ -36,7 +36,7 @@ func Configure() {
 }
 
 func Run() {
-	log.Info("Starting " + name + " ...")
+	log.Infof("Starting %s ...", name)
 	if err := daemon.BackgroundWorker(name, start, shutdown.ShutdownPriorityAnalysis); err != nil {
 		log.Errorf("Error starting as daemon: %s", err)
 	}
@@ -45,7 +45,7 @@ func Run() {
 func start(shutdownSignal <-chan struct{}) {
 	stopped := make(chan struct{})
 	go func() {
-		log.Infof("Started "+name+": http://%s", httpServer.Addr)
+		log.Infof("Started %s: http://%s", name, httpServer.Addr)
 		if err := httpServer.ListenAndServe(); err != nil {
 			if !errors.Is(err, http.ErrServerClosed) {
 				log.Errorf("Error serving: %s", err)

--- a/plugins/analysis/webinterface/httpserver/plugin.go
+++ b/plugins/analysis/webinterface/httpserver/plugin.go
@@ -59,12 +59,12 @@ func start(shutdownSignal <-chan struct{}) {
 	case <-stopped:
 	}
 
-	log.Info("Stopping " + name + " ...")
+	log.Infof("Stopping %s ...", name)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
 	if err := httpServer.Shutdown(ctx); err != nil {
 		log.Errorf("Error stopping: %s", err)
 	}
-	log.Info("Stopping " + name + " ... done")
+	log.Info("Stopping %s ... done", name)
 }

--- a/plugins/autopeering/autopeering.go
+++ b/plugins/autopeering/autopeering.go
@@ -68,7 +68,7 @@ func start(shutdownSignal <-chan struct{}) {
 	address := net.JoinHostPort(parameter.NodeConfig.GetString(local.CFG_BIND), peeringPort)
 	localAddr, err := net.ResolveUDPAddr(peeringAddr.Network(), address)
 	if err != nil {
-		log.Fatalf("Error resolving "+local.CFG_BIND+": %v", err)
+		log.Fatalf("Error resolving %s: %v", local.CFG_BIND, err)
 	}
 
 	// check that discovery is working and the port is open

--- a/plugins/autopeering/local/local.go
+++ b/plugins/autopeering/local/local.go
@@ -35,7 +35,7 @@ func configureLocal() *peer.Local {
 	} else {
 		externalIP = net.ParseIP(str)
 		if externalIP == nil {
-			log.Fatalf("Invalid IP address "+CFG_EXTERNAL+":%s", str)
+			log.Fatalf("Invalid IP address (%s): %s", CFG_EXTERNAL, str)
 		}
 	}
 	if !externalIP.IsGlobalUnicast() {

--- a/plugins/autopeering/local/local.go
+++ b/plugins/autopeering/local/local.go
@@ -54,8 +54,7 @@ func configureLocal() *peer.Local {
 
 	// set the private key from the seed provided in the config
 	var seed [][]byte
-	if parameter.NodeConfig.IsSet(CFG_SEED) {
-		str := parameter.NodeConfig.GetString(CFG_SEED)
+	if str := parameter.NodeConfig.GetString(CFG_SEED); str != "" {
 		bytes, err := base64.StdEncoding.DecodeString(str)
 		if err != nil {
 			log.Fatalf("Invalid %s: %s", CFG_SEED, err)

--- a/plugins/autopeering/local/parameters.go
+++ b/plugins/autopeering/local/parameters.go
@@ -5,8 +5,8 @@ import (
 )
 
 const (
-	CFG_BIND     = "node.bindAddress"
-	CFG_EXTERNAL = "node.externalAddress"
+	CFG_BIND     = "network.bindAddress"
+	CFG_EXTERNAL = "network.externalAddress"
 	CFG_PORT     = "autopeering.port"
 	CFG_SEED     = "autopeering.seed"
 )

--- a/plugins/autopeering/local/parameters.go
+++ b/plugins/autopeering/local/parameters.go
@@ -5,13 +5,15 @@ import (
 )
 
 const (
-	CFG_ADDRESS = "autopeering.address"
-	CFG_PORT    = "autopeering.port"
-	CFG_SEED    = "autopeering.seed"
+	CFG_BIND     = "node.bindAddress"
+	CFG_EXTERNAL = "node.externalAddress"
+	CFG_PORT     = "autopeering.port"
+	CFG_SEED     = "autopeering.seed"
 )
 
 func init() {
-	flag.String(CFG_ADDRESS, "0.0.0.0", "address to bind for incoming peering requests")
-	flag.Int(CFG_PORT, 14626, "udp port for incoming peering requests")
+	flag.String(CFG_BIND, "0.0.0.0", "bind address for global services such as autopeering and gossip")
+	flag.String(CFG_EXTERNAL, "auto", "external IP address under which the node is reachable; or 'auto' to determine it automatically")
+	flag.Int(CFG_PORT, 14626, "UDP port for incoming peering requests")
 	flag.BytesBase64(CFG_SEED, nil, "private key seed used to derive the node identity; optional Base64 encoded 256-bit string")
 }

--- a/plugins/cli/plugin.go
+++ b/plugins/cli/plugin.go
@@ -44,7 +44,7 @@ func parseParameters() {
 }
 
 func LoadConfig() {
-	if err := parameter.FetchConfig(false); err != nil {
+	if err := parameter.FetchConfig(true); err != nil {
 		panic(err)
 	}
 	parseParameters()

--- a/plugins/cli/plugin.go
+++ b/plugins/cli/plugin.go
@@ -44,7 +44,7 @@ func parseParameters() {
 }
 
 func LoadConfig() {
-	if err := parameter.FetchConfig(true); err != nil {
+	if err := parameter.FetchConfig(false); err != nil {
 		panic(err)
 	}
 	parseParameters()

--- a/plugins/dashboard/parameters.go
+++ b/plugins/dashboard/parameters.go
@@ -1,0 +1,13 @@
+package dashboard
+
+import (
+	flag "github.com/spf13/pflag"
+)
+
+const (
+	CFG_BIND_ADDRESS = "dashboard.bindAddress"
+)
+
+func init() {
+	flag.String(CFG_BIND_ADDRESS, "0.0.0.0:8081", "the bind address for the dashboard")
+}

--- a/plugins/dashboard/plugin.go
+++ b/plugins/dashboard/plugin.go
@@ -47,7 +47,7 @@ func configure(*node.Plugin) {
 }
 
 func run(*node.Plugin) {
-	log.Info("Starting " + name + " ...")
+	log.Infof("Starting %s ...", name)
 	if err := daemon.BackgroundWorker(name, workerFunc, shutdown.ShutdownPriorityDashboard); err != nil {
 		log.Errorf("Error starting as daemon: %s", err)
 	}
@@ -56,7 +56,7 @@ func run(*node.Plugin) {
 func workerFunc(shutdownSignal <-chan struct{}) {
 	stopped := make(chan struct{})
 	go func() {
-		log.Infof("Started "+name+": http://%s/dashboard", httpServer.Addr)
+		log.Infof("Started %s: http://%s/dashboard", name, httpServer.Addr)
 		if err := httpServer.ListenAndServe(); err != nil {
 			if !errors.Is(err, http.ErrServerClosed) {
 				log.Errorf("Error serving: %s", err)
@@ -70,12 +70,12 @@ func workerFunc(shutdownSignal <-chan struct{}) {
 	case <-stopped:
 	}
 
-	log.Info("Stopping " + name + " ...")
+	log.Infof("Stopping %s ...", name)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
 	if err := httpServer.Shutdown(ctx); err != nil {
 		log.Errorf("Error stopping: %s", err)
 	}
-	log.Info("Stopping " + name + " ... done")
+	log.Infof("Stopping %s ... done", name)
 }

--- a/plugins/dashboard/plugin.go
+++ b/plugins/dashboard/plugin.go
@@ -1,9 +1,11 @@
 package dashboard
 
 import (
+	"errors"
 	"net/http"
 	"time"
 
+	"github.com/iotaledger/goshimmer/packages/parameter"
 	"github.com/iotaledger/goshimmer/packages/shutdown"
 	"github.com/iotaledger/goshimmer/plugins/metrics"
 	"github.com/iotaledger/hive.go/daemon"
@@ -13,17 +15,24 @@ import (
 	"golang.org/x/net/context"
 )
 
-var server *http.Server
+var (
+	log        *logger.Logger
+	httpServer *http.Server
+)
 
-var router *http.ServeMux
+const name = "Dashboard"
 
-var PLUGIN = node.NewPlugin("Dashboard", node.Disabled, configure, run)
-var log *logger.Logger
+var PLUGIN = node.NewPlugin(name, node.Disabled, configure, run)
 
-func configure(plugin *node.Plugin) {
-	log = logger.NewLogger("Dashboard")
-	router = http.NewServeMux()
-	server = &http.Server{Addr: ":8081", Handler: router}
+func configure(*node.Plugin) {
+	log = logger.NewLogger(name)
+
+	router := http.NewServeMux()
+
+	httpServer = &http.Server{
+		Addr:    parameter.NodeConfig.GetString(CFG_BIND_ADDRESS),
+		Handler: router,
+	}
 
 	router.HandleFunc("/dashboard", ServeHome)
 	router.HandleFunc("/ws", ServeWs)
@@ -37,17 +46,36 @@ func configure(plugin *node.Plugin) {
 	}))
 }
 
-func run(plugin *node.Plugin) {
-	daemon.BackgroundWorker("Dashboard Updater", func(shutdownSignal <-chan struct{}) {
-		go func() {
-			if err := server.ListenAndServe(); err != nil {
-				log.Error(err.Error())
-			}
-		}()
+func run(*node.Plugin) {
+	log.Info("Starting " + name + " ...")
+	if err := daemon.BackgroundWorker(name, workerFunc, shutdown.ShutdownPriorityDashboard); err != nil {
+		log.Errorf("Error starting as daemon: %s", err)
+	}
+}
 
-		<-shutdownSignal
-		ctx, cancel := context.WithTimeout(context.Background(), 0*time.Second)
-		defer cancel()
-		_ = server.Shutdown(ctx)
-	}, shutdown.ShutdownPriorityDashboard)
+func workerFunc(shutdownSignal <-chan struct{}) {
+	stopped := make(chan struct{})
+	go func() {
+		log.Infof("Started "+name+": http://%s/dashboard", httpServer.Addr)
+		if err := httpServer.ListenAndServe(); err != nil {
+			if !errors.Is(err, http.ErrServerClosed) {
+				log.Errorf("Error serving: %s", err)
+			}
+			close(stopped)
+		}
+	}()
+
+	select {
+	case <-shutdownSignal:
+	case <-stopped:
+	}
+
+	log.Info("Stopping " + name + " ...")
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	if err := httpServer.Shutdown(ctx); err != nil {
+		log.Errorf("Error stopping: %s", err)
+	}
+	log.Info("Stopping " + name + " ... done")
 }

--- a/plugins/gossip/gossip.go
+++ b/plugins/gossip/gossip.go
@@ -57,7 +57,7 @@ func start(shutdownSignal <-chan struct{}) {
 	address := net.JoinHostPort(parameter.NodeConfig.GetString(local.CFG_BIND), gossipPort)
 	localAddr, err := net.ResolveTCPAddr(gossipAddr.Network(), address)
 	if err != nil {
-		log.Fatalf("Error resolving "+local.CFG_BIND+": %v", err)
+		log.Fatalf("Error resolving %s: %v", local.CFG_BIND, err)
 	}
 
 	listener, err := net.ListenTCP(gossipAddr.Network(), localAddr)
@@ -77,7 +77,7 @@ func start(shutdownSignal <-chan struct{}) {
 	mgr.Start(srv)
 	defer mgr.Close()
 
-	log.Infof(name+" started: Address=%s/%s", gossipAddr.String(), gossipAddr.Network())
+	log.Infof("%s started: Address=%s/%s", name, gossipAddr.String(), gossipAddr.Network())
 
 	<-shutdownSignal
 	log.Info("Stopping " + name + " ...")

--- a/plugins/gossip/gossip.go
+++ b/plugins/gossip/gossip.go
@@ -27,15 +27,17 @@ var (
 func configureGossip() {
 	lPeer := local.GetInstance()
 
-	port := strconv.Itoa(parameter.NodeConfig.GetInt(GOSSIP_PORT))
-
-	host, _, err := net.SplitHostPort(lPeer.Address())
+	peeringAddr := lPeer.Services().Get(service.PeeringKey)
+	external, _, err := net.SplitHostPort(peeringAddr.String())
 	if err != nil {
-		log.Fatalf("invalid peering address: %v", err)
+		panic(err)
 	}
-	err = lPeer.UpdateService(service.GossipKey, "tcp", net.JoinHostPort(host, port))
+
+	// announce the gossip service
+	gossipPort := strconv.Itoa(parameter.NodeConfig.GetInt(GOSSIP_PORT))
+	err = lPeer.UpdateService(service.GossipKey, "tcp", net.JoinHostPort(external, gossipPort))
 	if err != nil {
-		log.Fatalf("could not update services: %v", err)
+		log.Fatalf("could not update services: %s", err)
 	}
 
 	mgr = gp.NewManager(lPeer, loadTransaction, log)
@@ -44,23 +46,38 @@ func configureGossip() {
 func start(shutdownSignal <-chan struct{}) {
 	defer log.Info("Stopping " + name + " ... done")
 
-	loc := local.GetInstance()
-	srv, err := server.ListenTCP(loc, log)
+	lPeer := local.GetInstance()
+	// use the port of the gossip service
+	gossipAddr := lPeer.Services().Get(service.GossipKey)
+	_, gossipPort, err := net.SplitHostPort(gossipAddr.String())
 	if err != nil {
-		log.Fatalf("ListenTCP: %v", err)
+		panic(err)
 	}
+	// resolve the bind address
+	address := net.JoinHostPort(parameter.NodeConfig.GetString(local.CFG_BIND), gossipPort)
+	localAddr, err := net.ResolveTCPAddr(gossipAddr.Network(), address)
+	if err != nil {
+		log.Fatalf("Error resolving "+local.CFG_BIND+": %v", err)
+	}
+
+	listener, err := net.ListenTCP(gossipAddr.Network(), localAddr)
+	if err != nil {
+		log.Fatalf("Error listening: %v", err)
+	}
+	defer listener.Close()
+
+	srv := server.ServeTCP(lPeer, listener, log)
 	defer srv.Close()
 
 	//check that the server is working and the port is open
 	log.Info("Testing service ...")
-	checkConnection(srv, &loc.Peer)
+	checkConnection(srv, &lPeer.Peer)
 	log.Info("Testing service ... done")
 
 	mgr.Start(srv)
 	defer mgr.Close()
 
-	gossipAddr := loc.Services().Get(service.GossipKey)
-	log.Infof(name+" started: address=%s/%s", gossipAddr.String(), gossipAddr.Network())
+	log.Infof(name+" started: Address=%s/%s", gossipAddr.String(), gossipAddr.Network())
 
 	<-shutdownSignal
 	log.Info("Stopping " + name + " ...")

--- a/plugins/graph/graph.go
+++ b/plugins/graph/graph.go
@@ -66,7 +66,7 @@ func onConnectHandler(s socketio.Conn) error {
 	log.Info(infoMsg)
 	socketioServer.JoinRoom("broadcast", s)
 
-	config := &wsConfig{NetworkName: parameter.NodeConfig.GetString("graph.networkName")}
+	config := &wsConfig{NetworkName: parameter.NodeConfig.GetString(CFG_NETWORK)}
 
 	var initTxs []*wsTransaction
 	txRingBuffer.Do(func(tx interface{}) {

--- a/plugins/graph/parameters.go
+++ b/plugins/graph/parameters.go
@@ -1,27 +1,22 @@
 package graph
 
 import (
-	"github.com/iotaledger/goshimmer/packages/parameter"
 	"github.com/iotaledger/goshimmer/plugins/cli"
+	flag "github.com/spf13/pflag"
+)
+
+const (
+	CFG_WEBROOT      = "graph.webrootPath"
+	CFG_SOCKET_IO    = "graph.socketioPath"
+	CFG_DOMAIN       = "graph.domain"
+	CFG_BIND_ADDRESS = "graph.bindAddress"
+	CFG_NETWORK      = "graph.networkName"
 )
 
 func init() {
-
-	// "Path to IOTA Tangle Visualiser webroot files"
-	parameter.NodeConfig.SetDefault("graph.webrootPath", "IOTAtangle/webroot")
-
-	// "Path to socket.io.js"
-	parameter.NodeConfig.SetDefault("graph.socketioPath", "socket.io-client/dist/socket.io.js")
-
-	// "Set the domain on which IOTA Tangle Visualiser is served"
-	parameter.NodeConfig.SetDefault("graph.domain", "")
-
-	// "Set the host to which the IOTA Tangle Visualiser listens"
-	parameter.NodeConfig.SetDefault("graph.bindAddress", "127.0.0.1")
-
-	// "IOTA Tangle Visualiser webserver port"
-	parameter.NodeConfig.SetDefault("graph.port", 8083)
-
-	// "Name of the network shown in IOTA Tangle Visualiser"
-	parameter.NodeConfig.SetDefault("graph.networkName", cli.AppName)
+	flag.String(CFG_WEBROOT, "IOTAtangle/webroot", "Path to IOTA Tangle Visualiser webroot files")
+	flag.String(CFG_SOCKET_IO, "socket.io-client/dist/socket.io.js", "Path to socket.io.js")
+	flag.String(CFG_DOMAIN, "", "Set the domain on which IOTA Tangle Visualiser is served")
+	flag.String(CFG_BIND_ADDRESS, "127.0.0.1:8083", "Set the host to which the IOTA Tangle Visualiser listens")
+	flag.String(CFG_NETWORK, cli.AppName, "Name of the network shown in IOTA Tangle Visualiser")
 }

--- a/plugins/graph/parameters.go
+++ b/plugins/graph/parameters.go
@@ -2,6 +2,7 @@ package graph
 
 import (
 	"github.com/iotaledger/goshimmer/packages/parameter"
+	"github.com/iotaledger/goshimmer/plugins/cli"
 )
 
 func init() {
@@ -16,11 +17,11 @@ func init() {
 	parameter.NodeConfig.SetDefault("graph.domain", "")
 
 	// "Set the host to which the IOTA Tangle Visualiser listens"
-	parameter.NodeConfig.SetDefault("graph.host", "127.0.0.1")
+	parameter.NodeConfig.SetDefault("graph.bindAddress", "127.0.0.1")
 
 	// "IOTA Tangle Visualiser webserver port"
 	parameter.NodeConfig.SetDefault("graph.port", 8083)
 
 	// "Name of the network shown in IOTA Tangle Visualiser"
-	parameter.NodeConfig.SetDefault("graph.networkName", "meets HORNET")
+	parameter.NodeConfig.SetDefault("graph.networkName", cli.AppName)
 }

--- a/plugins/graph/parameters.go
+++ b/plugins/graph/parameters.go
@@ -17,6 +17,6 @@ func init() {
 	flag.String(CFG_WEBROOT, "IOTAtangle/webroot", "Path to IOTA Tangle Visualiser webroot files")
 	flag.String(CFG_SOCKET_IO, "socket.io-client/dist/socket.io.js", "Path to socket.io.js")
 	flag.String(CFG_DOMAIN, "", "Set the domain on which IOTA Tangle Visualiser is served")
-	flag.String(CFG_BIND_ADDRESS, "127.0.0.1:8083", "Set the host to which the IOTA Tangle Visualiser listens")
+	flag.String(CFG_BIND_ADDRESS, "127.0.0.1:8083", "the bind address for the IOTA Tangle Visualizer")
 	flag.String(CFG_NETWORK, cli.AppName, "Name of the network shown in IOTA Tangle Visualiser")
 }


### PR DESCRIPTION
- `network.externalAddress` for the public IP
- `network.bindAddress` for the address to bind autopeering and gossip
- Added `bindAddress` for analysis/httpserver, graph, dashboard
- Updated `config.json`

Fixes #150 