### PR TITLE
Fix entropy of prng

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.14
 
 require (
 	github.com/coreos/bbolt v1.3.3 // indirect
-	github.com/dchest/blake2b v1.0.0
 	github.com/dgraph-io/badger/v2 v2.0.2
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/drand/drand v0.8.1

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/coreos/bbolt v1.3.3 // indirect
+	github.com/dchest/blake2b v1.0.0
 	github.com/dgraph-io/badger/v2 v2.0.2
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/drand/drand v0.8.1


### PR DESCRIPTION
This PR fixes th entropy of the prng based on the Unix timestamp by hashing the timepoint before converting it to a float64