### PR TITLE
Increases send queue size/Ignore writes when connection is already closed

### DIFF
--- a/packages/gossip/manager.go
+++ b/packages/gossip/manager.go
@@ -174,7 +174,7 @@ func (m *Manager) send(b []byte, to ...peer.ID) {
 
 	for _, nbr := range neighbors {
 		if _, err := nbr.Write(b); err != nil {
-			m.log.Warnw("send error", "err", err)
+			m.log.Warnw("send error", "err", err, "neighbor", nbr.Peer.Address())
 		}
 	}
 }


### PR DESCRIPTION
* Increases send queue size of every neighbor to 5000 (we already had occasions where the limit of 1000 was too low)
* Skip sending into the send queue if the connection is deemed closed.
* Close the `BufferedConnection` also when a write fails, so the connection is "closed" earlier.
* Log the neighbor address when a write failed.