### PR TITLE
Removes periodic badgerdb gc & adds dirty/health flag to db

### DIFF
--- a/packages/database/prefix/prefix.go
+++ b/packages/database/prefix/prefix.go
@@ -7,6 +7,5 @@ const (
 	DBPrefixTransactionMetadata
 	DBPrefixAddressTransactions
 	DBPrefixAutoPeering
-	DBPrefixDatabaseVersion
 	DBPrefixHealth
 )

--- a/packages/database/prefix/prefix.go
+++ b/packages/database/prefix/prefix.go
@@ -8,4 +8,5 @@ const (
 	DBPrefixAddressTransactions
 	DBPrefixAutoPeering
 	DBPrefixDatabaseVersion
+	DBPrefixHealth
 )

--- a/packages/shutdown/order.go
+++ b/packages/shutdown/order.go
@@ -16,5 +16,4 @@ const (
 	PrioritySynchronization
 	PriorityBootstrap
 	PrioritySpammer
-	PriorityBadgerGarbageCollection
 )

--- a/plugins/database/health.go
+++ b/plugins/database/health.go
@@ -1,0 +1,42 @@
+package database
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/iotaledger/goshimmer/packages/database/prefix"
+	"github.com/iotaledger/hive.go/kvstore"
+)
+
+var (
+	healthStore kvstore.KVStore
+	healthKey   = []byte("db_health")
+)
+
+func configureHealthStore(store kvstore.KVStore) {
+	healthStore = store.WithRealm([]byte{prefix.DBPrefixHealth})
+}
+
+// MarkDatabaseUnhealthy marks the database as not healthy, meaning
+// that it wasn't shutdown properly.
+func MarkDatabaseUnhealthy() {
+	if err := healthStore.Set(healthKey, []byte{}); err != nil {
+		panic(fmt.Errorf("failed to set database health state: %w", err))
+	}
+}
+
+// MarkDatabaseHealthy marks the database as healthy, respectively correctly closed.
+func MarkDatabaseHealthy() {
+	if err := healthStore.Delete(healthKey); err != nil && !errors.Is(err, kvstore.ErrKeyNotFound) {
+		panic(fmt.Errorf("failed to set database health state: %w", err))
+	}
+}
+
+// IsDatabaseUnhealthy tells whether the database is unhealthy, meaning not shutdown properly.
+func IsDatabaseUnhealthy() bool {
+	contains, err := healthStore.Has(healthKey)
+	if err != nil {
+		panic(fmt.Errorf("failed to set database health state: %w", err))
+	}
+	return contains
+}

--- a/plugins/database/plugin.go
+++ b/plugins/database/plugin.go
@@ -62,11 +62,10 @@ func configure(_ *node.Plugin) {
 	store := Store()
 	configureHealthStore(store)
 
-	err := checkDatabaseVersion(store.WithRealm([]byte{prefix.DBPrefixDatabaseVersion}))
-	if errors.Is(err, ErrDBVersionIncompatible) {
-		log.Panicf("The database scheme was updated. Please delete the database folder.\n%s", err)
-	}
-	if err != nil {
+	if err := checkDatabaseVersion(store.WithRealm([]byte{prefix.DBPrefixDatabaseVersion})); err != nil {
+		if errors.Is(err, ErrDBVersionIncompatible) {
+			log.Panicf("The database scheme was updated. Please delete the database folder.\n%s", err)
+		}
 		log.Panicf("Failed to check database version: %s", err)
 	}
 
@@ -84,7 +83,7 @@ func configure(_ *node.Plugin) {
 	}
 
 	// we open the database in the configure, so we must also make sure it's closed here
-	if err = daemon.BackgroundWorker(PluginName, closeDB, shutdown.PriorityDatabase); err != nil {
+	if err := daemon.BackgroundWorker(PluginName, closeDB, shutdown.PriorityDatabase); err != nil {
 		log.Panicf("Failed to start as daemon: %s", err)
 	}
 

--- a/plugins/database/plugin.go
+++ b/plugins/database/plugin.go
@@ -3,6 +3,7 @@ package database
 
 import (
 	"errors"
+	"fmt"
 	"sync"
 	"time"
 
@@ -51,7 +52,7 @@ func createStore() {
 		db, err = database.NewDB(dbDir)
 	}
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal(fmt.Sprintf("Unable to open the database, please delete the database folder. Error: %s", err))
 	}
 
 	store = db.NewStore()


### PR DESCRIPTION
* When the node starts up it sets a key in the database marking it as dirty.
* When the node shuts down it deletes the key and therefore marks the node as successfully shutdown.
* Run database garbage collection on the configured store up on configure() and shutdown right before the close()
* Tell the user to delete the db folder if the store can't even be initialized.

Closes #520
Closes #521
Closes #522 
