### PR TITLE
Run integration tests only for PRs

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,6 +1,6 @@
 name: Test GoShimmer
 
-on: [push, pull_request]
+on: pull_request
 
 jobs:
 


### PR DESCRIPTION
As the CI integration tests take significantly longer than unit tests, it makes sense to only run them for PRs.