### PR TITLE
add healthz endpoint

### DIFF
--- a/pluginmgr/webapi/plugins.go
+++ b/pluginmgr/webapi/plugins.go
@@ -5,6 +5,7 @@ import (
 	"github.com/iotaledger/goshimmer/plugins/webapi/autopeering"
 	"github.com/iotaledger/goshimmer/plugins/webapi/data"
 	"github.com/iotaledger/goshimmer/plugins/webapi/drng"
+	"github.com/iotaledger/goshimmer/plugins/webapi/healthz"
 	"github.com/iotaledger/goshimmer/plugins/webapi/info"
 	"github.com/iotaledger/goshimmer/plugins/webapi/message"
 	"github.com/iotaledger/goshimmer/plugins/webapi/spammer"
@@ -19,6 +20,7 @@ var PLUGINS = node.Plugins(
 	spammer.Plugin,
 	data.Plugin,
 	drng.Plugin,
+	healthz.Plugin,
 	message.Plugin,
 	autopeering.Plugin,
 	info.Plugin,

--- a/plugins/webapi/healthz/plugin.go
+++ b/plugins/webapi/healthz/plugin.go
@@ -28,7 +28,7 @@ func getHealthz(c echo.Context) error {
 	return c.NoContent(http.StatusOK)
 }
 
-// IsNodeHealthy returns whether the node is synced, has active neighbors and its latest milestone is not too old.
+// IsNodeHealthy returns whether the node is synced, has active neighbors.
 func IsNodeHealthy() bool {
 	// Synced
 	if !sync.Synced() {

--- a/plugins/webapi/healthz/plugin.go
+++ b/plugins/webapi/healthz/plugin.go
@@ -1,0 +1,44 @@
+package healthz
+
+import (
+	"net/http"
+
+	"github.com/iotaledger/goshimmer/plugins/gossip"
+	"github.com/iotaledger/goshimmer/plugins/sync"
+	"github.com/iotaledger/goshimmer/plugins/webapi"
+	"github.com/iotaledger/hive.go/node"
+	"github.com/labstack/echo"
+)
+
+// PluginName is the name of the web API healthz endpoint plugin.
+const PluginName = "WebAPI healthz Endpoint"
+
+// Plugin is the plugin instance of the web API info endpoint plugin.
+var Plugin = node.NewPlugin(PluginName, node.Enabled, configure)
+
+func configure(_ *node.Plugin) {
+	webapi.Server.GET("healthz", getHealthz)
+}
+
+func getHealthz(c echo.Context) error {
+	if !IsNodeHealthy() {
+		return c.NoContent(http.StatusServiceUnavailable)
+	}
+
+	return c.NoContent(http.StatusOK)
+}
+
+// IsNodeHealthy returns whether the node is synced, has active neighbors and its latest milestone is not too old.
+func IsNodeHealthy() bool {
+	// Synced
+	if !sync.Synced() {
+		return false
+	}
+
+	// Has connected neighbors
+	if len(gossip.Manager().AllNeighbors()) == 0 {
+		return false
+	}
+
+	return true
+}


### PR DESCRIPTION
Adds a new endpoint `/healthz` that response with `HTTP.OK` if the node is synced and has at least 1 connected neighbor. Else, responds with `HTTP.StatusServiceUnavailable`

Fixes #420 