### PR TITLE
adds a cli to override database dirty flag

### DIFF
--- a/plugins/database/parameters.go
+++ b/plugins/database/parameters.go
@@ -9,9 +9,12 @@ const (
 	CfgDatabaseDir = "database.directory"
 	// CfgDatabaseInMemory defines whether to use an in-memory database.
 	CfgDatabaseInMemory = "database.inMemory"
+	// CfgDatabaseDirty defines whether to override the database dirty flag.
+	CfgDatabaseDirty = "database.dirty"
 )
 
 func init() {
 	flag.String(CfgDatabaseDir, "mainnetdb", "path to the database folder")
 	flag.Bool(CfgDatabaseInMemory, false, "whether the database is only kept in memory and not persisted")
+	flag.String(CfgDatabaseDirty, "", "set the dirty flag of the database")
 }

--- a/plugins/database/plugin.go
+++ b/plugins/database/plugin.go
@@ -79,10 +79,10 @@ func configure(_ *node.Plugin) {
 	}
 
 	if str := config.Node().GetString(CfgDatabaseDirty); str != "" {
-		val ,err := strconv.ParseBool(str)
+		val, err := strconv.ParseBool(str)
 		if err != nil {
 			log.Warnf("Invalid %s: %s", CfgDatabaseDirty, err)
-		} else if val  {
+		} else if val {
 			MarkDatabaseUnhealthy()
 		} else {
 			MarkDatabaseHealthy()

--- a/plugins/database/plugin.go
+++ b/plugins/database/plugin.go
@@ -3,6 +3,7 @@ package database
 
 import (
 	"errors"
+	"strconv"
 	"sync"
 	"time"
 
@@ -75,6 +76,17 @@ func configure(_ *node.Plugin) {
 			log.Fatalf("The database scheme was updated. Please delete the database folder. %s", err)
 		}
 		log.Fatalf("Failed to check database version: %s", err)
+	}
+
+	if str := config.Node().GetString(CfgDatabaseDirty); str != "" {
+		val ,err := strconv.ParseBool(str)
+		if err != nil {
+			log.Warnf("Invalid %s: %s", CfgDatabaseDirty, err)
+		} else if val  {
+			MarkDatabaseUnhealthy()
+		} else {
+			MarkDatabaseHealthy()
+		}
 	}
 
 	if IsDatabaseUnhealthy() {


### PR DESCRIPTION
# Description of change

Adds a CLI flag `database.dirty` that accepts a boolean (passed as a string) and sets the database dirty flag to the value specified.
If the string passed to the `database.dirty` cannot be converted to boolean, a warning is printed and the override is ignored.

Fixes #599 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Tested manually

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
