### PR TITLE
Do not limit the number of issues per linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,7 @@ run:
 
 issues:
     exclude-use-default: false
+    max-issues-per-linter: 0
 
 linters-settings:
     gofmt:


### PR DESCRIPTION
By default `GolangCI-Lint` limits the number of issues per linter to 50. This is not enough.