### PR TITLE
Adds bootstrap/sync/issuer plugin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,14 @@ module github.com/iotaledger/goshimmer
 go 1.14
 
 require (
+	github.com/Microsoft/go-winio v0.4.14 // indirect
 	github.com/coreos/bbolt v1.3.3 // indirect
 	github.com/dgraph-io/badger/v2 v2.0.2
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/docker/distribution v2.7.1+incompatible // indirect
+	github.com/docker/docker v1.13.1 // indirect
+	github.com/docker/go-connections v0.4.0 // indirect
+	github.com/docker/go-units v0.4.0 // indirect
 	github.com/drand/drand v0.5.4
 	github.com/gobuffalo/packr/v2 v2.7.1
 	github.com/golang/protobuf v1.3.4
@@ -16,8 +21,10 @@ require (
 	github.com/labstack/gommon v0.3.0
 	github.com/magiconair/properties v1.8.1
 	github.com/mr-tron/base58 v1.1.3
+	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
+	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/panjf2000/ants/v2 v2.2.2
-	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pkg/errors v0.9.1
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.6.2
 	github.com/stretchr/testify v1.5.1

--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,9 @@ module github.com/iotaledger/goshimmer
 go 1.14
 
 require (
-	github.com/Microsoft/go-winio v0.4.14 // indirect
 	github.com/coreos/bbolt v1.3.3 // indirect
 	github.com/dgraph-io/badger/v2 v2.0.2
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
-	github.com/docker/distribution v2.7.1+incompatible // indirect
-	github.com/docker/docker v1.13.1 // indirect
-	github.com/docker/go-connections v0.4.0 // indirect
-	github.com/docker/go-units v0.4.0 // indirect
 	github.com/drand/drand v0.5.4
 	github.com/gobuffalo/packr/v2 v2.7.1
 	github.com/golang/protobuf v1.3.4
@@ -21,10 +16,8 @@ require (
 	github.com/labstack/gommon v0.3.0
 	github.com/magiconair/properties v1.8.1
 	github.com/mr-tron/base58 v1.1.3
-	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
-	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/panjf2000/ants/v2 v2.2.2
-	github.com/pkg/errors v0.9.1
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.6.2
 	github.com/stretchr/testify v1.5.1

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/magiconair/properties v1.8.1
 	github.com/mr-tron/base58 v1.1.3
 	github.com/panjf2000/ants/v2 v2.2.2
-	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pkg/errors v0.9.1
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.6.2
 	github.com/stretchr/testify v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/DataDog/zstd v1.4.1 h1:3oxKN3wbHibqx897utPC2LTQU4J+IHWWJO+glkAkpFM=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
+github.com/Microsoft/go-winio v0.4.14 h1:+hMXMk01us9KgxGb7ftKQt2Xpf5hH/yky+TDA+qxleU=
+github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7 h1:uSoVVbwJiQipAclBbw+8quDsfcvFjOpI5iCf4p/cqCs=
@@ -57,6 +59,14 @@ github.com/dgryski/go-farm v0.0.0-20190323231341-8198c7b169ec/go.mod h1:SqUrOPUn
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
+github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+github.com/docker/docker v1.13.1 h1:IkZjBSIc8hBjLpqeAbeE5mca5mNgeatLHBy3GO78BWo=
+github.com/docker/docker v1.13.1/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
+github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
+github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
+github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/drand/bls12-381 v0.0.0-20200110233355-faca855b3a67 h1:+zwFBPeS6Tx0ShngG44wyJ8wBh8ENK9upPxN2fE58Uc=
 github.com/drand/bls12-381 v0.0.0-20200110233355-faca855b3a67/go.mod h1:HRtP9ULniFcAfoXvSrD5Kebk1e3/g4cvtBfjlT80PuQ=
 github.com/drand/drand v0.5.4 h1:DyCkE4YHy1klVtu0YgYiYtsryyzyc0x6Y78HM2C9Mws=
@@ -237,6 +247,7 @@ github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAm
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/simia-tech/env v0.1.0/go.mod h1:eVRQ7W5NXXHifpPAcTJ3r5EmoGgMn++dXfSVbZv3Opo=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
+github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
@@ -383,6 +394,7 @@ golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190403152447-81d4e9dc473e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190515120540-06a5c4944438/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e h1:D5TXcfTk7xF7hvieo4QErS3qqCB4teTffacDWr7CI+0=

--- a/go.sum
+++ b/go.sum
@@ -198,10 +198,7 @@ github.com/onsi/ginkgo v1.8.0 h1:VkHVNpR4iVnU8XQR6DBm8BqYjN7CRzw+xKUbVVbbW9w=
 github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.5.0 h1:izbySO9zDPmjJ8rDjLvkA2zJHIo+HkYXHnf7eN7SSyo=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
-<<<<<<< HEAD
-=======
 github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
->>>>>>> re-introduce go.mod into integration test dir
 github.com/panjf2000/ants/v2 v2.2.2 h1:TWzusBjq/IflXhy+/S6u5wmMLCBdJnB9tPIx9Zmhvok=
 github.com/panjf2000/ants/v2 v2.2.2/go.mod h1:1GFm8bV8nyCQvU5K4WvBCTG1/YBFOD2VzjffD8fV55A=
 github.com/pelletier/go-buffruneio v0.2.0/go.mod h1:JkE26KsDizTr40EUHkXVtNPvgGtbSNq5BcowyYOWdKo=
@@ -471,8 +468,3 @@ honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3 h1:3JgtbtFHMiCmsznwGVTUWbgGov+pVqnlf1dEJTNAXeM=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
-<<<<<<< HEAD
-=======
-sourcegraph.com/sourcegraph/go-diff v0.5.0/go.mod h1:kuch7UrkMzY0X+p9CRK03kfuPQ2zzQcaEFbx8wA8rck=
-sourcegraph.com/sqs/pbtypes v0.0.0-20180604144634-d3ebe8f20ae4/go.mod h1:ketZ/q3QxT9HOBeFhu6RdvsftgpsbFHBF5Cas6cDKZ0=
->>>>>>> re-introduce go.mod into integration test dir

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,6 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/DataDog/zstd v1.4.1 h1:3oxKN3wbHibqx897utPC2LTQU4J+IHWWJO+glkAkpFM=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
-github.com/Microsoft/go-winio v0.4.14 h1:+hMXMk01us9KgxGb7ftKQt2Xpf5hH/yky+TDA+qxleU=
-github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7 h1:uSoVVbwJiQipAclBbw+8quDsfcvFjOpI5iCf4p/cqCs=
@@ -59,14 +57,6 @@ github.com/dgryski/go-farm v0.0.0-20190323231341-8198c7b169ec/go.mod h1:SqUrOPUn
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
-github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
-github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v1.13.1 h1:IkZjBSIc8hBjLpqeAbeE5mca5mNgeatLHBy3GO78BWo=
-github.com/docker/docker v1.13.1/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
-github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
-github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
-github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
-github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/drand/bls12-381 v0.0.0-20200110233355-faca855b3a67 h1:+zwFBPeS6Tx0ShngG44wyJ8wBh8ENK9upPxN2fE58Uc=
 github.com/drand/bls12-381 v0.0.0-20200110233355-faca855b3a67/go.mod h1:HRtP9ULniFcAfoXvSrD5Kebk1e3/g4cvtBfjlT80PuQ=
 github.com/drand/drand v0.5.4 h1:DyCkE4YHy1klVtu0YgYiYtsryyzyc0x6Y78HM2C9Mws=
@@ -208,6 +198,10 @@ github.com/onsi/ginkgo v1.8.0 h1:VkHVNpR4iVnU8XQR6DBm8BqYjN7CRzw+xKUbVVbbW9w=
 github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.5.0 h1:izbySO9zDPmjJ8rDjLvkA2zJHIo+HkYXHnf7eN7SSyo=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+<<<<<<< HEAD
+=======
+github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
+>>>>>>> re-introduce go.mod into integration test dir
 github.com/panjf2000/ants/v2 v2.2.2 h1:TWzusBjq/IflXhy+/S6u5wmMLCBdJnB9tPIx9Zmhvok=
 github.com/panjf2000/ants/v2 v2.2.2/go.mod h1:1GFm8bV8nyCQvU5K4WvBCTG1/YBFOD2VzjffD8fV55A=
 github.com/pelletier/go-buffruneio v0.2.0/go.mod h1:JkE26KsDizTr40EUHkXVtNPvgGtbSNq5BcowyYOWdKo=
@@ -247,7 +241,6 @@ github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAm
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/simia-tech/env v0.1.0/go.mod h1:eVRQ7W5NXXHifpPAcTJ3r5EmoGgMn++dXfSVbZv3Opo=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
-github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
@@ -394,7 +387,6 @@ golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190403152447-81d4e9dc473e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190515120540-06a5c4944438/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e h1:D5TXcfTk7xF7hvieo4QErS3qqCB4teTffacDWr7CI+0=
@@ -479,3 +471,8 @@ honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3 h1:3JgtbtFHMiCmsznwGVTUWbgGov+pVqnlf1dEJTNAXeM=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
+<<<<<<< HEAD
+=======
+sourcegraph.com/sourcegraph/go-diff v0.5.0/go.mod h1:kuch7UrkMzY0X+p9CRK03kfuPQ2zzQcaEFbx8wA8rck=
+sourcegraph.com/sqs/pbtypes v0.0.0-20180604144634-d3ebe8f20ae4/go.mod h1:ketZ/q3QxT9HOBeFhu6RdvsftgpsbFHBF5Cas6cDKZ0=
+>>>>>>> re-introduce go.mod into integration test dir

--- a/go.sum
+++ b/go.sum
@@ -198,7 +198,6 @@ github.com/onsi/ginkgo v1.8.0 h1:VkHVNpR4iVnU8XQR6DBm8BqYjN7CRzw+xKUbVVbbW9w=
 github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.5.0 h1:izbySO9zDPmjJ8rDjLvkA2zJHIo+HkYXHnf7eN7SSyo=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
-github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
 github.com/panjf2000/ants/v2 v2.2.2 h1:TWzusBjq/IflXhy+/S6u5wmMLCBdJnB9tPIx9Zmhvok=
 github.com/panjf2000/ants/v2 v2.2.2/go.mod h1:1GFm8bV8nyCQvU5K4WvBCTG1/YBFOD2VzjffD8fV55A=
 github.com/pelletier/go-buffruneio v0.2.0/go.mod h1:JkE26KsDizTr40EUHkXVtNPvgGtbSNq5BcowyYOWdKo=

--- a/packages/binary/spammer/spammer.go
+++ b/packages/binary/spammer/spammer.go
@@ -6,24 +6,26 @@ import (
 
 	"github.com/iotaledger/hive.go/types"
 
-	"github.com/iotaledger/goshimmer/packages/binary/messagelayer/messagefactory"
+	"github.com/iotaledger/goshimmer/packages/binary/messagelayer/message"
 	"github.com/iotaledger/goshimmer/packages/binary/messagelayer/payload"
 )
 
+// IssuePayloadFunc is a function which issues a payload.
+type IssuePayloadFunc = func(payload payload.Payload) (*message.Message, error)
+
 // Spammer spams messages with a static data payload.
 type Spammer struct {
-	messageFactory *messagefactory.MessageFactory
+	issuePayloadFunc IssuePayloadFunc
 
 	processId      int64
 	shutdownSignal chan types.Empty
 }
 
 // New creates a new spammer.
-func New(messageFactory *messagefactory.MessageFactory) *Spammer {
+func New(issuePayloadFunc IssuePayloadFunc) *Spammer {
 	return &Spammer{
-		messageFactory: messageFactory,
-
-		shutdownSignal: make(chan types.Empty),
+		issuePayloadFunc: issuePayloadFunc,
+		shutdownSignal:   make(chan types.Empty),
 	}
 }
 
@@ -46,7 +48,8 @@ func (spammer *Spammer) run(mps int, processId int64) {
 			return
 		}
 
-		spammer.messageFactory.IssuePayload(payload.NewData([]byte("SPAM")))
+		// we don't care about errors or the actual issued message
+		_, _ = spammer.issuePayloadFunc(payload.NewData([]byte("SPAM")))
 
 		currentSentCounter++
 

--- a/packages/shutdown/order.go
+++ b/packages/shutdown/order.go
@@ -12,7 +12,7 @@ const (
 	PriorityWebAPI
 	PriorityDashboard
 	PrioritySynchronization
-	PriorityGraph
+	PriorityBootstrap
 	PrioritySpammer
 	PriorityBadgerGarbageCollection
 )

--- a/packages/shutdown/order.go
+++ b/packages/shutdown/order.go
@@ -11,6 +11,7 @@ const (
 	PriorityGossip
 	PriorityWebAPI
 	PriorityDashboard
+	PrioritySynchronization
 	PriorityGraph
 	PrioritySpammer
 	PriorityBadgerGarbageCollection

--- a/pluginmgr/core/plugins.go
+++ b/pluginmgr/core/plugins.go
@@ -3,6 +3,7 @@ package core
 import (
 	"github.com/iotaledger/goshimmer/plugins/autopeering"
 	"github.com/iotaledger/goshimmer/plugins/banner"
+	"github.com/iotaledger/goshimmer/plugins/bootstrap"
 	"github.com/iotaledger/goshimmer/plugins/cli"
 	"github.com/iotaledger/goshimmer/plugins/config"
 	"github.com/iotaledger/goshimmer/plugins/database"
@@ -29,6 +30,7 @@ var PLUGINS = node.Plugins(
 	autopeering.Plugin,
 	messagelayer.Plugin,
 	gossip.Plugin,
+	bootstrap.Plugin,
 	gracefulshutdown.Plugin,
 	metrics.Plugin,
 	drng.Plugin,

--- a/pluginmgr/core/plugins.go
+++ b/pluginmgr/core/plugins.go
@@ -10,11 +10,13 @@ import (
 	"github.com/iotaledger/goshimmer/plugins/drng"
 	"github.com/iotaledger/goshimmer/plugins/gossip"
 	"github.com/iotaledger/goshimmer/plugins/gracefulshutdown"
+	"github.com/iotaledger/goshimmer/plugins/issuer"
 	"github.com/iotaledger/goshimmer/plugins/logger"
 	"github.com/iotaledger/goshimmer/plugins/messagelayer"
 	"github.com/iotaledger/goshimmer/plugins/metrics"
 	"github.com/iotaledger/goshimmer/plugins/portcheck"
 	"github.com/iotaledger/goshimmer/plugins/profiling"
+	"github.com/iotaledger/goshimmer/plugins/sync"
 
 	"github.com/iotaledger/hive.go/node"
 )
@@ -30,7 +32,9 @@ var PLUGINS = node.Plugins(
 	autopeering.Plugin,
 	messagelayer.Plugin,
 	gossip.Plugin,
+	issuer.Plugin,
 	bootstrap.Plugin,
+	sync.Plugin,
 	gracefulshutdown.Plugin,
 	metrics.Plugin,
 	drng.Plugin,

--- a/plugins/bootstrap/plugin.go
+++ b/plugins/bootstrap/plugin.go
@@ -1,0 +1,231 @@
+package bootstrap
+
+import (
+	"sync"
+	"time"
+
+	"github.com/iotaledger/goshimmer/packages/binary/messagelayer/message"
+	"github.com/iotaledger/goshimmer/packages/binary/messagelayer/tangle"
+	"github.com/iotaledger/goshimmer/packages/binary/spammer"
+	"github.com/iotaledger/goshimmer/plugins/config"
+	"github.com/iotaledger/goshimmer/plugins/messagelayer"
+	"github.com/iotaledger/hive.go/daemon"
+	"github.com/iotaledger/hive.go/events"
+	"github.com/iotaledger/hive.go/logger"
+	"github.com/iotaledger/hive.go/node"
+	"github.com/iotaledger/hive.go/types"
+	flag "github.com/spf13/pflag"
+	"go.uber.org/atomic"
+)
+
+const (
+	// PluginName is the plugin name of the bootstrap plugin.
+	PluginName = "Bootstrap"
+	// CfgBootstrapMode defines whether the node starts in bootstrapping mode.
+	CfgBootstrapMode = "bootstrap.mode"
+	// CfgBootstrapInitialIssuanceTimePeriodSec defines the initial time period of how long the node should be
+	// issuing messages when started in bootstrapping mode. If the value is set to -1, the issuance is continuous.
+	CfgBootstrapInitialIssuanceTimePeriodSec = "bootstrap.initialIssuance.timePeriodSec"
+	// CfgBootstrapSyncAnchorPointsCount defines the amount of anchor points to use to determine whether a node is
+	// synchronized when not running in bootstrapping mode.
+	CfgBootstrapSyncAnchorPointsCount = "bootstrap.syncAnchorPointsCount"
+	// the messages per second to issue when in bootstrapping mode.
+	initialIssuanceMPS = 1
+	// the value which determines a continuous issuance of messages from the bootstrap plugin.
+	continuousIssuance = -1
+)
+
+func init() {
+	flag.Bool(CfgBootstrapMode, false, "whether the node should be started in bootstrapping mode or not.")
+	flag.Int(CfgBootstrapInitialIssuanceTimePeriodSec, -1, "the initial time period of how long the node should be issuing messages when started in bootstrapping mode. "+
+		"If the value is set to -1, the issuance is continuous.")
+	flag.Int(CfgBootstrapSyncAnchorPointsCount, 3, "the amount of anchor points to use to determine whether a node is synchronized when not running in bootstrapping mode")
+}
+
+var (
+	// Plugin is the plugin instance of the bootstrap plugin.
+	Plugin         = node.NewPlugin(PluginName, node.Enabled, configure, run)
+	log            *logger.Logger
+	synchronized   atomic.Bool
+	anchorPoints   *anchorpoints
+	detachHandlers func()
+)
+
+// Synchronized tells whether the node is in a state we consider synchronized, meaning
+// it has the relevant past and present message data.
+func Synchronized() bool {
+	return synchronized.Load()
+}
+
+func configure(_ *node.Plugin) {
+	log = logger.NewLogger(PluginName)
+
+	if config.Node.GetBool(CfgBootstrapMode) {
+		log.Infof("starting node in bootstrapping mode")
+		// auto. synced if in bootstrapping mode
+		synchronized.Store(true)
+		return
+	}
+
+	wantedAnchorPointsCount := config.Node.GetInt(CfgBootstrapSyncAnchorPointsCount)
+	anchorPoints = &anchorpoints{
+		ids:    make(map[message.Id]types.Empty),
+		wanted: wantedAnchorPointsCount,
+	}
+
+	log.Infof("starting node in non-bootstrapping mode, awaiting %d anchor point messages to become solid", wantedAnchorPointsCount)
+
+	// only register anchor event handlers when we're not in bootstrap mode
+	detachHandlers = registerMessageHandlers()
+}
+
+func run(_ *node.Plugin) {
+	if !config.Node.GetBool(CfgBootstrapMode) {
+		return
+	}
+
+	messageSpammer := spammer.New(messagelayer.MessageFactory)
+	issuancePeriodSec := config.Node.GetInt(CfgBootstrapInitialIssuanceTimePeriodSec)
+	issuancePeriod := time.Duration(issuancePeriodSec) * time.Second
+
+	// issue messages on top of the genesis
+	_ = daemon.BackgroundWorker("Bootstrapping-Issuer", func(shutdownSignal <-chan struct{}) {
+		messageSpammer.Start(initialIssuanceMPS)
+		defer messageSpammer.Shutdown()
+		// don't stop issuing messages if in continuous mode
+		if issuancePeriodSec == continuousIssuance {
+			log.Info("continuously issuing bootstrapping messages")
+			<-shutdownSignal
+			return
+		}
+		log.Infof("issuing bootstrapping messages for %d seconds", issuancePeriodSec)
+		select {
+		case <-time.After(issuancePeriod):
+		case <-shutdownSignal:
+		}
+	})
+}
+
+// registers the event handler for checking the anchor message state
+// and returns a function to detach those event handlers.
+func registerMessageHandlers() func() {
+	initAnchorPointClosure := events.NewClosure(initAnchorPoint)
+	checkAnchorPointSolidityClosure := events.NewClosure(checkAnchorPointSolidity)
+	messagelayer.Tangle.Events.MessageAttached.Attach(initAnchorPointClosure)
+	messagelayer.Tangle.Events.MessageSolid.Attach(checkAnchorPointSolidityClosure)
+	return func() {
+		messagelayer.Tangle.Events.MessageAttached.Detach(initAnchorPointClosure)
+		messagelayer.Tangle.Events.MessageSolid.Detach(checkAnchorPointSolidityClosure)
+	}
+}
+
+// fills up the anchor points with newly attached messages which then are used to determine whether we are synchronized.
+func initAnchorPoint(cachedMessage *message.CachedMessage, cachedMessageMetadata *tangle.CachedMessageMetadata) {
+	defer cachedMessage.Release()
+	defer cachedMessageMetadata.Release()
+	if synchronized.Load() {
+		return
+	}
+
+	anchorPoints.Lock()
+	defer anchorPoints.Unlock()
+
+	// we don't need to add additional anchor points if the set was already filled once
+	if anchorPoints.wasFilled() {
+		return
+	}
+
+	// as a rule, we don't consider messages attaching directly to genesis anchors
+	msg := cachedMessage.Unwrap()
+	if msg.TrunkId() == message.EmptyId || msg.BranchId() == message.EmptyId {
+		return
+	}
+
+	// add a new anchor point
+	anchorPoints.add(msg.Id())
+	log.Infof("added message %s as synchronization anchor point (%d of %d collected)", msg.Id(), anchorPoints.collectedCount(), anchorPoints.wanted)
+}
+
+// checks whether an anchor point message became solid.
+// if all anchor points became solid, it sets the node's state to synchronized.
+func checkAnchorPointSolidity(cachedMessage *message.CachedMessage, cachedMessageMetadata *tangle.CachedMessageMetadata) {
+	defer cachedMessage.Release()
+	defer cachedMessageMetadata.Release()
+
+	anchorPoints.Lock()
+	defer anchorPoints.Unlock()
+
+	if synchronized.Load() || len(anchorPoints.ids) == 0 {
+		return
+	}
+
+	// check whether an anchor message become solid
+	msgID := cachedMessage.Unwrap().Id()
+	if !anchorPoints.has(msgID) {
+		return
+	}
+
+	// an anchor became solid
+	log.Infof("anchor message %s has become solid", msgID)
+	anchorPoints.markAsSolidified(msgID)
+
+	if !anchorPoints.wereAllSolidified() {
+		return
+	}
+
+	// all anchor points have become solid
+	log.Infof("all anchor messages have become solid, setting node as synchronized", msgID)
+	synchronized.Store(true)
+
+	// since we now are synchronized, we no longer need to listen to this events,
+	// however, we need to detach in a separate goroutine, since this function
+	// runs within the event handlers loop
+	if detachHandlers == nil {
+		return
+	}
+	go detachHandlers()
+}
+
+// anchorpoints are a set of messages which we use to determine whether the node has become synchronized.
+type anchorpoints struct {
+	sync.Mutex
+	// the ids of the anchor points.
+	ids map[message.Id]types.Empty
+	// the wanted amount of anchor points which should become solid.
+	wanted int
+	// how many anchor points have been solidified.
+	solidified int
+}
+
+// adds the given message to the anchor points set.
+func (ap *anchorpoints) add(id message.Id) {
+	ap.ids[id] = types.Empty{}
+}
+
+func (ap *anchorpoints) has(id message.Id) bool {
+	_, has := ap.ids[id]
+	return has
+}
+
+// marks the given anchor point as solidified which removes it from the set and bumps the solidified count.
+func (ap *anchorpoints) markAsSolidified(id message.Id) {
+	delete(ap.ids, id)
+	ap.solidified++
+}
+
+// tells whether the anchor points set was filled at some point.
+func (ap *anchorpoints) wasFilled() bool {
+	return ap.collectedCount() == ap.wanted
+}
+
+// tells whether all anchor points have become solid.
+func (ap *anchorpoints) wereAllSolidified() bool {
+	return ap.solidified == ap.wanted
+}
+
+// tells the number of effectively collected anchor points.
+func (ap *anchorpoints) collectedCount() int {
+	// since an anchor point potentially was solidified before the set became full,
+	// we need to incorporate that count too
+	return ap.solidified + len(ap.ids)
+}

--- a/plugins/bootstrap/plugin.go
+++ b/plugins/bootstrap/plugin.go
@@ -1,34 +1,24 @@
 package bootstrap
 
 import (
-	"sync"
 	"time"
 
-	"github.com/iotaledger/goshimmer/packages/binary/messagelayer/message"
-	"github.com/iotaledger/goshimmer/packages/binary/messagelayer/tangle"
 	"github.com/iotaledger/goshimmer/packages/binary/spammer"
 	"github.com/iotaledger/goshimmer/plugins/config"
-	"github.com/iotaledger/goshimmer/plugins/messagelayer"
+	"github.com/iotaledger/goshimmer/plugins/issuer"
+	"github.com/iotaledger/goshimmer/plugins/sync"
 	"github.com/iotaledger/hive.go/daemon"
-	"github.com/iotaledger/hive.go/events"
 	"github.com/iotaledger/hive.go/logger"
 	"github.com/iotaledger/hive.go/node"
-	"github.com/iotaledger/hive.go/types"
 	flag "github.com/spf13/pflag"
-	"go.uber.org/atomic"
 )
 
 const (
 	// PluginName is the plugin name of the bootstrap plugin.
 	PluginName = "Bootstrap"
-	// CfgBootstrapMode defines whether the node starts in bootstrapping mode.
-	CfgBootstrapMode = "bootstrap.mode"
 	// CfgBootstrapInitialIssuanceTimePeriodSec defines the initial time period of how long the node should be
 	// issuing messages when started in bootstrapping mode. If the value is set to -1, the issuance is continuous.
 	CfgBootstrapInitialIssuanceTimePeriodSec = "bootstrap.initialIssuance.timePeriodSec"
-	// CfgBootstrapSyncAnchorPointsCount defines the amount of anchor points to use to determine whether a node is
-	// synchronized when not running in bootstrapping mode.
-	CfgBootstrapSyncAnchorPointsCount = "bootstrap.syncAnchorPointsCount"
 	// the messages per second to issue when in bootstrapping mode.
 	initialIssuanceMPS = 1
 	// the value which determines a continuous issuance of messages from the bootstrap plugin.
@@ -36,55 +26,26 @@ const (
 )
 
 func init() {
-	flag.Bool(CfgBootstrapMode, false, "whether the node should be started in bootstrapping mode or not.")
 	flag.Int(CfgBootstrapInitialIssuanceTimePeriodSec, -1, "the initial time period of how long the node should be issuing messages when started in bootstrapping mode. "+
-		"If the value is set to -1, the issuance is continuous.")
-	flag.Int(CfgBootstrapSyncAnchorPointsCount, 3, "the amount of anchor points to use to determine whether a node is synchronized when not running in bootstrapping mode")
+		"if the value is set to -1, the issuance is continuous.")
 }
 
 var (
 	// Plugin is the plugin instance of the bootstrap plugin.
-	Plugin         = node.NewPlugin(PluginName, node.Enabled, configure, run)
-	log            *logger.Logger
-	synchronized   atomic.Bool
-	anchorPoints   *anchorpoints
-	detachHandlers func()
+	Plugin = node.NewPlugin(PluginName, node.Disabled, configure, run)
+	log    *logger.Logger
 )
-
-// Synchronized tells whether the node is in a state we consider synchronized, meaning
-// it has the relevant past and present message data.
-func Synchronized() bool {
-	return synchronized.Load()
-}
 
 func configure(_ *node.Plugin) {
 	log = logger.NewLogger(PluginName)
-
-	if config.Node.GetBool(CfgBootstrapMode) {
-		log.Infof("starting node in bootstrapping mode")
-		// auto. synced if in bootstrapping mode
-		synchronized.Store(true)
-		return
-	}
-
-	wantedAnchorPointsCount := config.Node.GetInt(CfgBootstrapSyncAnchorPointsCount)
-	anchorPoints = &anchorpoints{
-		ids:    make(map[message.Id]types.Empty),
-		wanted: wantedAnchorPointsCount,
-	}
-
-	log.Infof("starting node in non-bootstrapping mode, awaiting %d anchor point messages to become solid", wantedAnchorPointsCount)
-
-	// only register anchor event handlers when we're not in bootstrap mode
-	detachHandlers = registerMessageHandlers()
+	// we're auto. synced if we start in bootstrapping mode
+	sync.OverwriteSyncedState(true)
+	log.Infof("starting node in bootstrapping mode")
 }
 
 func run(_ *node.Plugin) {
-	if !config.Node.GetBool(CfgBootstrapMode) {
-		return
-	}
 
-	messageSpammer := spammer.New(messagelayer.MessageFactory)
+	messageSpammer := spammer.New(issuer.IssuePayload)
 	issuancePeriodSec := config.Node.GetInt(CfgBootstrapInitialIssuanceTimePeriodSec)
 	issuancePeriod := time.Duration(issuancePeriodSec) * time.Second
 
@@ -104,128 +65,4 @@ func run(_ *node.Plugin) {
 		case <-shutdownSignal:
 		}
 	})
-}
-
-// registers the event handler for checking the anchor message state
-// and returns a function to detach those event handlers.
-func registerMessageHandlers() func() {
-	initAnchorPointClosure := events.NewClosure(initAnchorPoint)
-	checkAnchorPointSolidityClosure := events.NewClosure(checkAnchorPointSolidity)
-	messagelayer.Tangle.Events.MessageAttached.Attach(initAnchorPointClosure)
-	messagelayer.Tangle.Events.MessageSolid.Attach(checkAnchorPointSolidityClosure)
-	return func() {
-		messagelayer.Tangle.Events.MessageAttached.Detach(initAnchorPointClosure)
-		messagelayer.Tangle.Events.MessageSolid.Detach(checkAnchorPointSolidityClosure)
-	}
-}
-
-// fills up the anchor points with newly attached messages which then are used to determine whether we are synchronized.
-func initAnchorPoint(cachedMessage *message.CachedMessage, cachedMessageMetadata *tangle.CachedMessageMetadata) {
-	defer cachedMessage.Release()
-	defer cachedMessageMetadata.Release()
-	if synchronized.Load() {
-		return
-	}
-
-	anchorPoints.Lock()
-	defer anchorPoints.Unlock()
-
-	// we don't need to add additional anchor points if the set was already filled once
-	if anchorPoints.wasFilled() {
-		return
-	}
-
-	// as a rule, we don't consider messages attaching directly to genesis anchors
-	msg := cachedMessage.Unwrap()
-	if msg.TrunkId() == message.EmptyId || msg.BranchId() == message.EmptyId {
-		return
-	}
-
-	// add a new anchor point
-	anchorPoints.add(msg.Id())
-	log.Infof("added message %s as synchronization anchor point (%d of %d collected)", msg.Id().String()[:10], anchorPoints.collectedCount(), anchorPoints.wanted)
-}
-
-// checks whether an anchor point message became solid.
-// if all anchor points became solid, it sets the node's state to synchronized.
-func checkAnchorPointSolidity(cachedMessage *message.CachedMessage, cachedMessageMetadata *tangle.CachedMessageMetadata) {
-	defer cachedMessage.Release()
-	defer cachedMessageMetadata.Release()
-
-	anchorPoints.Lock()
-	defer anchorPoints.Unlock()
-
-	if synchronized.Load() || len(anchorPoints.ids) == 0 {
-		return
-	}
-
-	// check whether an anchor message become solid
-	msgID := cachedMessage.Unwrap().Id()
-	if !anchorPoints.has(msgID) {
-		return
-	}
-
-	// an anchor became solid
-	log.Infof("anchor message %s has become solid", msgID.String()[:10])
-	anchorPoints.markAsSolidified(msgID)
-
-	if !anchorPoints.wereAllSolidified() {
-		return
-	}
-
-	// all anchor points have become solid
-	log.Infof("all anchor messages have become solid, setting node as synchronized")
-	synchronized.Store(true)
-
-	// since we now are synchronized, we no longer need to listen to this events,
-	// however, we need to detach in a separate goroutine, since this function
-	// runs within the event handlers loop
-	if detachHandlers == nil {
-		return
-	}
-	go detachHandlers()
-}
-
-// anchorpoints are a set of messages which we use to determine whether the node has become synchronized.
-type anchorpoints struct {
-	sync.Mutex
-	// the ids of the anchor points.
-	ids map[message.Id]types.Empty
-	// the wanted amount of anchor points which should become solid.
-	wanted int
-	// how many anchor points have been solidified.
-	solidified int
-}
-
-// adds the given message to the anchor points set.
-func (ap *anchorpoints) add(id message.Id) {
-	ap.ids[id] = types.Empty{}
-}
-
-func (ap *anchorpoints) has(id message.Id) bool {
-	_, has := ap.ids[id]
-	return has
-}
-
-// marks the given anchor point as solidified which removes it from the set and bumps the solidified count.
-func (ap *anchorpoints) markAsSolidified(id message.Id) {
-	delete(ap.ids, id)
-	ap.solidified++
-}
-
-// tells whether the anchor points set was filled at some point.
-func (ap *anchorpoints) wasFilled() bool {
-	return ap.collectedCount() == ap.wanted
-}
-
-// tells whether all anchor points have become solid.
-func (ap *anchorpoints) wereAllSolidified() bool {
-	return ap.solidified == ap.wanted
-}
-
-// tells the number of effectively collected anchor points.
-func (ap *anchorpoints) collectedCount() int {
-	// since an anchor point potentially was solidified before the set became full,
-	// we need to incorporate that count too
-	return ap.solidified + len(ap.ids)
 }

--- a/plugins/bootstrap/plugin.go
+++ b/plugins/bootstrap/plugin.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/iotaledger/goshimmer/packages/binary/spammer"
+	"github.com/iotaledger/goshimmer/packages/shutdown"
 	"github.com/iotaledger/goshimmer/plugins/config"
 	"github.com/iotaledger/goshimmer/plugins/issuer"
 	"github.com/iotaledger/goshimmer/plugins/sync"
@@ -64,5 +65,5 @@ func run(_ *node.Plugin) {
 		case <-time.After(issuancePeriod):
 		case <-shutdownSignal:
 		}
-	})
+	}, shutdown.PriorityBootstrap)
 }

--- a/plugins/bootstrap/plugin.go
+++ b/plugins/bootstrap/plugin.go
@@ -143,7 +143,7 @@ func initAnchorPoint(cachedMessage *message.CachedMessage, cachedMessageMetadata
 
 	// add a new anchor point
 	anchorPoints.add(msg.Id())
-	log.Infof("added message %s as synchronization anchor point (%d of %d collected)", msg.Id(), anchorPoints.collectedCount(), anchorPoints.wanted)
+	log.Infof("added message %s as synchronization anchor point (%d of %d collected)", msg.Id().String()[:10], anchorPoints.collectedCount(), anchorPoints.wanted)
 }
 
 // checks whether an anchor point message became solid.
@@ -166,7 +166,7 @@ func checkAnchorPointSolidity(cachedMessage *message.CachedMessage, cachedMessag
 	}
 
 	// an anchor became solid
-	log.Infof("anchor message %s has become solid", msgID)
+	log.Infof("anchor message %s has become solid", msgID.String()[:10])
 	anchorPoints.markAsSolidified(msgID)
 
 	if !anchorPoints.wereAllSolidified() {
@@ -174,7 +174,7 @@ func checkAnchorPointSolidity(cachedMessage *message.CachedMessage, cachedMessag
 	}
 
 	// all anchor points have become solid
-	log.Infof("all anchor messages have become solid, setting node as synchronized", msgID)
+	log.Infof("all anchor messages have become solid, setting node as synchronized")
 	synchronized.Store(true)
 
 	// since we now are synchronized, we no longer need to listen to this events,

--- a/plugins/issuer/plugin.go
+++ b/plugins/issuer/plugin.go
@@ -1,0 +1,34 @@
+package issuer
+
+import (
+	"fmt"
+
+	"github.com/iotaledger/goshimmer/packages/binary/messagelayer/message"
+	"github.com/iotaledger/goshimmer/packages/binary/messagelayer/payload"
+	"github.com/iotaledger/goshimmer/plugins/messagelayer"
+	"github.com/iotaledger/goshimmer/plugins/sync"
+	"github.com/iotaledger/hive.go/logger"
+	"github.com/iotaledger/hive.go/node"
+)
+
+// PluginName is the name of the issuer plugin.
+const PluginName = "Issuer"
+
+var (
+	// Plugin is the plugin instance of the issuer plugin.
+	Plugin = node.NewPlugin(PluginName, node.Enabled, configure)
+	log    *logger.Logger
+)
+
+func configure(_ *node.Plugin) {
+	log = logger.NewLogger(PluginName)
+}
+
+// IssuePayload issues a payload to the message layer.
+// If the node is not synchronized an error is returned.
+func IssuePayload(payload payload.Payload) (*message.Message, error) {
+	if !sync.Synced() {
+		return nil, fmt.Errorf("can't issue payload: %w", sync.ErrNodeNotSynchronized)
+	}
+	return messagelayer.MessageFactory.IssuePayload(payload), nil
+}

--- a/plugins/issuer/plugin.go
+++ b/plugins/issuer/plugin.go
@@ -7,7 +7,6 @@ import (
 	"github.com/iotaledger/goshimmer/packages/binary/messagelayer/payload"
 	"github.com/iotaledger/goshimmer/plugins/messagelayer"
 	"github.com/iotaledger/goshimmer/plugins/sync"
-	"github.com/iotaledger/hive.go/logger"
 	"github.com/iotaledger/hive.go/node"
 )
 
@@ -17,12 +16,9 @@ const PluginName = "Issuer"
 var (
 	// Plugin is the plugin instance of the issuer plugin.
 	Plugin = node.NewPlugin(PluginName, node.Enabled, configure)
-	log    *logger.Logger
 )
 
-func configure(_ *node.Plugin) {
-	log = logger.NewLogger(PluginName)
-}
+func configure(_ *node.Plugin) {}
 
 // IssuePayload issues a payload to the message layer.
 // If the node is not synchronized an error is returned.

--- a/plugins/sync/plugin.go
+++ b/plugins/sync/plugin.go
@@ -33,7 +33,7 @@ const (
 	// of how long it should take for an anchor point to become solid. Even if this value is set too low, usually a node
 	// would eventually solidify collected anchor points.
 	CfgSyncAnchorPointsCleanupAfterSec = "sync.anchorPointsCleanupAfterSec"
-	// CfgSyncAnchorPointsCleanupAfterSec defines the interval at which it is checked whether anchor points fall
+	// CfgSyncAnchorPointsCleanupIntervalSec defines the interval at which it is checked whether anchor points fall
 	// into the cleanup window.
 	CfgSyncAnchorPointsCleanupIntervalSec = "sync.anchorPointsCleanupIntervalSec"
 	// CfgSyncDesyncedIfNoMessageAfterSec defines the time period in which new messages must be received and if not
@@ -133,7 +133,6 @@ func monitorForDesynchronization() {
 	daemon.BackgroundWorker("Desync-Monitor", func(shutdownSignal <-chan struct{}) {
 		gossip.Manager().Events().NeighborRemoved.Attach(monitorPeerCountClosure)
 		defer gossip.Manager().Events().NeighborRemoved.Detach(monitorPeerCountClosure)
-		// TODO: replace with MessageSolid
 		messagelayer.Tangle.Events.MessageAttached.Attach(monitorMessageInflowClosure)
 		defer messagelayer.Tangle.Events.MessageAttached.Detach(monitorMessageInflowClosure)
 

--- a/plugins/sync/plugin.go
+++ b/plugins/sync/plugin.go
@@ -28,7 +28,7 @@ const (
 	// CfgSyncAnchorPointsCount defines the amount of anchor points to use to determine
 	// whether a node is synchronized.
 	CfgSyncAnchorPointsCount = "sync.anchorPointsCount"
-	// CfgSyncAnchorPointsCount defines the time period in which new messages must be received and if not
+	// CfgSyncDesyncedIfNoMessageInSec defines the time period in which new messages must be received and if not
 	// the node is marked as desynced.
 	CfgSyncDesyncedIfNoMessageInSec = "sync.desyncedIfNoMessagesInSec"
 )

--- a/plugins/sync/plugin.go
+++ b/plugins/sync/plugin.go
@@ -2,11 +2,17 @@ package sync
 
 import (
 	"sync"
+	"time"
 
 	"github.com/iotaledger/goshimmer/packages/binary/messagelayer/message"
 	"github.com/iotaledger/goshimmer/packages/binary/messagelayer/tangle"
+	"github.com/iotaledger/goshimmer/packages/shutdown"
+	"github.com/iotaledger/goshimmer/plugins/autopeering/local"
 	"github.com/iotaledger/goshimmer/plugins/config"
+	"github.com/iotaledger/goshimmer/plugins/gossip"
 	"github.com/iotaledger/goshimmer/plugins/messagelayer"
+	"github.com/iotaledger/hive.go/autopeering/peer"
+	"github.com/iotaledger/hive.go/daemon"
 	"github.com/iotaledger/hive.go/events"
 	"github.com/iotaledger/hive.go/logger"
 	"github.com/iotaledger/hive.go/node"
@@ -22,75 +28,184 @@ const (
 	// CfgSyncAnchorPointsCount defines the amount of anchor points to use to determine
 	// whether a node is synchronized.
 	CfgSyncAnchorPointsCount = "sync.anchorPointsCount"
+	// CfgSyncAnchorPointsCount defines the time period in which new messages must be received and if not
+	// the node is marked as desynced.
+	CfgSyncDesyncedIfNoMessageInSec = "sync.desyncedIfNoMessagesInSec"
 )
 
 func init() {
 	flag.Int(CfgSyncAnchorPointsCount, 3, "the amount of anchor points to use to determine whether a node is synchronized")
+	flag.Int(CfgSyncDesyncedIfNoMessageInSec, 300, "the time period in seconds which sets the node as desynced if no new messages are received")
 }
 
 var (
 	// Plugin is the plugin instance of the sync plugin.
-	Plugin = node.NewPlugin(PluginName, node.Enabled, configure)
+	Plugin = node.NewPlugin(PluginName, node.Enabled, configure, run)
 	// ErrNodeNotSynchronized is returned when an operation can't be executed because
 	// the node is not synchronized.
 	ErrNodeNotSynchronized = errors.New("node is not synchronized")
-	log                    *logger.Logger
-	synchronized           atomic.Bool
-	anchorPoints           *anchorpoints
-	detachHandlers         func()
+	// tells whether the node is synced or not.
+	synced atomic.Bool
+	log    *logger.Logger
 )
 
 // Synced tells whether the node is in a state we consider synchronized, meaning
 // it has the relevant past and present message data.
 func Synced() bool {
-	return synchronized.Load()
+	return synced.Load()
 }
 
 // OverwriteSyncedState overwrites the synced state with the given value.
-func OverwriteSyncedState(synced bool) {
-	synchronized.Store(synced)
+func OverwriteSyncedState(syncedOverwrite bool) {
+	synced.Store(syncedOverwrite)
 }
 
 func configure(_ *node.Plugin) {
 	log = logger.NewLogger(PluginName)
+}
 
-	// another plugin might overwrite the sync state while configuring itself,
-	// for example the bootstrap plugin, implying that we don't need to register any handlers
-	if Synced() {
+func run(_ *node.Plugin) {
+	// per default the node starts in a desynced state
+	if !Synced() {
+		monitorForSynchronization()
 		return
 	}
 
-	wantedAnchorPointsCount := config.Node.GetInt(CfgSyncAnchorPointsCount)
-	anchorPoints = &anchorpoints{
-		ids:    make(map[message.Id]types.Empty),
-		wanted: wantedAnchorPointsCount,
-	}
-
-	log.Infof("starting node in non-bootstrapping mode, awaiting %d anchor point messages to become solid", wantedAnchorPointsCount)
-
-	// only register anchor event handlers when we're not in bootstrap mode
-	detachHandlers = registerMessageHandlers()
+	// however, another plugin might want to overwrite the synced state (i.e. the bootstrap plugin)
+	// in order to start issuing messages
+	monitorForDesynchronization()
 }
 
-// registers the event handler for checking the anchor message state
-// and returns a function to detach those event handlers.
-func registerMessageHandlers() func() {
-	initAnchorPointClosure := events.NewClosure(initAnchorPoint)
-	checkAnchorPointSolidityClosure := events.NewClosure(checkAnchorPointSolidity)
-	messagelayer.Tangle.Events.MessageAttached.Attach(initAnchorPointClosure)
-	messagelayer.Tangle.Events.MessageSolid.Attach(checkAnchorPointSolidityClosure)
-	return func() {
-		messagelayer.Tangle.Events.MessageAttached.Detach(initAnchorPointClosure)
-		messagelayer.Tangle.Events.MessageSolid.Detach(checkAnchorPointSolidityClosure)
-	}
+// marks the node as synced and spawns the background worker to monitor desynchronization.
+func markSynced() {
+	synced.Store(true)
+	monitorForDesynchronization()
+}
+
+// marks the node as desynced and spawns the background worker to monitor synchronization.
+func markDesynced() {
+	synced.Store(false)
+	monitorForSynchronization()
+}
+
+// starts a background worker and event handlers to check whether the node is desynchronized by checking
+// whether the node has no more peers or didn't receive any message in a given time period.
+func monitorForDesynchronization() {
+	log.Info("monitoring for desynchronization")
+
+	// monitors the peer count of the manager and sets the node as desynced if it has no more peers.
+	noPeers := make(chan types.Empty)
+	monitorPeerCountClosure := events.NewClosure(func(_ *peer.Peer) {
+		anyPeers := len(gossip.Manager().AllNeighbors()) > 0
+		if anyPeers {
+			return
+		}
+		noPeers <- types.Empty{}
+	})
+
+	msgReceived := make(chan types.Empty, 1)
+
+	monitorMessageInflowClosure := events.NewClosure(func(cachedMessage *message.CachedMessage, cachedMessageMetadata *tangle.CachedMessageMetadata) {
+		defer cachedMessage.Release()
+		defer cachedMessageMetadata.Release()
+		// ignore messages sent by the node itself
+		if local.GetInstance().LocalIdentity().PublicKey() == cachedMessage.Unwrap().IssuerPublicKey() {
+			return
+		}
+		select {
+		case msgReceived <- types.Empty{}:
+		default:
+		}
+	})
+
+	daemon.BackgroundWorker("Desync-Monitor", func(shutdownSignal <-chan struct{}) {
+		gossip.Manager().Events().NeighborRemoved.Attach(monitorPeerCountClosure)
+		defer gossip.Manager().Events().NeighborRemoved.Detach(monitorPeerCountClosure)
+		messagelayer.Tangle.Events.MessageAttached.Attach(monitorMessageInflowClosure)
+		defer messagelayer.Tangle.Events.MessageAttached.Detach(monitorMessageInflowClosure)
+
+		desyncedIfNoMessageInSec := config.Node.GetDuration(CfgSyncDesyncedIfNoMessageInSec) * time.Second
+		timer := time.NewTimer(desyncedIfNoMessageInSec)
+		for {
+			select {
+
+			case <-msgReceived:
+				// we received a message, therefore reset the timer to check for message receives
+				if !timer.Stop() {
+					<-timer.C
+				}
+				// TODO: perhaps find a better way instead of constantly resetting the timer
+				timer.Reset(desyncedIfNoMessageInSec)
+
+			case <-timer.C:
+				log.Infof("no message received in %d seconds, marking node as desynced", desyncedIfNoMessageInSec)
+				markDesynced()
+				return
+
+			case <-noPeers:
+				log.Info("all peers have been lost, marking node as desynced")
+				markDesynced()
+
+			case <-shutdownSignal:
+				return
+			}
+		}
+	}, shutdown.PrioritySynchronization)
+}
+
+// starts a background worker and event handlers to check whether the node is synchronized by first collecting
+// a set of newly received messages and then waiting for them to become solid.
+func monitorForSynchronization() {
+	wantedAnchorPointsCount := config.Node.GetInt(CfgSyncAnchorPointsCount)
+	anchorPoints := newAnchorPoints(wantedAnchorPointsCount)
+	log.Infof("monitoring for synchronization, awaiting %d anchor point messages to become solid", wantedAnchorPointsCount)
+
+	synced := make(chan types.Empty)
+
+	initAnchorPointClosure := events.NewClosure(func(cachedMessage *message.CachedMessage, cachedMessageMetadata *tangle.CachedMessageMetadata) {
+		defer cachedMessage.Release()
+		defer cachedMessageMetadata.Release()
+		if addedAnchorID := initAnchorPoint(anchorPoints, cachedMessage.Unwrap()); addedAnchorID != nil {
+			anchorPoints.Lock()
+			defer anchorPoints.Unlock()
+			log.Infof("added message %s as anchor point (%d of %d collected)", addedAnchorID.String()[:10], anchorPoints.collectedCount(), anchorPoints.wanted)
+		}
+	})
+
+	checkAnchorPointSolidityClosure := events.NewClosure(func(cachedMessage *message.CachedMessage, cachedMessageMetadata *tangle.CachedMessageMetadata) {
+		defer cachedMessage.Release()
+		defer cachedMessageMetadata.Release()
+		allSolid, newSolidAnchorID := checkAnchorPointSolidity(anchorPoints, cachedMessage.Unwrap())
+
+		if newSolidAnchorID != nil {
+			log.Infof("anchor message %s has become solid", newSolidAnchorID.String()[:10])
+		}
+
+		if !allSolid {
+			return
+		}
+		synced <- types.Empty{}
+	})
+
+	daemon.BackgroundWorker("Sync-Monitor", func(shutdownSignal <-chan struct{}) {
+		messagelayer.Tangle.Events.MessageAttached.Attach(initAnchorPointClosure)
+		defer messagelayer.Tangle.Events.MessageAttached.Detach(initAnchorPointClosure)
+		messagelayer.Tangle.Events.MessageSolid.Attach(checkAnchorPointSolidityClosure)
+		defer messagelayer.Tangle.Events.MessageSolid.Detach(checkAnchorPointSolidityClosure)
+
+		select {
+		case <-shutdownSignal:
+		case <-synced:
+			log.Infof("all anchor messages have become solid, marking node as synced")
+			markSynced()
+		}
+	}, shutdown.PrioritySynchronization)
 }
 
 // fills up the anchor points with newly attached messages which then are used to determine whether we are synchronized.
-func initAnchorPoint(cachedMessage *message.CachedMessage, cachedMessageMetadata *tangle.CachedMessageMetadata) {
-	defer cachedMessage.Release()
-	defer cachedMessageMetadata.Release()
-	if synchronized.Load() {
-		return
+func initAnchorPoint(anchorPoints *anchorpoints, msg *message.Message) *message.Id {
+	if synced.Load() {
+		return nil
 	}
 
 	anchorPoints.Lock()
@@ -98,58 +213,52 @@ func initAnchorPoint(cachedMessage *message.CachedMessage, cachedMessageMetadata
 
 	// we don't need to add additional anchor points if the set was already filled once
 	if anchorPoints.wasFilled() {
-		return
+		return nil
 	}
 
 	// as a rule, we don't consider messages attaching directly to genesis anchors
-	msg := cachedMessage.Unwrap()
 	if msg.TrunkId() == message.EmptyId || msg.BranchId() == message.EmptyId {
-		return
+		return nil
 	}
 
 	// add a new anchor point
-	anchorPoints.add(msg.Id())
-	log.Infof("added message %s as synchronization anchor point (%d of %d collected)", msg.Id().String()[:10], anchorPoints.collectedCount(), anchorPoints.wanted)
+	id := msg.Id()
+	anchorPoints.add(id)
+	return &id
 }
 
 // checks whether an anchor point message became solid.
 // if all anchor points became solid, it sets the node's state to synchronized.
-func checkAnchorPointSolidity(cachedMessage *message.CachedMessage, cachedMessageMetadata *tangle.CachedMessageMetadata) {
-	defer cachedMessage.Release()
-	defer cachedMessageMetadata.Release()
-
+func checkAnchorPointSolidity(anchorPoints *anchorpoints, msg *message.Message) (bool, *message.Id) {
 	anchorPoints.Lock()
 	defer anchorPoints.Unlock()
 
-	if synchronized.Load() || len(anchorPoints.ids) == 0 {
-		return
+	if synced.Load() || len(anchorPoints.ids) == 0 {
+		return false, nil
 	}
 
 	// check whether an anchor message become solid
-	msgID := cachedMessage.Unwrap().Id()
+	msgID := msg.Id()
 	if !anchorPoints.has(msgID) {
-		return
+		return false, nil
 	}
 
 	// an anchor became solid
-	log.Infof("anchor message %s has become solid", msgID.String()[:10])
 	anchorPoints.markAsSolidified(msgID)
 
 	if !anchorPoints.wereAllSolidified() {
-		return
+		return false, &msgID
 	}
 
 	// all anchor points have become solid
-	log.Infof("all anchor messages have become solid, setting node as synchronized")
-	synchronized.Store(true)
+	return true, &msgID
+}
 
-	// since we now are synchronized, we no longer need to listen to this events,
-	// however, we need to detach in a separate goroutine, since this function
-	// runs within the event handlers loop
-	if detachHandlers == nil {
-		return
+func newAnchorPoints(wantedAnchorPointsCount int) *anchorpoints {
+	return &anchorpoints{
+		ids:    make(map[message.Id]types.Empty),
+		wanted: wantedAnchorPointsCount,
 	}
-	go detachHandlers()
 }
 
 // anchorpoints are a set of messages which we use to determine whether the node has become synchronized.

--- a/plugins/sync/plugin.go
+++ b/plugins/sync/plugin.go
@@ -1,0 +1,197 @@
+package sync
+
+import (
+	"sync"
+
+	"github.com/iotaledger/goshimmer/packages/binary/messagelayer/message"
+	"github.com/iotaledger/goshimmer/packages/binary/messagelayer/tangle"
+	"github.com/iotaledger/goshimmer/plugins/config"
+	"github.com/iotaledger/goshimmer/plugins/messagelayer"
+	"github.com/iotaledger/hive.go/events"
+	"github.com/iotaledger/hive.go/logger"
+	"github.com/iotaledger/hive.go/node"
+	"github.com/iotaledger/hive.go/types"
+	"github.com/pkg/errors"
+	flag "github.com/spf13/pflag"
+	"go.uber.org/atomic"
+)
+
+const (
+	// PluginName is the plugin name of the sync plugin.
+	PluginName = "Sync"
+	// CfgBootstrapSyncAnchorPointsCount defines the amount of anchor points to use to determine
+	// whether a node is synchronized.
+	CfgSyncAnchorPointsCount = "sync.anchorPointsCount"
+)
+
+func init() {
+	flag.Int(CfgSyncAnchorPointsCount, 3, "the amount of anchor points to use to determine whether a node is synchronized")
+}
+
+var (
+	// Plugin is the plugin instance of the sync plugin.
+	Plugin = node.NewPlugin(PluginName, node.Enabled, configure)
+	// ErrNodeNotSynchronized is returned when an operation can't be executed because
+	// the node is not synchronized.
+	ErrNodeNotSynchronized = errors.New("node is not synchronized")
+	log                    *logger.Logger
+	synchronized           atomic.Bool
+	anchorPoints           *anchorpoints
+	detachHandlers         func()
+)
+
+// Synced tells whether the node is in a state we consider synchronized, meaning
+// it has the relevant past and present message data.
+func Synced() bool {
+	return synchronized.Load()
+}
+
+// OverwriteSyncedState overwrites the synced state with the given value.
+func OverwriteSyncedState(synced bool) {
+	synchronized.Store(synced)
+}
+
+func configure(_ *node.Plugin) {
+	log = logger.NewLogger(PluginName)
+
+	// another plugin might overwrite the sync state while configuring itself,
+	// for example the bootstrap plugin, implying that we don't need to register any handlers
+	if Synced() {
+		return
+	}
+
+	wantedAnchorPointsCount := config.Node.GetInt(CfgSyncAnchorPointsCount)
+	anchorPoints = &anchorpoints{
+		ids:    make(map[message.Id]types.Empty),
+		wanted: wantedAnchorPointsCount,
+	}
+
+	log.Infof("starting node in non-bootstrapping mode, awaiting %d anchor point messages to become solid", wantedAnchorPointsCount)
+
+	// only register anchor event handlers when we're not in bootstrap mode
+	detachHandlers = registerMessageHandlers()
+}
+
+// registers the event handler for checking the anchor message state
+// and returns a function to detach those event handlers.
+func registerMessageHandlers() func() {
+	initAnchorPointClosure := events.NewClosure(initAnchorPoint)
+	checkAnchorPointSolidityClosure := events.NewClosure(checkAnchorPointSolidity)
+	messagelayer.Tangle.Events.MessageAttached.Attach(initAnchorPointClosure)
+	messagelayer.Tangle.Events.MessageSolid.Attach(checkAnchorPointSolidityClosure)
+	return func() {
+		messagelayer.Tangle.Events.MessageAttached.Detach(initAnchorPointClosure)
+		messagelayer.Tangle.Events.MessageSolid.Detach(checkAnchorPointSolidityClosure)
+	}
+}
+
+// fills up the anchor points with newly attached messages which then are used to determine whether we are synchronized.
+func initAnchorPoint(cachedMessage *message.CachedMessage, cachedMessageMetadata *tangle.CachedMessageMetadata) {
+	defer cachedMessage.Release()
+	defer cachedMessageMetadata.Release()
+	if synchronized.Load() {
+		return
+	}
+
+	anchorPoints.Lock()
+	defer anchorPoints.Unlock()
+
+	// we don't need to add additional anchor points if the set was already filled once
+	if anchorPoints.wasFilled() {
+		return
+	}
+
+	// as a rule, we don't consider messages attaching directly to genesis anchors
+	msg := cachedMessage.Unwrap()
+	if msg.TrunkId() == message.EmptyId || msg.BranchId() == message.EmptyId {
+		return
+	}
+
+	// add a new anchor point
+	anchorPoints.add(msg.Id())
+	log.Infof("added message %s as synchronization anchor point (%d of %d collected)", msg.Id().String()[:10], anchorPoints.collectedCount(), anchorPoints.wanted)
+}
+
+// checks whether an anchor point message became solid.
+// if all anchor points became solid, it sets the node's state to synchronized.
+func checkAnchorPointSolidity(cachedMessage *message.CachedMessage, cachedMessageMetadata *tangle.CachedMessageMetadata) {
+	defer cachedMessage.Release()
+	defer cachedMessageMetadata.Release()
+
+	anchorPoints.Lock()
+	defer anchorPoints.Unlock()
+
+	if synchronized.Load() || len(anchorPoints.ids) == 0 {
+		return
+	}
+
+	// check whether an anchor message become solid
+	msgID := cachedMessage.Unwrap().Id()
+	if !anchorPoints.has(msgID) {
+		return
+	}
+
+	// an anchor became solid
+	log.Infof("anchor message %s has become solid", msgID.String()[:10])
+	anchorPoints.markAsSolidified(msgID)
+
+	if !anchorPoints.wereAllSolidified() {
+		return
+	}
+
+	// all anchor points have become solid
+	log.Infof("all anchor messages have become solid, setting node as synchronized")
+	synchronized.Store(true)
+
+	// since we now are synchronized, we no longer need to listen to this events,
+	// however, we need to detach in a separate goroutine, since this function
+	// runs within the event handlers loop
+	if detachHandlers == nil {
+		return
+	}
+	go detachHandlers()
+}
+
+// anchorpoints are a set of messages which we use to determine whether the node has become synchronized.
+type anchorpoints struct {
+	sync.Mutex
+	// the ids of the anchor points.
+	ids map[message.Id]types.Empty
+	// the wanted amount of anchor points which should become solid.
+	wanted int
+	// how many anchor points have been solidified.
+	solidified int
+}
+
+// adds the given message to the anchor points set.
+func (ap *anchorpoints) add(id message.Id) {
+	ap.ids[id] = types.Empty{}
+}
+
+func (ap *anchorpoints) has(id message.Id) bool {
+	_, has := ap.ids[id]
+	return has
+}
+
+// marks the given anchor point as solidified which removes it from the set and bumps the solidified count.
+func (ap *anchorpoints) markAsSolidified(id message.Id) {
+	delete(ap.ids, id)
+	ap.solidified++
+}
+
+// tells whether the anchor points set was filled at some point.
+func (ap *anchorpoints) wasFilled() bool {
+	return ap.collectedCount() == ap.wanted
+}
+
+// tells whether all anchor points have become solid.
+func (ap *anchorpoints) wereAllSolidified() bool {
+	return ap.solidified == ap.wanted
+}
+
+// tells the number of effectively collected anchor points.
+func (ap *anchorpoints) collectedCount() int {
+	// since an anchor point potentially was solidified before the set became full,
+	// we need to incorporate that count too
+	return ap.solidified + len(ap.ids)
+}

--- a/plugins/sync/plugin.go
+++ b/plugins/sync/plugin.go
@@ -19,7 +19,7 @@ import (
 const (
 	// PluginName is the plugin name of the sync plugin.
 	PluginName = "Sync"
-	// CfgBootstrapSyncAnchorPointsCount defines the amount of anchor points to use to determine
+	// CfgSyncAnchorPointsCount defines the amount of anchor points to use to determine
 	// whether a node is synchronized.
 	CfgSyncAnchorPointsCount = "sync.anchorPointsCount"
 )

--- a/plugins/webapi/data/plugin.go
+++ b/plugins/webapi/data/plugin.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 
 	"github.com/iotaledger/goshimmer/packages/binary/messagelayer/payload"
-	"github.com/iotaledger/goshimmer/plugins/messagelayer"
+	"github.com/iotaledger/goshimmer/plugins/issuer"
 	"github.com/iotaledger/goshimmer/plugins/webapi"
 	"github.com/iotaledger/hive.go/logger"
 	"github.com/iotaledger/hive.go/node"
@@ -35,7 +35,10 @@ func broadcastData(c echo.Context) error {
 	}
 
 	//TODO: to check max payload size allowed, if exceeding return an error
-	msg := messagelayer.MessageFactory.IssuePayload(payload.NewData(request.Data))
+	msg, err := issuer.IssuePayload(payload.NewData(request.Data))
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, Response{Error: err.Error()})
+	}
 	return c.JSON(http.StatusOK, Response{ID: msg.Id().String()})
 }
 

--- a/plugins/webapi/drng/collectivebeacon/handler.go
+++ b/plugins/webapi/drng/collectivebeacon/handler.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 
 	"github.com/iotaledger/goshimmer/packages/binary/drng/subtypes/collectiveBeacon/payload"
-	"github.com/iotaledger/goshimmer/plugins/messagelayer"
+	"github.com/iotaledger/goshimmer/plugins/issuer"
 	"github.com/iotaledger/hive.go/marshalutil"
 	"github.com/labstack/echo"
 	"github.com/labstack/gommon/log"
@@ -25,7 +25,10 @@ func Handler(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, Response{Error: "not a valid Collective Beacon payload"})
 	}
 
-	msg := messagelayer.MessageFactory.IssuePayload(parsedPayload)
+	msg, err := issuer.IssuePayload(parsedPayload)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, Response{Error: err.Error()})
+	}
 	return c.JSON(http.StatusOK, Response{ID: msg.Id().String()})
 }
 

--- a/plugins/webapi/info/plugin.go
+++ b/plugins/webapi/info/plugin.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/iotaledger/goshimmer/plugins/autopeering/local"
 	"github.com/iotaledger/goshimmer/plugins/banner"
-	"github.com/iotaledger/goshimmer/plugins/bootstrap"
+	"github.com/iotaledger/goshimmer/plugins/sync"
 	"github.com/iotaledger/goshimmer/plugins/webapi"
 	"github.com/iotaledger/hive.go/node"
 	"github.com/labstack/echo"
@@ -72,7 +72,7 @@ func getInfo(c echo.Context) error {
 
 	return c.JSON(http.StatusOK, Response{
 		Version:         banner.AppVersion,
-		Synchronized:    bootstrap.Synchronized(),
+		Synced:          sync.Synced(),
 		IdentityID:      local.GetInstance().Identity.ID().String(),
 		PublicKey:       local.GetInstance().PublicKey().String(),
 		EnabledPlugins:  enabledPlugins,
@@ -85,7 +85,7 @@ type Response struct {
 	// version of GoShimmer
 	Version string `json:"version,omitempty"`
 	// whether the node is synchronized
-	Synchronized bool `json:"synchronized"`
+	Synced bool `json:"synced"`
 	// identity ID of the node encoded in hex and truncated to its first 8 bytes
 	IdentityID string `json:"identityID,omitempty"`
 	// public key of the node encoded in base58

--- a/plugins/webapi/info/plugin.go
+++ b/plugins/webapi/info/plugin.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/iotaledger/goshimmer/plugins/autopeering/local"
 	"github.com/iotaledger/goshimmer/plugins/banner"
+	"github.com/iotaledger/goshimmer/plugins/bootstrap"
 	"github.com/iotaledger/goshimmer/plugins/webapi"
 	"github.com/iotaledger/hive.go/node"
 	"github.com/labstack/echo"
@@ -24,6 +25,7 @@ func configure(_ *node.Plugin) {
 // e.g.,
 // {
 // 	"version":"v0.2.0",
+//  "synchronized": true,
 // 	"identityID":"5bf4aa1d6c47e4ce",
 // 	"publickey":"CjUsn86jpFHWnSCx3NhWfU4Lk16mDdy1Hr7ERSTv3xn9",
 // 	"enabledplugins":[
@@ -70,6 +72,7 @@ func getInfo(c echo.Context) error {
 
 	return c.JSON(http.StatusOK, Response{
 		Version:         banner.AppVersion,
+		Synchronized:    bootstrap.Synchronized(),
 		IdentityID:      local.GetInstance().Identity.ID().String(),
 		PublicKey:       local.GetInstance().PublicKey().String(),
 		EnabledPlugins:  enabledPlugins,
@@ -81,6 +84,8 @@ func getInfo(c echo.Context) error {
 type Response struct {
 	// version of GoShimmer
 	Version string `json:"version,omitempty"`
+	// whether the node is synchronized
+	Synchronized bool `json:"synchronized"`
 	// identity ID of the node encoded in hex and truncated to its first 8 bytes
 	IdentityID string `json:"identityID,omitempty"`
 	// public key of the node encoded in base58

--- a/plugins/webapi/spammer/plugin.go
+++ b/plugins/webapi/spammer/plugin.go
@@ -3,7 +3,7 @@ package spammer
 import (
 	"github.com/iotaledger/goshimmer/packages/binary/spammer"
 	"github.com/iotaledger/goshimmer/packages/shutdown"
-	"github.com/iotaledger/goshimmer/plugins/messagelayer"
+	"github.com/iotaledger/goshimmer/plugins/issuer"
 	"github.com/iotaledger/goshimmer/plugins/webapi"
 	"github.com/iotaledger/hive.go/daemon"
 	"github.com/iotaledger/hive.go/node"
@@ -18,7 +18,7 @@ const PluginName = "Spammer"
 var Plugin = node.NewPlugin(PluginName, node.Disabled, configure, run)
 
 func configure(plugin *node.Plugin) {
-	messageSpammer = spammer.New(messagelayer.MessageFactory)
+	messageSpammer = spammer.New(issuer.IssuePayload)
 	webapi.Server.GET("spammer", handleRequest)
 }
 

--- a/tools/docker-network/docker-compose.yml
+++ b/tools/docker-network/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - integration-test
 
   peer_master:
+    command: --node.enablePlugins=bootstrap
     container_name: peer_master
     image: iotaledger/goshimmer
     build:

--- a/tools/integration-tests/tester/docker-compose.yml
+++ b/tools/integration-tests/tester/docker-compose.yml
@@ -7,7 +7,6 @@ services:
     working_dir: /go/src/github.com/iotaledger/goshimmer/tools/integration-tests/tester
     entrypoint: go test ./tests -v -mod=readonly
     volumes:
-    - /var/run/docker.sock:/var/run/docker.sock:ro
-    - ../../..:/go/src/github.com/iotaledger/goshimmer:ro
-    - ../logs:/tmp/logs
-
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ../../..:/go/src/github.com/iotaledger/goshimmer:ro
+      - ../logs:/tmp/logs

--- a/tools/integration-tests/tester/framework/docker.go
+++ b/tools/integration-tests/tester/framework/docker.go
@@ -69,7 +69,7 @@ func (d *DockerContainer) CreateGoShimmerEntryNode(name string, seed string) err
 }
 
 // CreateGoShimmerPeer creates a new container with the GoShimmer peer's configuration.
-func (d *DockerContainer) CreateGoShimmerPeer(name string, seed string, entryNodeHost string, entryNodePublicKey string) error {
+func (d *DockerContainer) CreateGoShimmerPeer(name string, seed string, entryNodeHost string, entryNodePublicKey string, bootstrap bool) error {
 	// configure GoShimmer container instance
 	containerConfig := &container.Config{
 		Image: "iotaledger/goshimmer",
@@ -78,6 +78,12 @@ func (d *DockerContainer) CreateGoShimmerPeer(name string, seed string, entryNod
 		},
 		Cmd: strslice.StrSlice{
 			fmt.Sprintf("--node.disablePlugins=%s", disabledPluginsPeer),
+			fmt.Sprintf("--node.enablePlugins=%s", func() string {
+				if bootstrap {
+					return "Bootstrap"
+				}
+				return ""
+			}()),
 			"--webapi.bindAddress=0.0.0.0:8080",
 			fmt.Sprintf("--autopeering.seed=%s", seed),
 			fmt.Sprintf("--autopeering.entryNodes=%s@%s:14626", entryNodePublicKey, entryNodeHost),

--- a/tools/integration-tests/tester/framework/framework.go
+++ b/tools/integration-tests/tester/framework/framework.go
@@ -55,6 +55,7 @@ func newFramework() (*Framework, error) {
 
 // CreateNetwork creates and returns a (Docker) Network that contains `peers` GoShimmer nodes.
 // It waits for the peers to autopeer until the minimum neighbors criteria is met for every peer.
+// The first peer automatically starts with the bootstrap plugin enabled.
 func (f *Framework) CreateNetwork(name string, peers int, minimumNeighbors int) (*Network, error) {
 	network, err := newNetwork(f.dockerClient, strings.ToLower(name), f.tester)
 	if err != nil {
@@ -68,8 +69,8 @@ func (f *Framework) CreateNetwork(name string, peers int, minimumNeighbors int) 
 
 	// create peers/GoShimmer nodes
 	for i := 0; i < peers; i++ {
-		_, err = network.CreatePeer()
-		if err != nil {
+		bootstrap := i == 0
+		if _, err = network.CreatePeer(bootstrap); err != nil {
 			return nil, err
 		}
 	}

--- a/tools/integration-tests/tester/framework/network.go
+++ b/tools/integration-tests/tester/framework/network.go
@@ -82,7 +82,8 @@ func (n *Network) createEntryNode() error {
 }
 
 // CreatePeer creates a new peer/GoShimmer node in the network and returns it.
-func (n *Network) CreatePeer() (*Peer, error) {
+// Passing bootstrap true enables the bootstrap plugin on the given peer.
+func (n *Network) CreatePeer(bootstrap bool) (*Peer, error) {
 	name := n.namePrefix(fmt.Sprintf("%s%d", containerNameReplica, len(n.peers)))
 
 	// create identity
@@ -94,7 +95,7 @@ func (n *Network) CreatePeer() (*Peer, error) {
 
 	// create Docker container
 	container := NewDockerContainer(n.dockerClient)
-	err = container.CreateGoShimmerPeer(name, seed, n.namePrefix(containerNameEntryNode), n.entryNodePublicKey())
+	err = container.CreateGoShimmerPeer(name, seed, n.namePrefix(containerNameEntryNode), n.entryNodePublicKey(), bootstrap)
 	if err != nil {
 		return nil, err
 	}

--- a/tools/integration-tests/tester/tests/synchronization_test.go
+++ b/tools/integration-tests/tester/tests/synchronization_test.go
@@ -18,6 +18,9 @@ func TestNodeSynchronization(t *testing.T) {
 	require.NoError(t, err)
 	defer n.Shutdown()
 
+	// wait for peers to change their state to synchronized
+	time.Sleep(5 * time.Second)
+
 	numMessages := 100
 	idsMap := make(map[string]MessageSent, numMessages)
 	ids := make([]string, numMessages)
@@ -40,7 +43,7 @@ func TestNodeSynchronization(t *testing.T) {
 	checkForMessageIds(t, n.Peers(), ids, idsMap)
 
 	// spawn peer without knowledge of previous messages
-	newPeer, err := n.CreatePeer()
+	newPeer, err := n.CreatePeer(false)
 	require.NoError(t, err)
 	err = n.WaitForAutopeering(3)
 	require.NoError(t, err)
@@ -94,7 +97,7 @@ func checkForMessageIds(t *testing.T, peers []*framework.Peer, ids []string, ids
 		// check that the peer sees itself as synchronized
 		info, err := peer.Info()
 		require.NoError(t, err)
-		require.True(t, info.Synchronized)
+		require.True(t, info.Synced)
 
 		resp, err := peer.FindMessageByID(ids)
 		require.NoError(t, err)

--- a/tools/integration-tests/tester/tests/synchronization_test.go
+++ b/tools/integration-tests/tester/tests/synchronization_test.go
@@ -91,6 +91,11 @@ func sendDataMessage(t *testing.T, peer *framework.Peer, data []byte, number int
 
 func checkForMessageIds(t *testing.T, peers []*framework.Peer, ids []string, idsMap map[string]MessageSent) {
 	for _, peer := range peers {
+		// check that the peer sees itself as synchronized
+		info, err := peer.Info()
+		require.NoError(t, err)
+		require.True(t, info.Synchronized)
+
 		resp, err := peer.FindMessageByID(ids)
 		require.NoError(t, err)
 


### PR DESCRIPTION
* Adds a `Bootstrap` plugin which sets the node's `synced` state to true on `configure` and then proceeds to issue messages for a specified issuance time period (or continuously per default). This plugin is disabled per default.
* Adds a `Sync` plugin which determines the node's `synced` state by monitoring `MessageAttached` events and then checking whether those anchor points become solid (the amount of anchor points is set to 3 per default and is a config option). It also determines whether the node is desynced by monitoring whether the node has any connected peers or didn't receive any non self-issued message in a configurable time window. When the node switches its `synced` state, it launches the corresponding monitoring routines. As an additional measure, anchor points are automatically removed if they don't become solid within a given time window in order to both prevent non-solidifiable messages rendering the node to never sync (theoretically this shouldn't happen since messages are only gossiped on solidification) and to let the node continuously update to more recent anchor points while syncing.
* Adds an `Issuer` plugin which uses the `synced` state from the `Sync` plugin and issues payloads if the node is synced. This plugin is necessary because otherwise there's automatically an import cycle between the `MessageLayer` plugin providing the `MessageFactory` to issue payloads and that factory having to pre-check the synced state. Web APIs issuing payloads have been adjusted to use the `Issuer` plugin `IssuePayload` function.
* The info web API now also returns the node's synced state.
* Additionally this PR modifies the integration test framework to let the first peer of a given spawned network to run with the `Bootstrap` plugin enabled. The `TestNodeSynchronization` integration test now checks whether the nodes are synced.