### PR TITLE
Enabled golint warnings for missing comments

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,7 +8,7 @@ linters-settings:
     gofmt:
         simplify: true
     golint:
-        min-confidence: 0.9
+        min-confidence: 0.8
     govet:
         check-shadowing: true
     misspell:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,13 +1,14 @@
 run:
     tests: true
 
+issues:
+    exclude-use-default: false
+
 linters-settings:
     gofmt:
         simplify: true
     golint:
         min-confidence: 0.9
-    gocyclo:
-        min-complexity: 15
     govet:
         check-shadowing: true
     misspell:
@@ -19,7 +20,7 @@ linters:
         - gofmt
         - goimports
         - govet
+        - golint
     disable:
         - errcheck
         - gochecknoglobals
-        - golint


### PR DESCRIPTION
- Enable `golint` in GolangCI
- Do not excluded warnings about missing comments
- Set confidence level to 0.9 to disable capitalization warnings