### PR TITLE
Remove global gossip events

### DIFF
--- a/packages/gossip/events.go
+++ b/packages/gossip/events.go
@@ -5,8 +5,8 @@ import (
 	"github.com/iotaledger/hive.go/events"
 )
 
-// Events contains all the events related to the gossip protocol.
-var Events = struct {
+// Events defines all the events related to the gossip protocol.
+type Events struct {
 	// Fired when an attempt to build a connection to a neighbor has failed.
 	ConnectionFailed *events.Event
 	// Fired when a neighbor connection has been established.
@@ -15,11 +15,6 @@ var Events = struct {
 	NeighborRemoved *events.Event
 	// Fired when a new message was received via the gossip protocol.
 	MessageReceived *events.Event
-}{
-	ConnectionFailed: events.NewEvent(peerAndErrorCaller),
-	NeighborAdded:    events.NewEvent(neighborCaller),
-	NeighborRemoved:  events.NewEvent(peerCaller),
-	MessageReceived:  events.NewEvent(messageReceived),
 }
 
 // MessageReceivedEvent holds data about a message received event.

--- a/plugins/autopeering/plugin.go
+++ b/plugins/autopeering/plugin.go
@@ -37,10 +37,10 @@ func run(*node.Plugin) {
 
 func configureEvents() {
 	// notify the selection when a connection is closed or failed.
-	gossip.Events().ConnectionFailed.Attach(events.NewClosure(func(p *peer.Peer, _ error) {
+	gossip.Manager().Events().ConnectionFailed.Attach(events.NewClosure(func(p *peer.Peer, _ error) {
 		Selection.RemoveNeighbor(p.ID())
 	}))
-	gossip.Events().NeighborRemoved.Attach(events.NewClosure(func(p *peer.Peer) {
+	gossip.Manager().Events().NeighborRemoved.Attach(events.NewClosure(func(p *peer.Peer) {
 		Selection.RemoveNeighbor(p.ID())
 	}))
 

--- a/plugins/autopeering/plugin.go
+++ b/plugins/autopeering/plugin.go
@@ -3,8 +3,8 @@ package autopeering
 import (
 	"time"
 
-	"github.com/iotaledger/goshimmer/packages/gossip"
 	"github.com/iotaledger/goshimmer/packages/shutdown"
+	"github.com/iotaledger/goshimmer/plugins/gossip"
 	"github.com/iotaledger/hive.go/autopeering/discover"
 	"github.com/iotaledger/hive.go/autopeering/peer"
 	"github.com/iotaledger/hive.go/autopeering/selection"
@@ -37,10 +37,10 @@ func run(*node.Plugin) {
 
 func configureEvents() {
 	// notify the selection when a connection is closed or failed.
-	gossip.Events.ConnectionFailed.Attach(events.NewClosure(func(p *peer.Peer, _ error) {
+	gossip.Events().ConnectionFailed.Attach(events.NewClosure(func(p *peer.Peer, _ error) {
 		Selection.RemoveNeighbor(p.ID())
 	}))
-	gossip.Events.NeighborRemoved.Attach(events.NewClosure(func(p *peer.Peer) {
+	gossip.Events().NeighborRemoved.Attach(events.NewClosure(func(p *peer.Peer) {
 		Selection.RemoveNeighbor(p.ID())
 	}))
 

--- a/plugins/dashboard/plugin.go
+++ b/plugins/dashboard/plugin.go
@@ -193,7 +193,7 @@ func neighborMetrics() []neighbormetric {
 	stats := []neighbormetric{}
 
 	// gossip plugin might be disabled
-	neighbors := gossip.Neighbors()
+	neighbors := gossip.Manager().AllNeighbors()
 	if neighbors == nil {
 		return stats
 	}

--- a/plugins/gossip/gossip.go
+++ b/plugins/gossip/gossip.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 
 	"github.com/iotaledger/goshimmer/packages/binary/messagelayer/message"
-	gp "github.com/iotaledger/goshimmer/packages/gossip"
+	"github.com/iotaledger/goshimmer/packages/gossip"
 	"github.com/iotaledger/goshimmer/packages/gossip/server"
 	"github.com/iotaledger/goshimmer/plugins/autopeering/local"
 	"github.com/iotaledger/goshimmer/plugins/config"
@@ -18,7 +18,7 @@ import (
 
 var (
 	log *logger.Logger
-	mgr *gp.Manager
+	mgr *gossip.Manager
 	srv *server.TCP
 )
 
@@ -34,7 +34,7 @@ func configureGossip() {
 	if err := lPeer.UpdateService(service.GossipKey, "tcp", gossipPort); err != nil {
 		log.Fatalf("could not update services: %s", err)
 	}
-	mgr = gp.NewManager(lPeer, loadMessage, log)
+	mgr = gossip.NewManager(lPeer, loadMessage, log)
 }
 
 func start(shutdownSignal <-chan struct{}) {
@@ -82,9 +82,14 @@ func loadMessage(messageID message.Id) (bytes []byte, err error) {
 }
 
 // Neighbors returns the list of the neighbors.
-func Neighbors() []*gp.Neighbor {
+func Neighbors() []*gossip.Neighbor {
 	if mgr == nil {
 		return nil
 	}
 	return mgr.AllNeighbors()
+}
+
+// Events exposes all the events triggered by the gossip plugin.
+func Events() gossip.Events {
+	return mgr.Events()
 }

--- a/plugins/gossip/gossip.go
+++ b/plugins/gossip/gossip.go
@@ -23,6 +23,7 @@ var (
 	mgrOnce sync.Once
 )
 
+// Manager returns the manager instance of the gossip plugin.
 func Manager() *gossip.Manager {
 	mgrOnce.Do(createManager)
 	return mgr

--- a/plugins/gossip/plugin.go
+++ b/plugins/gossip/plugin.go
@@ -20,6 +20,10 @@ const PluginName = "Gossip"
 var Plugin = node.NewPlugin(PluginName, node.Enabled, configure, run)
 
 func configure(*node.Plugin) {
+	// assure that the Manager is instantiated
+	mgr := Manager()
+
+	// link to the auto peering
 	selection.Events.Dropped.Attach(events.NewClosure(func(ev *selection.DroppedEvent) {
 		go func() {
 			if err := mgr.DropNeighbor(ev.DroppedID); err != nil {
@@ -48,7 +52,7 @@ func configure(*node.Plugin) {
 		}()
 	}))
 
-	mgr := Manager()
+	// log neighbor changes
 	mgr.Events().ConnectionFailed.Attach(events.NewClosure(func(p *peer.Peer, err error) {
 		log.Infof("Connection to neighbor %s / %s failed: %s", gossip.GetAddress(p), p.ID(), err)
 	}))

--- a/plugins/gossip/plugin.go
+++ b/plugins/gossip/plugin.go
@@ -62,18 +62,18 @@ func configureEvents() {
 		}()
 	}))
 
-	gossip.Events.ConnectionFailed.Attach(events.NewClosure(func(p *peer.Peer, err error) {
+	mgr.Events().ConnectionFailed.Attach(events.NewClosure(func(p *peer.Peer, err error) {
 		log.Infof("Connection to neighbor %s / %s failed: %s", gossip.GetAddress(p), p.ID(), err)
 	}))
-	gossip.Events.NeighborAdded.Attach(events.NewClosure(func(n *gossip.Neighbor) {
+	mgr.Events().NeighborAdded.Attach(events.NewClosure(func(n *gossip.Neighbor) {
 		log.Infof("Neighbor added: %s / %s", gossip.GetAddress(n.Peer), n.ID())
 	}))
-	gossip.Events.NeighborRemoved.Attach(events.NewClosure(func(p *peer.Peer) {
+	mgr.Events().NeighborRemoved.Attach(events.NewClosure(func(p *peer.Peer) {
 		log.Infof("Neighbor removed: %s / %s", gossip.GetAddress(p), p.ID())
 	}))
 
 	// configure flow of incoming messages
-	gossip.Events.MessageReceived.Attach(events.NewClosure(func(event *gossip.MessageReceivedEvent) {
+	mgr.Events().MessageReceived.Attach(events.NewClosure(func(event *gossip.MessageReceivedEvent) {
 		messagelayer.MessageParser.Parse(event.Data, event.Peer)
 	}))
 


### PR DESCRIPTION
Remove the global `Events` variable of the gossip package and make it part of the `Manager` struct.

Fixes #349 