### PR TITLE
Use a background worker to handle missing messages on the base layer

### DIFF
--- a/packages/shutdown/order.go
+++ b/packages/shutdown/order.go
@@ -4,6 +4,7 @@ const (
 	PriorityDatabase = iota
 	PriorityFPC
 	PriorityTangle
+	PriorityMissingMessagesMonitoring
 	PriorityRemoteLog
 	PriorityAnalysis
 	PriorityMetrics

--- a/plugins/messagelayer/plugin.go
+++ b/plugins/messagelayer/plugin.go
@@ -72,10 +72,15 @@ func configure(*node.Plugin) {
 }
 
 func run(*node.Plugin) {
+	_ = daemon.BackgroundWorker("Tangle[MissingMessagesMonitor]", func(shutdownSignal <-chan struct{}) {
+		Tangle.MonitorMissingMessages(shutdownSignal)
+	}, shutdown.PriorityMissingMessagesMonitoring)
+
 	_ = daemon.BackgroundWorker("Tangle", func(shutdownSignal <-chan struct{}) {
 		<-shutdownSignal
 		MessageFactory.Shutdown()
 		MessageParser.Shutdown()
 		Tangle.Shutdown()
 	}, shutdown.PriorityTangle)
+
 }


### PR DESCRIPTION
The Tangle of the base layer would spawn separate goroutines per missing message which would check for a given time frame whether a message became available or not. If it doesn't become available, the message and its future cone (approver references) is deleted.

This PR fixes the spawning of a new goroutine per missing message by using a single background worker which is registered in the message layer plugin. Additionally this fixes the problem of the storage being accessed after the corresponding ObjectStorages have been shutdown, since the priority of the "missing mesages monitor" is higher than that of the Tangle's.