### PR TITLE
Makes pprof profiling a plugin

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"net/http"
 	_ "net/http/pprof"
 
 	"github.com/iotaledger/goshimmer/pluginmgr/core"
@@ -13,8 +12,6 @@ import (
 )
 
 func main() {
-	go http.ListenAndServe("localhost:6061", nil) // pprof Server for Debbuging Mutexes
-
 	node.Run(
 		core.PLUGINS,
 		research.PLUGINS,

--- a/pluginmgr/core/plugins.go
+++ b/pluginmgr/core/plugins.go
@@ -13,6 +13,7 @@ import (
 	"github.com/iotaledger/goshimmer/plugins/messagelayer"
 	"github.com/iotaledger/goshimmer/plugins/metrics"
 	"github.com/iotaledger/goshimmer/plugins/portcheck"
+	"github.com/iotaledger/goshimmer/plugins/profiling"
 
 	"github.com/iotaledger/hive.go/node"
 )
@@ -23,6 +24,7 @@ var PLUGINS = node.Plugins(
 	logger.PLUGIN,
 	cli.PLUGIN,
 	portcheck.PLUGIN,
+	profiling.PLUGIN,
 	database.PLUGIN,
 	autopeering.PLUGIN,
 	messagelayer.PLUGIN,

--- a/pluginmgr/core/plugins.go
+++ b/pluginmgr/core/plugins.go
@@ -24,7 +24,7 @@ var PLUGINS = node.Plugins(
 	logger.PLUGIN,
 	cli.PLUGIN,
 	portcheck.PLUGIN,
-	profiling.PLUGIN,
+	profiling.Plugin,
 	database.PLUGIN,
 	autopeering.PLUGIN,
 	messagelayer.PLUGIN,

--- a/plugins/profiling/plugin.go
+++ b/plugins/profiling/plugin.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	PLUGIN = node.NewPlugin("Profiling", node.Enabled, configure, run)
+	Plugin = node.NewPlugin("Profiling", node.Enabled, configure, run)
 )
 
 const CfgProfilingBindAddress = "profiling.bindAddress"

--- a/plugins/profiling/plugin.go
+++ b/plugins/profiling/plugin.go
@@ -1,0 +1,26 @@
+package profiling
+
+import (
+	"net/http"
+	_ "net/http/pprof"
+
+	"github.com/iotaledger/goshimmer/plugins/config"
+	"github.com/iotaledger/hive.go/node"
+	flag "github.com/spf13/pflag"
+)
+
+var (
+	PLUGIN = node.NewPlugin("Profiling", node.Enabled, configure, run)
+)
+
+const CfgProfilingBindAddress = "profiling.bindAddress"
+
+func init() {
+	flag.String(CfgProfilingBindAddress, "localhost:6061", "bind address for the pprof server")
+}
+
+func configure(_ *node.Plugin) {}
+
+func run(_ *node.Plugin) {
+	go http.ListenAndServe(config.Node.GetString(CfgProfilingBindAddress), nil)
+}


### PR DESCRIPTION
Adds a `profiling` plugin so one can adjust the bind address for the pprof server or disable profiling all together.