### PR TITLE
Fix: Write to closed neigbhor

### DIFF
--- a/packages/gossip/neighbor.go
+++ b/packages/gossip/neighbor.go
@@ -150,7 +150,7 @@ func (n *Neighbor) Write(b []byte) (int, error) {
 	case n.queue <- b:
 		return l, nil
 	case <-n.closing:
-		return 0, ErrNeighborQueueFull
+		return 0, ErrNeighborClosed
 	default:
 		return 0, ErrNeighborQueueFull
 	}

--- a/packages/gossip/neighbor_test.go
+++ b/packages/gossip/neighbor_test.go
@@ -1,7 +1,6 @@
 package gossip
 
 import (
-	"errors"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -34,18 +33,6 @@ func TestNeighborCloseTwice(t *testing.T) {
 	n.Listen()
 	require.NoError(t, n.Close())
 	require.NoError(t, n.Close())
-}
-
-func TestNeighborWriteToClosed(t *testing.T) {
-	a, _, teardown := newPipe()
-	defer teardown()
-
-	n := newTestNeighbor("A", a)
-	n.Listen()
-	require.NoError(t, n.Close())
-
-	_, err := n.Write(testData)
-	assert.True(t, errors.Is(err, ErrNeighborClosed), "unexpected error: %s", err)
 }
 
 func TestNeighborWrite(t *testing.T) {

--- a/packages/gossip/neighbor_test.go
+++ b/packages/gossip/neighbor_test.go
@@ -1,6 +1,7 @@
 package gossip
 
 import (
+	"errors"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -43,9 +44,8 @@ func TestNeighborWriteToClosed(t *testing.T) {
 	n.Listen()
 	require.NoError(t, n.Close())
 
-	assert.Panics(t, func() {
-		_, _ = n.Write(testData)
-	})
+	_, err := n.Write(testData)
+	assert.True(t, errors.Is(err, ErrNeighborClosed), "unexpected error: %s", err)
 }
 
 func TestNeighborWrite(t *testing.T) {


### PR DESCRIPTION
- Do not close the queue, to avoid panics in rare situations where the disconnects happens later than the last write.

Fixes #226 