### PR TITLE
fix: Fix docker_network

### DIFF
--- a/tools/docker-network/docker-compose.yml
+++ b/tools/docker-network/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.5"
 
 services:
   entry_node:
-    command: --autopeering.seed=uuDCzsjyLNQ17/7fWKPNMYmr4IWuaVRf7qKqRL0v/6c= --autopeering.entryNodes= --analysis.server.port=1888 --node.disablePlugins=gossip,portcheck,spa,webapi,webapibroadcastdataendpoint,webapifindtransactionhashesendpoint,webapigetneighborsendpoint,webapigettransactionobjectsbyhashendpoint,webapigettransactiontrytesbyhashendpoint
+    command: --autopeering.seed=uuDCzsjyLNQ17/7fWKPNMYmr4IWuaVRf7qKqRL0v/6c= --autopeering.entryNodes= --analysis.server.port=1888 --node.disablePlugins=gossip,portcheck,dashboard,webapi,webapibroadcastdataendpoint,webapifindtransactionhashesendpoint,webapigetneighborsendpoint,webapigettransactionobjectsbyhashendpoint,webapigettransactiontrytesbyhashendpoint
     container_name: entry_node
     image: iotaledger/goshimmer
     build:
@@ -32,7 +32,7 @@ services:
       - integration-test
 
   peer_replica:
-    command: --node.disablePlugins=spa
+    command: --node.disablePlugins=dashboard,portcheck
     image: iotaledger/goshimmer
     build:
       context: ../..

--- a/tools/docker-network/docker-compose.yml
+++ b/tools/docker-network/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.5"
 
 services:
   entry_node:
-    command: --autopeering.seed=uuDCzsjyLNQ17/7fWKPNMYmr4IWuaVRf7qKqRL0v/6c= --autopeering.entryNodes= --analysis.server.port=1888 --node.disablePlugins=gossip,portcheck,dashboard,webapi,webapibroadcastdataendpoint,webapifindtransactionhashesendpoint,webapigetneighborsendpoint,webapigettransactionobjectsbyhashendpoint,webapigettransactiontrytesbyhashendpoint
+    command: --autopeering.seed=uuDCzsjyLNQ17/7fWKPNMYmr4IWuaVRf7qKqRL0v/6c= --autopeering.entryNodes= --analysis.server.port=1888 --node.disablePlugins=portcheck,dashboard,webapi,webapibroadcastdataendpoint,webapifindtransactionhashesendpoint,webapigetneighborsendpoint,webapigettransactionobjectsbyhashendpoint,webapigettransactiontrytesbyhashendpoint
     container_name: entry_node
     image: iotaledger/goshimmer
     build:


### PR DESCRIPTION
* Rename SPA to dashboard
* Disable portcheck in command of peer_replica, otherwise the CLI commands cover settings in config file, and portcheck is enabled again.
* Remove gossip from disablePlugins of entry node, it should be enabled.

## Type of change

- Bug fix 


## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
