### PR TITLE
clear trunk and branch tip states once they are referenced

### DIFF
--- a/plugins/dashboard/frontend/src/app/stores/VisualizerStore.ts
+++ b/plugins/dashboard/frontend/src/app/stores/VisualizerStore.ts
@@ -108,6 +108,18 @@ export class VisualizerStore {
             }
             this.verticesIncomingOrder.push(vert.id);
             this.checkLimit();
+
+            //clear trunk and branch tip state
+            let trunkVert = this.vertices.get(vert.trunk_id)
+            let branchVert = this.vertices.get(vert.branch_id)
+            if(trunkVert) {
+                trunkVert.is_tip = false
+                this.vertices.set(trunkVert.id, trunkVert)
+            }
+            if(branchVert){
+                branchVert.is_tip = false
+                this.vertices.set(branchVert.id, branchVert)
+            }
         }
 
         this.vertices.set(vert.id, vert);


### PR DESCRIPTION
https://github.com/iotaledger/goshimmer/issues/500#issuecomment-647508722

>Let the tips chart on the dashboard use the size of the tip pool instead of the "add/remove" tips event to derive the current tips count. Use metrics.MessageTips() to get the tip pool count.

It already uses the tips count `broadcastWsMessage(&wsmsg{MsgTypeTipsMetric, messagelayer.TipSelector.TipCount()})
`
I also monitored the tip counts on 3 nodes and a spammer at 100 MPS. The values were consistent.

So this PR only clears the previous tips that have been referenced.

#500 