### PR TITLE
Adds a couple of setModified()

### DIFF
--- a/dapps/valuetransfers/packages/tangle/output.go
+++ b/dapps/valuetransfers/packages/tangle/output.go
@@ -162,6 +162,7 @@ func (output *Output) setBranchID(branchID branchmanager.BranchID) (modified boo
 	}
 
 	output.branchID = branchID
+	output.SetModified()
 	modified = true
 
 	return

--- a/dapps/valuetransfers/packages/tangle/transactionmetadata.go
+++ b/dapps/valuetransfers/packages/tangle/transactionmetadata.go
@@ -131,6 +131,7 @@ func (transactionMetadata *TransactionMetadata) setBranchID(branchID branchmanag
 	}
 
 	transactionMetadata.branchID = branchID
+	transactionMetadata.SetModified()
 	modified = true
 
 	return

--- a/dapps/valuetransfers/packages/transaction/transaction.go
+++ b/dapps/valuetransfers/packages/transaction/transaction.go
@@ -207,6 +207,7 @@ func (transaction *Transaction) EssenceBytes() []byte {
 
 	// store marshaled result
 	transaction.essenceBytes = marshalUtil.Bytes()
+	transaction.SetModified()
 
 	return transaction.essenceBytes
 }
@@ -274,7 +275,7 @@ func (transaction *Transaction) Bytes() []byte {
 // Sign adds a new signature to the Transaction.
 func (transaction *Transaction) Sign(signature signaturescheme.SignatureScheme) *Transaction {
 	transaction.signatures.Add(signature.Address(), signature.Sign(transaction.EssenceBytes()))
-
+	transaction.SetModified()
 	return transaction
 }
 
@@ -284,7 +285,7 @@ func (transaction *Transaction) PutSignature(signature signaturescheme.Signature
 		return errors.New("PutSignature: invalid signature")
 	}
 	transaction.signatures.Add(signature.Address(), signature)
-
+	transaction.SetModified()
 	return nil
 }
 


### PR DESCRIPTION
Entities:
* Value Layer:
  * [x] Branch (`ComputeIfAbsent()` with setModified), setModified set on all field mutations 
  * [x] Child Branch (`StoreIfAbsent()`), no later field mutations
  * [x] Conflict (`ComputeIfAbsent()` with setModified), setModified set on all field mutations
  * [x] Conflict Member (`StoreIfAbsent()`), no later field mutations
  * [x] Payload/ValueObject (`StoreIfAbsent()`), setModified on all field updates set
  * [x] Attachment (`StoreIfAbsent()`), no later field mutations
  * [x] Consumer (`Store()`), no later field mutations
  * [x] Missing output (not used anywhere)
  * [x] Missing payload (`StoreIfAbsent()`), no later field mutations
  * [x] Output (`Store()` when a transaction is booked), added setModified to `setBranchID`, rest has setModified set on all field mutations 
  * [x] Payload approver (`Store()`), no later field mutations
  * [x] Payload metadata (`Store()`), setModified set on all field mutations 
  * [x] Transaction metadata (`Store()`), added setModified to `setBranchID`, rest has setModified set on all field mutations 
  * [x] Transaction (`ComputeIfAbsent()`), added setModified to `EssenceBytes()` when the field is assigned to, `Sign()` and `PutSignature()`
* Communication layer:
  * [x] Message (`StoreIfAbsent()`), no later field mutations
  * [x] Approver (`Store()`), no later field mutations
  * [x] Message metadata (`Store()`), setModified set on all field mutations
  * [x] Missing message (`StoreIfAbsent()`), no later field mutations

Closes #436 