### PR TITLE
Fix: Harden docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,14 @@
+.git
+.gitignore
+
+LICENSE
+README.md
+CHANGELOG.md
+images/
+docker-compose.yml
+
+tools/
+client/
+
 # Database directory
 mainnetdb/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,47 @@
-# we need to use alpine to build since cgo is required
-FROM golang:1.13-alpine AS build
-RUN apk add --no-cache git gcc g++
+############################
+# Build
+############################
+# golang:1.14.0-buster
+FROM golang@sha256:fc7e7c9c4b0f6d2d5e8611ee73b9d1d3132750108878517bbf988aa772359ae4 AS build
+
+# Ensure ca-certficates are up to date
+RUN update-ca-certificates
 
 # Set the current Working Directory inside the container
 RUN mkdir /goshimmer
 WORKDIR /goshimmer
 
-# Download dependencies
-COPY go.mod . 
+# Use Go Modules
+COPY go.mod .
 COPY go.sum .
+
+ENV GO111MODULE=on
 RUN go mod download
+RUN go mod verify
 
 # Copy everything from the current directory to the PWD(Present Working Directory) inside the container
 COPY . .
 
-# Build
-RUN CGO_ENABLED=1 GOOS=linux go build -o /go/bin/goshimmer
+# Build the binary
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+      -ldflags='-w -s -extldflags "-static"' -a \
+       -o /go/bin/goshimmer
 
-FROM alpine:latest  
+############################
+# Image
+############################
+# using static nonroot image
+# user:group is nonroot:nonroot, uid:gid = 65532:65532
+FROM gcr.io/distroless/static@sha256:23aa732bba4c8618c0d97c26a72a32997363d591807b0d4c31b0bbc8a774bddf
 
-RUN apk --no-cache add ca-certificates
-
-WORKDIR /app
-
-VOLUME /app/mainnetdb
+VOLUME /mainnetdb
 
 EXPOSE 14666/tcp
 EXPOSE 14626/udp
 
 # Copy the Pre-built binary file from the previous stage
-COPY --from=build /go/bin/goshimmer .
-# Copy the docker config
-COPY config.json config.json
+COPY --from=build /go/bin/goshimmer /run/goshimmer
+# Copy the default config
+COPY config.default.json config.json
 
-ENTRYPOINT ["./goshimmer"] 
+ENTRYPOINT ["/run/goshimmer", "--database.directory=/mainnetdb"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     container_name: iota_goshimmer
     restart: unless-stopped
     volumes:
-      - ./mainnetdb:/app/mainnetdb:rw
+      - ./mainnetdb/:/mainnetdb/:rw
     ports:
       - "14666:14666/tcp"
       - "14626:14626/udp"


### PR DESCRIPTION
- Fix base image version using sha256 hash
- Disable cgo
 - Build static binary without debug symbols
 - Use `gcr.io/distroless/static to run`
 - Run as unprivileged user
