### PR TITLE
Update config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -57,8 +57,5 @@
       "username": "goshimmer"
     },
     "bindAddress": "127.0.0.1:8080"
-  },
-  "zeromq": {
-    "port": 5556
   }
 }


### PR DESCRIPTION
Removed reference to `zeromq` configuration option because we've removed the plugin.