### PR TITLE
Remove usage of github.com/pkg/errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/magiconair/properties v1.8.1
 	github.com/mr-tron/base58 v1.1.3
 	github.com/panjf2000/ants/v2 v2.2.2
-	github.com/pkg/errors v0.9.1
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.6.2
 	github.com/stretchr/testify v1.5.1

--- a/plugins/dashboard/explorer_routes.go
+++ b/plugins/dashboard/explorer_routes.go
@@ -1,13 +1,13 @@
 package dashboard
 
 import (
+	"fmt"
 	"net/http"
 	"sync"
 
 	"github.com/iotaledger/goshimmer/packages/binary/messagelayer/message"
 	"github.com/iotaledger/goshimmer/plugins/messagelayer"
 	"github.com/labstack/echo"
-	"github.com/pkg/errors"
 )
 
 // ExplorerMessage defines the struct of the ExplorerMessage.
@@ -80,7 +80,7 @@ func setupExplorerRoutes(routeGroup *echo.Group) {
 		result := &SearchResult{}
 
 		if len(search) < 81 {
-			return errors.Wrapf(ErrInvalidParameter, "search id invalid: %s", search)
+			return fmt.Errorf("%w: search ID %s", ErrInvalidParameter, search)
 		}
 
 		wg := sync.WaitGroup{}
@@ -116,14 +116,14 @@ func findMessage(messageID message.Id) (explorerMsg *ExplorerMessage, err error)
 	if !messagelayer.Tangle.Message(messageID).Consume(func(msg *message.Message) {
 		explorerMsg, err = createExplorerMessage(msg)
 	}) {
-		err = errors.Wrapf(ErrNotFound, "message: %s", messageID.String())
+		err = fmt.Errorf("%w: message %s", ErrNotFound, messageID.String())
 	}
 
 	return
 }
 
 func findAddress(address string) (*ExplorerAddress, error) {
-	return nil, errors.Wrapf(ErrNotFound, "address %s not found", address)
+	return nil, fmt.Errorf("%w: address %s", ErrNotFound, address)
 
 	// TODO: ADD ADDRESS LOOKUPS ONCE THE VALUE TRANSFER ONTOLOGY IS MERGED
 }

--- a/plugins/dashboard/routes.go
+++ b/plugins/dashboard/routes.go
@@ -1,6 +1,7 @@
 package dashboard
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -9,7 +10,6 @@ import (
 	"github.com/gobuffalo/packr/v2"
 	"github.com/iotaledger/goshimmer/plugins/config"
 	"github.com/labstack/echo"
-	"github.com/pkg/errors"
 )
 
 // ErrInvalidParameter defines the invalid parameter error.
@@ -79,7 +79,7 @@ func setupRoutes(e *echo.Echo) {
 		var statusCode int
 		var message string
 
-		switch errors.Cause(err) {
+		switch errors.Unwrap(err) {
 
 		case echo.ErrNotFound:
 			c.Redirect(http.StatusSeeOther, "/")


### PR DESCRIPTION
Replace usage of `github.com/pkg/errors` functions with stdlib `error`'s equivalent.