### PR TITLE
feat: Bundle plugins in to groups

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,25 +4,11 @@ import (
 	"net/http"
 	_ "net/http/pprof"
 
-	"github.com/iotaledger/goshimmer/plugins/analysis"
-	"github.com/iotaledger/goshimmer/plugins/autopeering"
-	"github.com/iotaledger/goshimmer/plugins/banner"
-	"github.com/iotaledger/goshimmer/plugins/cli"
+	"github.com/iotaledger/goshimmer/pluginmgr/core"
+	"github.com/iotaledger/goshimmer/pluginmgr/research"
+	"github.com/iotaledger/goshimmer/pluginmgr/ui"
+	"github.com/iotaledger/goshimmer/pluginmgr/webapi"
 	"github.com/iotaledger/goshimmer/plugins/config"
-	"github.com/iotaledger/goshimmer/plugins/gossip"
-	"github.com/iotaledger/goshimmer/plugins/gracefulshutdown"
-	"github.com/iotaledger/goshimmer/plugins/logger"
-	"github.com/iotaledger/goshimmer/plugins/metrics"
-	"github.com/iotaledger/goshimmer/plugins/portcheck"
-	"github.com/iotaledger/goshimmer/plugins/remotelog"
-	"github.com/iotaledger/goshimmer/plugins/spa"
-	"github.com/iotaledger/goshimmer/plugins/tangle"
-	"github.com/iotaledger/goshimmer/plugins/webapi"
-	webapi_broadcastData "github.com/iotaledger/goshimmer/plugins/webapi/broadcastData"
-	webapi_gtta "github.com/iotaledger/goshimmer/plugins/webapi/gtta"
-	webapi_spammer "github.com/iotaledger/goshimmer/plugins/webapi/spammer"
-	webapi_auth "github.com/iotaledger/goshimmer/plugins/webauth"
-
 	"github.com/iotaledger/hive.go/node"
 )
 
@@ -32,38 +18,9 @@ func main() {
 	go http.ListenAndServe("localhost:6061", nil) // pprof Server for Debbuging Mutexes
 
 	node.Run(
-		node.Plugins(
-			banner.PLUGIN,
-			config.PLUGIN,
-			logger.PLUGIN,
-			cli.PLUGIN,
-			remotelog.PLUGIN,
-			portcheck.PLUGIN,
-
-			autopeering.PLUGIN,
-			tangle.PLUGIN,
-			gossip.PLUGIN,
-			gracefulshutdown.PLUGIN,
-
-			analysis.PLUGIN,
-			metrics.PLUGIN,
-
-			webapi.PLUGIN,
-			webapi_auth.PLUGIN,
-			webapi_gtta.PLUGIN,
-			webapi_spammer.PLUGIN,
-			webapi_broadcastData.PLUGIN,
-
-			spa.PLUGIN,
-
-			/*
-				webapi_getTransactionTrytesByHash.PLUGIN,
-				webapi_getTransactionObjectsByHash.PLUGIN,
-				webapi_findTransactionHashes.PLUGIN,
-				webapi_getNeighbors.PLUGIN,
-
-				//graph.PLUGIN,
-			*/
-		),
+		core.PLUGINS,
+		research.PLUGINS,
+		ui.PLUGINS,
+		webapi.PLUGINS,
 	)
 }

--- a/pluginmgr/core/plugins.go
+++ b/pluginmgr/core/plugins.go
@@ -8,6 +8,7 @@ import (
 	"github.com/iotaledger/goshimmer/plugins/gossip"
 	"github.com/iotaledger/goshimmer/plugins/gracefulshutdown"
 	"github.com/iotaledger/goshimmer/plugins/logger"
+	"github.com/iotaledger/goshimmer/plugins/metrics"
 	"github.com/iotaledger/goshimmer/plugins/portcheck"
 	"github.com/iotaledger/goshimmer/plugins/tangle"
 	"github.com/iotaledger/hive.go/node"
@@ -23,4 +24,5 @@ var PLUGINS = node.Plugins(
 	tangle.PLUGIN,
 	gossip.PLUGIN,
 	gracefulshutdown.PLUGIN,
+	metrics.PLUGIN,
 )

--- a/pluginmgr/core/plugins.go
+++ b/pluginmgr/core/plugins.go
@@ -1,0 +1,26 @@
+package core
+
+import (
+	"github.com/iotaledger/goshimmer/plugins/autopeering"
+	"github.com/iotaledger/goshimmer/plugins/banner"
+	"github.com/iotaledger/goshimmer/plugins/cli"
+	"github.com/iotaledger/goshimmer/plugins/config"
+	"github.com/iotaledger/goshimmer/plugins/gossip"
+	"github.com/iotaledger/goshimmer/plugins/gracefulshutdown"
+	"github.com/iotaledger/goshimmer/plugins/logger"
+	"github.com/iotaledger/goshimmer/plugins/portcheck"
+	"github.com/iotaledger/goshimmer/plugins/tangle"
+	"github.com/iotaledger/hive.go/node"
+)
+
+var PLUGINS = node.Plugins(
+	banner.PLUGIN,
+	config.PLUGIN,
+	logger.PLUGIN,
+	cli.PLUGIN,
+	portcheck.PLUGIN,
+	autopeering.PLUGIN,
+	tangle.PLUGIN,
+	gossip.PLUGIN,
+	gracefulshutdown.PLUGIN,
+)

--- a/pluginmgr/research/plugins.go
+++ b/pluginmgr/research/plugins.go
@@ -2,7 +2,6 @@ package research
 
 import (
 	"github.com/iotaledger/goshimmer/plugins/analysis"
-	"github.com/iotaledger/goshimmer/plugins/metrics"
 	"github.com/iotaledger/goshimmer/plugins/remotelog"
 	"github.com/iotaledger/hive.go/node"
 )
@@ -10,5 +9,4 @@ import (
 var PLUGINS = node.Plugins(
 	remotelog.PLUGIN,
 	analysis.PLUGIN,
-	metrics.PLUGIN,
 )

--- a/pluginmgr/research/plugins.go
+++ b/pluginmgr/research/plugins.go
@@ -1,0 +1,14 @@
+package research
+
+import (
+	"github.com/iotaledger/goshimmer/plugins/analysis"
+	"github.com/iotaledger/goshimmer/plugins/metrics"
+	"github.com/iotaledger/goshimmer/plugins/remotelog"
+	"github.com/iotaledger/hive.go/node"
+)
+
+var PLUGINS = node.Plugins(
+	remotelog.PLUGIN,
+	analysis.PLUGIN,
+	metrics.PLUGIN,
+)

--- a/pluginmgr/ui/plugins.go
+++ b/pluginmgr/ui/plugins.go
@@ -1,0 +1,12 @@
+package ui
+
+import (
+	"github.com/iotaledger/goshimmer/plugins/graph"
+	"github.com/iotaledger/goshimmer/plugins/spa"
+	"github.com/iotaledger/hive.go/node"
+)
+
+var PLUGINS = node.Plugins(
+	spa.PLUGIN,
+	graph.PLUGIN,
+)

--- a/pluginmgr/webapi/plugins.go
+++ b/pluginmgr/webapi/plugins.go
@@ -1,0 +1,26 @@
+package webapi
+
+import (
+	"github.com/iotaledger/goshimmer/plugins/webapi"
+	webapi_broadcastData "github.com/iotaledger/goshimmer/plugins/webapi/broadcastData"
+	webapi_findTransactionHashes "github.com/iotaledger/goshimmer/plugins/webapi/findTransactionHashes"
+	webapi_getNeighbors "github.com/iotaledger/goshimmer/plugins/webapi/getNeighbors"
+	webapi_getTransactionObjectsByHash "github.com/iotaledger/goshimmer/plugins/webapi/getTransactionObjectsByHash"
+	webapi_getTransactionTrytesByHash "github.com/iotaledger/goshimmer/plugins/webapi/getTransactionTrytesByHash"
+	webapi_gtta "github.com/iotaledger/goshimmer/plugins/webapi/gtta"
+	webapi_spammer "github.com/iotaledger/goshimmer/plugins/webapi/spammer"
+	webapi_auth "github.com/iotaledger/goshimmer/plugins/webauth"
+	"github.com/iotaledger/hive.go/node"
+)
+
+var PLUGINS = node.Plugins(
+	webapi.PLUGIN,
+	webapi_auth.PLUGIN,
+	webapi_gtta.PLUGIN,
+	webapi_spammer.PLUGIN,
+	webapi_broadcastData.PLUGIN,
+	webapi_getTransactionTrytesByHash.PLUGIN,
+	webapi_getTransactionObjectsByHash.PLUGIN,
+	webapi_findTransactionHashes.PLUGIN,
+	webapi_getNeighbors.PLUGIN,
+)

--- a/pluginmgr/webapi/plugins.go
+++ b/pluginmgr/webapi/plugins.go
@@ -2,25 +2,25 @@ package webapi
 
 import (
 	"github.com/iotaledger/goshimmer/plugins/webapi"
-	webapi_broadcastData "github.com/iotaledger/goshimmer/plugins/webapi/broadcastData"
-	webapi_findTransactionHashes "github.com/iotaledger/goshimmer/plugins/webapi/findTransactionHashes"
-	webapi_getNeighbors "github.com/iotaledger/goshimmer/plugins/webapi/getNeighbors"
-	webapi_getTransactionObjectsByHash "github.com/iotaledger/goshimmer/plugins/webapi/getTransactionObjectsByHash"
-	webapi_getTransactionTrytesByHash "github.com/iotaledger/goshimmer/plugins/webapi/getTransactionTrytesByHash"
-	webapi_gtta "github.com/iotaledger/goshimmer/plugins/webapi/gtta"
-	webapi_spammer "github.com/iotaledger/goshimmer/plugins/webapi/spammer"
-	webapi_auth "github.com/iotaledger/goshimmer/plugins/webauth"
+	"github.com/iotaledger/goshimmer/plugins/webapi/broadcastData"
+	"github.com/iotaledger/goshimmer/plugins/webapi/findTransactionHashes"
+	"github.com/iotaledger/goshimmer/plugins/webapi/getNeighbors"
+	"github.com/iotaledger/goshimmer/plugins/webapi/getTransactionObjectsByHash"
+	"github.com/iotaledger/goshimmer/plugins/webapi/getTransactionTrytesByHash"
+	"github.com/iotaledger/goshimmer/plugins/webapi/gtta"
+	"github.com/iotaledger/goshimmer/plugins/webapi/spammer"
+	"github.com/iotaledger/goshimmer/plugins/webauth"
 	"github.com/iotaledger/hive.go/node"
 )
 
 var PLUGINS = node.Plugins(
 	webapi.PLUGIN,
-	webapi_auth.PLUGIN,
-	webapi_gtta.PLUGIN,
-	webapi_spammer.PLUGIN,
-	webapi_broadcastData.PLUGIN,
-	webapi_getTransactionTrytesByHash.PLUGIN,
-	webapi_getTransactionObjectsByHash.PLUGIN,
-	webapi_findTransactionHashes.PLUGIN,
-	webapi_getNeighbors.PLUGIN,
+	webauth.PLUGIN,
+	gtta.PLUGIN,
+	spammer.PLUGIN,
+	broadcastData.PLUGIN,
+	getTransactionTrytesByHash.PLUGIN,
+	getTransactionObjectsByHash.PLUGIN,
+	findTransactionHashes.PLUGIN,
+	getNeighbors.PLUGIN,
 )


### PR DESCRIPTION
Manage all plugin bundles under `/pluginmgr`.

Blocked by [hive.go PR 66](https://github.com/iotaledger/hive.go/pull/66)
