### PR TITLE
Reduces BadgerDB's memory usage

### DIFF
--- a/packages/database/database.go
+++ b/packages/database/database.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/dgraph-io/badger/v2"
+	"github.com/dgraph-io/badger/v2/options"
 	"github.com/iotaledger/goshimmer/packages/parameter"
 	"github.com/iotaledger/hive.go/database"
 	"github.com/iotaledger/hive.go/logger"
@@ -55,6 +56,13 @@ func GetBadgerInstance() *badger.DB {
 		if runtime.GOOS == "windows" {
 			opts = opts.WithTruncate(true)
 		}
+
+		opts.CompactL0OnClose = false
+		opts.KeepL0InMemory = false
+		opts.VerifyValueChecksum = false
+		opts.ZSTDCompressionLevel = 1
+		opts.Compression = options.None
+		opts.MaxCacheSize = 50000000
 
 		db, err := database.CreateDB(dbDir, opts)
 		if err != nil {


### PR DESCRIPTION
* Disables compression
* Reduces the cache size to 50 MB

130 megabyte vs. 500 megabytes after startup

As seen in the heap flame chart, most memory is simply used for compression and caching within BadgerDB:
![image](https://user-images.githubusercontent.com/1385611/73975713-303bd080-4927-11ea-87c3-f3ccd7794921.png)
