### PR TITLE
Fixes deadlock in neighbor manager

### DIFF
--- a/packages/gossip/manager.go
+++ b/packages/gossip/manager.go
@@ -78,6 +78,7 @@ func (m *Manager) AddOutbound(p *peer.Peer) error {
 	var srv *server.TCP
 	m.mu.RLock()
 	if m.srv == nil {
+		m.mu.RUnlock()
 		return ErrNotStarted
 	}
 	srv = m.srv
@@ -94,6 +95,7 @@ func (m *Manager) AddInbound(p *peer.Peer) error {
 	var srv *server.TCP
 	m.mu.RLock()
 	if m.srv == nil {
+		m.mu.RUnlock()
 		return ErrNotStarted
 	}
 	srv = m.srv
@@ -139,12 +141,11 @@ func (m *Manager) SendTransaction(txData []byte, to ...peer.ID) {
 
 func (m *Manager) GetAllNeighbors() []*Neighbor {
 	m.mu.RLock()
+	defer m.mu.RUnlock()
 	result := make([]*Neighbor, 0, len(m.neighbors))
 	for _, n := range m.neighbors {
 		result = append(result, n)
 	}
-	m.mu.RUnlock()
-
 	return result
 }
 
@@ -159,13 +160,12 @@ func (m *Manager) getNeighborsById(ids []peer.ID) []*Neighbor {
 	result := make([]*Neighbor, 0, len(ids))
 
 	m.mu.RLock()
+	defer m.mu.RUnlock()
 	for _, id := range ids {
 		if n, ok := m.neighbors[id]; ok {
 			result = append(result, n)
 		}
 	}
-	m.mu.RUnlock()
-
 	return result
 }
 


### PR DESCRIPTION
* `AddInbound()` and `AddOutbound()` didn't unlock in case `srv` wasn't defined. (not the cause of the deadlock but still wrong)
* Per neighbor a `WaitGroup` exists up on which is waited on when `Close()` is called on the neighbor. The `WaitGroup` is resolved when the writing and the reading goroutine (2 different goroutines) return out of their loop. In some cases, when the write goroutine would cause the `BufferedConnection.Close()` to be called, which in turn calls `DropNeighbor()` (which acquires the write lock of the neighbor manager), the reading goroutine could still be processing an incoming packet, which could be a transaction request, which in turn causes it to to call `SendTransaction()` which acquires the read lock of the neighbor manager causing a major deadlock for all neighbor related functionality (as the lock is write locked by `DropNeighbor()` while that one waits on the `WaitGroup`).

This PR moves the deleting of the neighbor entry into a separate function which acquires the write locks only during the deletion, so, that the subsequent `Close()` on the neighbor doesn't hold the lock anymore, allowing the reading-goroutine to still pass through and then eventually free the `WaitGroup`.