### PR TITLE
Refactors webapi regarding returned HTTP status codes

### DIFF
--- a/client/lib.go
+++ b/client/lib.go
@@ -29,6 +29,7 @@ var (
 	ErrNotFound            = errors.New("not found")
 	ErrUnauthorized        = errors.New("unauthorized")
 	ErrUnknownError        = errors.New("unknown error")
+	ErrNotImplemented      = errors.New("operation not implemented/supported/available")
 )
 
 const (
@@ -87,6 +88,8 @@ func interpretBody(res *http.Response, decodeTo interface{}) error {
 		return fmt.Errorf("%w: %s", ErrBadRequest, errRes.Error)
 	case http.StatusUnauthorized:
 		return fmt.Errorf("%w: %s", ErrUnauthorized, errRes.Error)
+	case http.StatusNotImplemented:
+		return fmt.Errorf("%w: %s", ErrNotImplemented, errRes.Error)
 	}
 
 	return fmt.Errorf("%w: %s", ErrUnknownError, errRes.Error)

--- a/plugins/webapi/broadcastData/plugin.go
+++ b/plugins/webapi/broadcastData/plugin.go
@@ -33,7 +33,7 @@ func broadcastData(c echo.Context) error {
 	var request Request
 	if err := c.Bind(&request); err != nil {
 		log.Info(err.Error())
-		return requestFailed(c, err.Error())
+		return c.JSON(http.StatusBadRequest, Response{Error: err.Error()})
 	}
 
 	log.Debug("Received - address:", request.Address, " data:", request.Data)
@@ -44,22 +44,22 @@ func broadcastData(c echo.Context) error {
 
 	buffer := make([]byte, 2187)
 	if len(request.Data) > 2187 {
-		log.Warn("Data exceeding 2187 byte limit -", len(request.Data))
-		return requestFailed(c, "Data exceeding 2187 byte limit")
+		log.Warnf("data exceeds 2187 byte limit - (payload data size: %d)", len(request.Data))
+		return c.JSON(http.StatusBadRequest, Response{Error: "data exceeds 2187 byte limit"})
 	}
 
 	copy(buffer, typeutils.StringToBytes(request.Data))
 
 	trytes, err := trinary.BytesToTrytes(buffer)
 	if err != nil {
-		log.Warn("Trytes conversion failed", err.Error())
-		return requestFailed(c, err.Error())
+		log.Warnf("trytes conversion failed: %s", err.Error())
+		return c.JSON(http.StatusBadRequest, Response{Error: err.Error()})
 	}
 
 	err = address.ValidAddress(request.Address)
 	if err != nil {
-		log.Warn("Invalid Address:", request.Address)
-		return requestFailed(c, err.Error())
+		log.Warnf("invalid Address: %s", request.Address)
+		return c.JSON(http.StatusBadRequest, Response{Error: err.Error()})
 	}
 
 	tx.SetAddress(request.Address)
@@ -69,24 +69,12 @@ func broadcastData(c echo.Context) error {
 	tx.SetTrunkTransactionHash(tipselection.GetRandomTip())
 	tx.SetTimestamp(uint(time.Now().Unix()))
 	if err := tx.DoProofOfWork(meta_transaction.MIN_WEIGHT_MAGNITUDE); err != nil {
-		log.Warn("PoW failed", err)
-		return requestFailed(c, err.Error())
+		log.Warnf("PoW failed: %s", err)
+		return c.JSON(http.StatusInternalServerError, Response{Error: err.Error()})
 	}
 
 	gossip.Events.TransactionReceived.Trigger(&gossip.TransactionReceivedEvent{Data: tx.GetBytes(), Peer: &local.GetInstance().Peer})
-	return requestSuccessful(c, tx.GetHash())
-}
-
-func requestSuccessful(c echo.Context, txHash string) error {
-	return c.JSON(http.StatusCreated, Response{
-		Hash: txHash,
-	})
-}
-
-func requestFailed(c echo.Context, message string) error {
-	return c.JSON(http.StatusBadRequest, Response{
-		Error: message,
-	})
+	return c.JSON(http.StatusOK, Response{Hash: tx.GetHash()})
 }
 
 type Response struct {

--- a/plugins/webapi/getNeighbors/plugin.go
+++ b/plugins/webapi/getNeighbors/plugin.go
@@ -26,11 +26,11 @@ func getNeighbors(c echo.Context) error {
 	knownPeers := []Neighbor{}
 
 	if autopeering.Selection == nil {
-		return requestFailed(c, "Neighbor Selection is not enabled")
+		return c.JSON(http.StatusNotImplemented, Response{Error: "Neighbor Selection is not enabled"})
 	}
 
 	if autopeering.Discovery == nil {
-		return requestFailed(c, "Neighbor Discovery is not enabled")
+		return c.JSON(http.StatusNotImplemented, Response{Error: "Neighbor Discovery is not enabled"})
 	}
 
 	if c.QueryParam("known") == "1" {
@@ -45,7 +45,6 @@ func getNeighbors(c echo.Context) error {
 	}
 
 	for _, peer := range autopeering.Selection.GetOutgoingNeighbors() {
-
 		n := Neighbor{
 			ID:        peer.ID().String(),
 			PublicKey: base64.StdEncoding.EncodeToString(peer.PublicKey()),
@@ -62,21 +61,7 @@ func getNeighbors(c echo.Context) error {
 		accepted = append(accepted, n)
 	}
 
-	return requestSuccessful(c, knownPeers, chosen, accepted)
-}
-
-func requestSuccessful(c echo.Context, knownPeers, chosen, accepted []Neighbor) error {
-	return c.JSON(http.StatusOK, Response{
-		KnownPeers: knownPeers,
-		Chosen:     chosen,
-		Accepted:   accepted,
-	})
-}
-
-func requestFailed(c echo.Context, message string) error {
-	return c.JSON(http.StatusNotFound, Response{
-		Error: message,
-	})
+	return c.JSON(http.StatusOK, Response{KnownPeers: knownPeers, Chosen: chosen, Accepted: accepted})
 }
 
 type Response struct {

--- a/plugins/webapi/spammer/plugin.go
+++ b/plugins/webapi/spammer/plugin.go
@@ -19,7 +19,7 @@ func WebApiHandler(c echo.Context) error {
 
 	var request Request
 	if err := c.Bind(&request); err != nil {
-		return requestFailed(c, err.Error())
+		return c.JSON(http.StatusBadRequest, Response{Error: err.Error()})
 	}
 
 	switch request.Cmd {
@@ -30,33 +30,18 @@ func WebApiHandler(c echo.Context) error {
 
 		transactionspammer.Stop()
 		transactionspammer.Start(request.Tps)
-
-		return requestSuccessful(c, "started spamming transactions")
-
+		return c.JSON(http.StatusOK, Response{Message: "started spamming transactions"})
 	case "stop":
 		transactionspammer.Stop()
-
-		return requestSuccessful(c, "stopped spamming transactions")
-
+		return c.JSON(http.StatusOK, Response{Message: "stopped spamming transactions"})
 	default:
-		return requestFailed(c, "invalid cmd in request")
+		return c.JSON(http.StatusBadRequest, Response{Error: "invalid cmd in request"})
 	}
-}
-
-func requestSuccessful(c echo.Context, message string) error {
-	return c.JSON(http.StatusOK, Response{
-		Message: message,
-	})
-}
-
-func requestFailed(c echo.Context, message string) error {
-	return c.JSON(http.StatusNotFound, Response{
-		Message: message,
-	})
 }
 
 type Response struct {
 	Message string `json:"message"`
+	Error   string `json:"error"`
 }
 
 type Request struct {


### PR DESCRIPTION
* Return 404 if for explicit transactions is searched via their hashes if any of them is not known
* Return 501 when autopeering discovery/selection is disabled
* Fixes occurrences of the wrong HTTP status code being returned