### PR TITLE
Fix #372 Analysis client plugin panic without gossip

### DIFF
--- a/plugins/analysis/client/plugin.go
+++ b/plugins/analysis/client/plugin.go
@@ -88,20 +88,26 @@ func reportHeartbeat(dispatchers *EventDispatchers) {
 		nodeID = local.GetInstance().ID().Bytes()
 	}
 
-	// Get outboundIds (chosen neighbors)
-	outgoingNeighbors := autopeering.Selection.GetOutgoingNeighbors()
-	outboundIds := make([][]byte, len(outgoingNeighbors))
-	for i, neighbor := range outgoingNeighbors {
-		// Doesn't copy the ID, take care not to modify underlying bytearray!
-		outboundIds[i] = neighbor.ID().Bytes()
-	}
+	var outboundIds [][]byte
+	var inboundIds [][]byte
 
-	// Get inboundIds (accepted neighbors)
-	incomingNeighbors := autopeering.Selection.GetIncomingNeighbors()
-	inboundIds := make([][]byte, len(incomingNeighbors))
-	for i, neighbor := range incomingNeighbors {
-		// Doesn't copy the ID, take care not to modify underlying bytearray!
-		inboundIds[i] = neighbor.ID().Bytes()
+	// When gossip (and autopeering selection) is enabled, we have neighbors to report
+	if autopeering.Selection != nil {
+		// Get outboundIds (chosen neighbors)
+		outgoingNeighbors := autopeering.Selection.GetOutgoingNeighbors()
+		outboundIds = make([][]byte, len(outgoingNeighbors))
+		for i, neighbor := range outgoingNeighbors {
+			// Doesn't copy the ID, take care not to modify underlying bytearray!
+			outboundIds[i] = neighbor.ID().Bytes()
+		}
+
+		// Get inboundIds (accepted neighbors)
+		incomingNeighbors := autopeering.Selection.GetIncomingNeighbors()
+		inboundIds = make([][]byte, len(incomingNeighbors))
+		for i, neighbor := range incomingNeighbors {
+			// Doesn't copy the ID, take care not to modify underlying bytearray!
+			inboundIds[i] = neighbor.ID().Bytes()
+		}
 	}
 
 	packet := &heartbeat.Packet{OwnID: nodeID, OutboundIDs: outboundIds, InboundIDs: inboundIds}


### PR DESCRIPTION
# Description of change
fixes #372 
When `autopeering.Selection` is `nil`, report no neighbors in `Heartbeat`.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Running GoShimmer with `gossip` plugin disabled and verify that it doesn't panic.

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
