### PR TITLE
Fix: keep offline master peers in active peer list

### DIFF
--- a/packages/autopeering/discover/mpeer.go
+++ b/packages/autopeering/discover/mpeer.go
@@ -19,6 +19,14 @@ func wrapPeer(p *peer.Peer) *mpeer {
 	return &mpeer{Peer: *p}
 }
 
+func wrapPeers(ps []*peer.Peer) []*mpeer {
+	result := make([]*mpeer, len(ps))
+	for i, n := range ps {
+		result[i] = wrapPeer(n)
+	}
+	return result
+}
+
 func unwrapPeer(p *mpeer) *peer.Peer {
 	return &p.Peer
 }

--- a/packages/autopeering/discover/mpeer_test.go
+++ b/packages/autopeering/discover/mpeer_test.go
@@ -9,6 +9,18 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestWrapPeers(t *testing.T) {
+	m := make([]*mpeer, 5)
+	p := make([]*peer.Peer, 5)
+	for i := range m {
+		p[i] = peertest.NewPeer(testNetwork, fmt.Sprintf("%d", i))
+		m[i] = &mpeer{Peer: *p[i]}
+	}
+
+	wrapP := wrapPeers(p)
+	assert.Equal(t, m, wrapP, "wrapPeers")
+}
+
 func TestUnwrapPeers(t *testing.T) {
 	m := make([]*mpeer, 5)
 	p := make([]*peer.Peer, 5)


### PR DESCRIPTION
* Add a `masters` mpeer list to record master peers
* Implement `wrapPeers` to initiate `masters`
* If a master peer is offline
   1. set the `verifiedCount` to 0 => it will not be included in `GetVerifiedPeers`
   2. move it to the front of active list => avoid reverifying the same offline node

Close #246 