### PR TITLE
Add reviewdog GitHub action

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,8 +1,7 @@
 name: Test GoShimmer
-on:
-  push:
-  pull_request:
-    types: [opened, reopened]
+
+on: [push, pull_request]
+
 jobs:
 
   integration-test:

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,0 +1,21 @@
+name: reviewdog
+
+on: 
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+
+  golangci-lint:
+    name: GolangCI-Lint 
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+    
+    - name: golangci-lint
+      uses: docker://reviewdog/action-golangci-lint:latest
+      with:
+        github_token: ${{ secrets.github_token }}
+        golangci_lint_flags: "--timeout=10m"

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,8 +1,8 @@
 name: reviewdog
 
-on: 
+on:
   pull_request:
-    types: [opened, reopened]
+    types: [opened, reopened, synchronize]
 
 jobs:
 

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
     
-    - name: golangci-lint
+    - name: Run golangci-lint
       uses: docker://reviewdog/action-golangci-lint:latest
       with:
         github_token: ${{ secrets.github_token }}

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -19,3 +19,4 @@ jobs:
       with:
         github_token: ${{ secrets.github_token }}
         golangci_lint_flags: "--timeout=10m"
+        reporter: "github-pr-review"

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,8 +1,6 @@
 name: reviewdog
 
-on:
-  pull_request:
-    types: [opened, reopened, synchronize]
+on: pull_request
 
 jobs:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,7 @@
 name: Test GoShimmer
-on:
-  push:
-  pull_request:
-    types: [opened, reopened]
+
+on: [push, pull_request]
+
 jobs:
 
   build:


### PR DESCRIPTION
Use [reviewdog](https://github.com/reviewdog/reviewdog) to run GoLangCI-Linter and report warnings as PR reviews. Replaces the discontinued GolangCI.com bot.

See #338 for how it will look.