### PR TITLE
prevent double spend from same node

### DIFF
--- a/dapps/valuetransfers/packages/tangle/errors.go
+++ b/dapps/valuetransfers/packages/tangle/errors.go
@@ -11,4 +11,7 @@ var (
 
 	// ErrPayloadInvalid represents an error type that is triggered when an invalid payload is detected.
 	ErrPayloadInvalid = errors.New("payload invalid")
+
+	// ErrDoubleSpendForbidden represents an error that is triggered when a user tries to issue a double spend.
+	ErrDoubleSpendForbidden = errors.New("it is not allowed to issue a double spend")
 )

--- a/dapps/valuetransfers/packages/tangle/tangle.go
+++ b/dapps/valuetransfers/packages/tangle/tangle.go
@@ -1595,6 +1595,18 @@ func (tangle *Tangle) ValidateTransactionToAttach(tx *transaction.Transaction) (
 	if err != nil {
 		return
 	}
+
+	for _, cachedInput := range cachedInputs {
+		cachedInput.Consume(func(output *Output) {
+			if output.consumerCount > 0 {
+				err = ErrDoubleSpendForbidden
+			}
+		})
+		if err != nil {
+			return
+		}
+	}
+
 	if !tangle.checkTransactionOutputs(consumedBalances, tx.Outputs()) {
 		err = ErrTransactionDoesNotSpendAllFunds
 		return

--- a/plugins/webapi/value/sendtransaction/handler.go
+++ b/plugins/webapi/value/sendtransaction/handler.go
@@ -2,6 +2,7 @@ package sendtransaction
 
 import (
 	"net/http"
+	"sync"
 
 	"github.com/iotaledger/goshimmer/dapps/valuetransfers"
 	"github.com/iotaledger/goshimmer/dapps/valuetransfers/packages/transaction"
@@ -9,8 +10,15 @@ import (
 	"github.com/labstack/echo"
 )
 
+var (
+	mutex sync.Mutex
+)
+
 // Handler sends a transaction.
 func Handler(c echo.Context) error {
+	mutex.Lock()
+	defer mutex.Unlock()
+
 	var request Request
 	if err := c.Bind(&request); err != nil {
 		return c.JSON(http.StatusBadRequest, Response{Error: err.Error()})


### PR DESCRIPTION
Prevents double spend from the same node.
Synchronizes `sendTransaction` API handler and adds conflict validation in `ValidateTransactionToAttach`

#603 