### PR TITLE
Prepare v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v0.1.3 - 2020-03-16
+
+* Update SPA plugin's JS dependencies
+* Upgrad `github.com/gobuffalo/packr` to v2.8.0
+* Resolves a security issue in the packr dependency, which would allow an unauthenticated attacker to read any
+ file from the application's filesystem 
+
 # v0.1.2 - 2020-02-24
 
 * Adds `--version` flag to retrieve the GoShimmer version

--- a/plugins/cli/plugin.go
+++ b/plugins/cli/plugin.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// AppVersion version number
-	AppVersion = "v0.1.2"
+	AppVersion = "v0.1.3"
 	// AppName app code name
 	AppName = "GoShimmer"
 )


### PR DESCRIPTION
# v0.1.3 - 2020-03-16

* Update SPA plugin's JS dependencies
* Upgrad `github.com/gobuffalo/packr` to v2.8.0
* Resolves a security issue in the packr dependency, which would allow an unauthenticated attacker to read any file from the application's filesystem 