### PR TITLE
Normalize bind addresses prints

### DIFF
--- a/plugins/dashboard/plugin.go
+++ b/plugins/dashboard/plugin.go
@@ -100,7 +100,7 @@ func worker(shutdownSignal <-chan struct{}) {
 	stopped := make(chan struct{})
 	bindAddr := config.Node.GetString(CfgBindAddress)
 	go func() {
-		log.Infof("Started %s: http://%s", PluginName, bindAddr)
+		log.Infof("%s started, bind-address=%s", PluginName, bindAddr)
 		if err := server.Start(bindAddr); err != nil {
 			if !errors.Is(err, http.ErrServerClosed) {
 				log.Errorf("Error serving: %s", err)

--- a/plugins/gossip/gossip.go
+++ b/plugins/gossip/gossip.go
@@ -76,7 +76,7 @@ func start(shutdownSignal <-chan struct{}) {
 	// trigger start of the autopeering selection
 	go func() { autopeering.StartSelection() }()
 
-	log.Infof("%s started: Address=%s/%s", PluginName, localAddr.String(), localAddr.Network())
+	log.Infof("%s started, bind-address=%s", PluginName, localAddr.String())
 
 	<-shutdownSignal
 	log.Info("Stopping " + PluginName + " ...")

--- a/plugins/profiling/plugin.go
+++ b/plugins/profiling/plugin.go
@@ -6,24 +6,33 @@ import (
 	_ "net/http/pprof"
 
 	"github.com/iotaledger/goshimmer/plugins/config"
+	"github.com/iotaledger/hive.go/logger"
 	"github.com/iotaledger/hive.go/node"
 	flag "github.com/spf13/pflag"
 )
 
+// PluginName is the name of the profiling plugin.
+const PluginName = "Profiling"
+
 var (
 	// Plugin is the profiling plugin.
-	Plugin = node.NewPlugin("Profiling", node.Enabled, configure, run)
+	Plugin = node.NewPlugin(PluginName, node.Enabled, configure, run)
+	log    *logger.Logger
 )
 
 // CfgProfilingBindAddress defines the config flag of the profiling binding address.
 const CfgProfilingBindAddress = "profiling.bindAddress"
 
 func init() {
-	flag.String(CfgProfilingBindAddress, "localhost:6061", "bind address for the pprof server")
+	flag.String(CfgProfilingBindAddress, "127.0.0.1:6061", "bind address for the pprof server")
 }
 
-func configure(_ *node.Plugin) {}
+func configure(_ *node.Plugin) {
+	log = logger.NewLogger(PluginName)
+}
 
 func run(_ *node.Plugin) {
-	go http.ListenAndServe(config.Node.GetString(CfgProfilingBindAddress), nil)
+	bindAddr := config.Node.GetString(CfgProfilingBindAddress)
+	log.Infof("%s started, bind-address=%s", PluginName, bindAddr)
+	go http.ListenAndServe(bindAddr, nil)
 }

--- a/plugins/webapi/plugin.go
+++ b/plugins/webapi/plugin.go
@@ -47,7 +47,7 @@ func worker(shutdownSignal <-chan struct{}) {
 	stopped := make(chan struct{})
 	bindAddr := config.Node.GetString(CfgBindAddress)
 	go func() {
-		log.Infof("Started %s: http://%s", PluginName, bindAddr)
+		log.Infof("%s started, bind-address=%s", PluginName, bindAddr)
 		if err := Server.Start(bindAddr); err != nil {
 			if !errors.Is(err, http.ErrServerClosed) {
 				log.Errorf("Error serving: %s", err)


### PR DESCRIPTION
Lets plugins which have some sort of bind address print their bind addresses in the form of `<plugin name> started, bind-address=<address:port>`