### PR TITLE
Fixes some small bugs in the sync plugin

### DIFF
--- a/plugins/sync/plugin.go
+++ b/plugins/sync/plugin.go
@@ -218,7 +218,7 @@ func monitorForSynchronization() {
 		defer messagelayer.Tangle().Events.MessageSolid.Detach(checkAnchorPointSolidityClosure)
 
 		cleanupDelta := config.Node().GetDuration(CfgSyncAnchorPointsCleanupAfterSec) * time.Second
-		ticker := time.NewTimer(config.Node().GetDuration(CfgSyncAnchorPointsCleanupIntervalSec) * time.Second)
+		ticker := time.NewTicker(config.Node().GetDuration(CfgSyncAnchorPointsCleanupIntervalSec) * time.Second)
 		defer ticker.Stop()
 		for {
 			select {


### PR DESCRIPTION
* It used a timer (one-shot) instead of a ticker to clean anchor points, resulting in them never getting replaced by newer ones
* Anchor points must now be always of a higher issuance time than previous anchor points. This prevents setting anchor points to messages which were requested instead of actual recent messages. This change doesn't have any actual effect other than conceptually making more sense to have anchor points towards the more recent parts of the comm. layer graph.