### PR TITLE
Fix: Only connect to valid neighbors

### DIFF
--- a/packages/autopeering/selection/common.go
+++ b/packages/autopeering/selection/common.go
@@ -3,7 +3,7 @@ package selection
 import (
 	"time"
 
-	"github.com/iotaledger/goshimmer/packages/autopeering/peer/service"
+	"github.com/iotaledger/goshimmer/packages/autopeering/peer"
 	"github.com/iotaledger/hive.go/logger"
 )
 
@@ -30,9 +30,21 @@ type Config struct {
 	Log *logger.Logger
 
 	// These settings are optional:
-	DropOnUpdate     bool          // set true to drop all neighbors when the salt is updated
-	RequiredServices []service.Key // services required in order to select/be selected during autopeering
+	DropOnUpdate      bool      // set true to drop all neighbors when the salt is updated
+	NeighborValidator Validator // potential neighbor validator
 }
+
+// A Validator checks whether a peer is a valid neighbor
+type Validator interface {
+	IsValid(*peer.Peer) bool
+}
+
+// The ValidatorFunc type is an adapter to allow the use of ordinary functions as neighbor validators.
+// If f is a function with the appropriate signature, ValidatorFunc(f) is a Validator that calls f.
+type ValidatorFunc func(p *peer.Peer) bool
+
+// IsValid calls f(p).
+func (f ValidatorFunc) IsValid(p *peer.Peer) bool { return f(p) }
 
 // Parameters holds the parameters that can be configured.
 type Parameters struct {

--- a/packages/autopeering/selection/selection.go
+++ b/packages/autopeering/selection/selection.go
@@ -11,8 +11,9 @@ type Selector interface {
 }
 
 type Filter struct {
-	internal map[peer.ID]bool
-	lock     sync.RWMutex
+	internal   map[peer.ID]bool
+	conditions []func(*peer.Peer) bool
+	lock       sync.RWMutex
 }
 
 func NewFilter() *Filter {
@@ -21,29 +22,23 @@ func NewFilter() *Filter {
 	}
 }
 
-func (f *Filter) Apply(list []peer.PeerDistance) (filteredList []peer.PeerDistance) {
+func (f *Filter) Apply(list []peer.PeerDistance) (filtered []peer.PeerDistance) {
 	f.lock.RLock()
 	defer f.lock.RUnlock()
-	for _, p := range list {
-		if !f.internal[p.Remote.ID()] {
-			filteredList = append(filteredList, p)
-		}
-	}
-	return filteredList
-}
 
-func (f *Filter) PushBack(list []peer.PeerDistance) (filteredList []peer.PeerDistance) {
-	var head, tail []peer.PeerDistance
-	f.lock.RLock()
-	defer f.lock.RUnlock()
+list:
 	for _, p := range list {
-		if f.internal[p.Remote.ID()] {
-			tail = append(tail, p)
-		} else {
-			head = append(head, p)
+		if _, contains := f.internal[p.Remote.ID()]; contains {
+			continue
 		}
+		for _, c := range f.conditions {
+			if !c(p.Remote) {
+				continue list
+			}
+		}
+		filtered = append(filtered, p)
 	}
-	return append(head, tail...)
+	return
 }
 
 func (f *Filter) AddPeers(n []*peer.Peer) {
@@ -64,6 +59,10 @@ func (f *Filter) RemovePeer(peer peer.ID) {
 	f.lock.Lock()
 	f.internal[peer] = false
 	f.lock.Unlock()
+}
+
+func (f *Filter) AddCondition(c func(p *peer.Peer) bool) {
+	f.conditions = append(f.conditions, c)
 }
 
 func (f *Filter) Clean() {

--- a/plugins/autopeering/autopeering.go
+++ b/plugins/autopeering/autopeering.go
@@ -48,10 +48,30 @@ func configureAP() {
 	// enable peer selection only when gossip is enabled
 	if !node.IsSkipped(gossip.PLUGIN) {
 		Selection = selection.New(local.GetInstance(), Discovery, selection.Config{
-			Log:              log.Named("sel"),
-			RequiredServices: []service.Key{service.GossipKey},
+			Log:               log.Named("sel"),
+			NeighborValidator: selection.ValidatorFunc(isValidNeighbor),
 		})
 	}
+}
+
+// isValidNeighbor checks whether a peer is a valid neighbor.
+func isValidNeighbor(p *peer.Peer) bool {
+	// gossip must be supported
+	gossipAddr := p.Services().Get(service.GossipKey)
+	if gossipAddr == nil {
+		return false
+	}
+	// the host for the gossip and peering service must be identical
+	gossipHost, _, err := net.SplitHostPort(gossipAddr.String())
+	if err != nil {
+		return false
+	}
+	peeringAddr := p.Services().Get(service.PeeringKey)
+	peeringHost, _, err := net.SplitHostPort(peeringAddr.String())
+	if err != nil {
+		return false
+	}
+	return gossipHost == peeringHost
 }
 
 func start(shutdownSignal <-chan struct{}) {


### PR DESCRIPTION
A neighbor is valid, if
- it has a gossip service
- the IP of the gossip service matches the IP of the peering service