### PR TITLE
Change spammer API to accept message per minute

### DIFF
--- a/plugins/webapi/spammer/webapi.go
+++ b/plugins/webapi/spammer/webapi.go
@@ -15,12 +15,12 @@ func handleRequest(c echo.Context) error {
 
 	switch request.Cmd {
 	case "start":
-		if request.MPS == 0 {
-			request.MPS = 1
+		if request.MPM == 0 {
+			request.MPM = 1
 		}
 
 		messageSpammer.Shutdown()
-		messageSpammer.Start(request.MPS, time.Second)
+		messageSpammer.Start(request.MPM, time.Minute)
 		return c.JSON(http.StatusOK, Response{Message: "started spamming messages"})
 	case "stop":
 		messageSpammer.Shutdown()
@@ -39,5 +39,5 @@ type Response struct {
 // Request contains the parameters of a spammer request.
 type Request struct {
 	Cmd string `json:"cmd"`
-	MPS int    `json:"mps"`
+	MPM int    `json:"mpm"`
 }


### PR DESCRIPTION
This PR changes the spammer API request to accept message per minute (MPM) as opposed to MPS. 
Default value is set to 1 MPM.

Due to PoW, the previous default of 1 MPS was too heavy on the node's CPU.

It fixes #632 