### PR TITLE
Fixes communication layer message loss due to cleanup routine bug

### DIFF
--- a/plugins/messagelayer/plugin.go
+++ b/plugins/messagelayer/plugin.go
@@ -73,6 +73,7 @@ func configure(*node.Plugin) {
 }
 
 func run(*node.Plugin) {
+
 	if err := daemon.BackgroundWorker("Tangle[MissingMessagesMonitor]", func(shutdownSignal <-chan struct{}) {
 		Tangle.MonitorMissingMessages(shutdownSignal)
 	}, shutdown.PriorityMissingMessagesMonitoring); err != nil {


### PR DESCRIPTION
Check whether a message really isn't in the db before deleting it and its future cone.