### PR TITLE
Update pprof port

### DIFF
--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ import (
 func main() {
 	cli.LoadConfig()
 
-	go http.ListenAndServe("localhost:6060", nil) // pprof Server for Debbuging Mutexes
+	go http.ListenAndServe("localhost:6061", nil) // pprof Server for Debbuging Mutexes
 
 	node.Run(
 		node.Plugins(


### PR DESCRIPTION
Since both Hornet and Goshimmer might be running on the same machine, update the port so that we can get debug information for both.