### PR TITLE
Use old version of reviewdog / action-golangci-lint 

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -13,7 +13,7 @@ jobs:
       uses: actions/checkout@v2
     
     - name: Run golangci-lint
-      uses: docker://reviewdog/action-golangci-lint:latest
+      uses: docker://reviewdog/action-golangci-lint:v1.2
       with:
         github_token: ${{ secrets.github_token }}
         golangci_lint_flags: "--timeout=10m"


### PR DESCRIPTION
There seems to be an issue with the very recent v1.3 update and the newly introduced flags.