### PR TITLE
sync beacon plugin

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -247,3 +247,37 @@ jobs:
         with:
           name: ${{ env.TEST_NAME }}
           path: tools/integration-tests/logs
+
+  syncbeacon:
+    name: syncbeacon
+    env:
+      TEST_NAME: syncbeacon
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Build GoShimmer image
+        run: docker build -t iotaledger/goshimmer .
+
+      - name: Pull additional Docker images
+        run: |
+          docker pull angelocapossele/drand:latest
+          docker pull gaiaadm/pumba:latest
+          docker pull gaiadocker/iproute2:latest
+
+      - name: Run integration tests
+        run: docker-compose -f tools/integration-tests/tester/docker-compose.yml up --abort-on-container-exit --exit-code-from tester --build
+
+      - name: Create logs from tester
+        if: always()
+        run: |
+          docker logs tester &> tools/integration-tests/logs/tester.log
+
+      - name: Save logs as artifacts
+        if: always()
+        uses: actions/upload-artifact@v1
+        with:
+          name: ${{ env.TEST_NAME }}
+          path: tools/integration-tests/logs

--- a/pluginmgr/core/plugins.go
+++ b/pluginmgr/core/plugins.go
@@ -21,6 +21,7 @@ import (
 	"github.com/iotaledger/goshimmer/plugins/profiling"
 	"github.com/iotaledger/goshimmer/plugins/sync"
 	"github.com/iotaledger/goshimmer/plugins/syncbeacon"
+	"github.com/iotaledger/goshimmer/plugins/syncbeaconfollower"
 
 	"github.com/iotaledger/hive.go/node"
 )
@@ -46,4 +47,5 @@ var PLUGINS = node.Plugins(
 	faucet.App(),
 	valuetransfers.App(),
 	syncbeacon.Plugin(),
+	syncbeaconfollower.Plugin(),
 )

--- a/pluginmgr/core/plugins.go
+++ b/pluginmgr/core/plugins.go
@@ -20,6 +20,7 @@ import (
 	"github.com/iotaledger/goshimmer/plugins/pow"
 	"github.com/iotaledger/goshimmer/plugins/profiling"
 	"github.com/iotaledger/goshimmer/plugins/sync"
+	"github.com/iotaledger/goshimmer/plugins/syncbeacon"
 
 	"github.com/iotaledger/hive.go/node"
 )
@@ -44,4 +45,5 @@ var PLUGINS = node.Plugins(
 	drng.Plugin(),
 	faucet.App(),
 	valuetransfers.App(),
+	syncbeacon.Plugin(),
 )

--- a/plugins/sync/plugin.go
+++ b/plugins/sync/plugin.go
@@ -102,13 +102,13 @@ func run(_ *node.Plugin) {
 }
 
 // marks the node as synced and spawns the background worker to monitor desynchronization.
-func markSynced() {
+func MarkSynced() {
 	synced.Store(true)
 	monitorForDesynchronization()
 }
 
 // marks the node as desynced and spawns the background worker to monitor synchronization.
-func markDesynced() {
+func MarkDesynced() {
 	synced.Store(false)
 	monitorForSynchronization()
 }
@@ -166,12 +166,12 @@ func monitorForDesynchronization() {
 
 			case <-timer.C:
 				log.Infof("no message received in %d seconds, marking node as desynced", int(timeForDesync.Seconds()))
-				markDesynced()
+				MarkDesynced()
 				return
 
 			case <-noPeers:
 				log.Info("all peers have been lost, marking node as desynced")
-				markDesynced()
+				MarkDesynced()
 				return
 
 			case <-shutdownSignal:
@@ -241,7 +241,7 @@ func monitorForSynchronization() {
 				return
 			case <-synced:
 				log.Infof("all anchor messages have become solid, marking node as synced")
-				markSynced()
+				MarkSynced()
 				return
 			}
 		}

--- a/plugins/sync/plugin.go
+++ b/plugins/sync/plugin.go
@@ -64,7 +64,6 @@ var (
 	// tells whether the node is synced or not.
 	synced atomic.Bool
 	log    *logger.Logger
-	anchorPoints *anchorpoints
 )
 
 // Plugin gets the plugin instance.
@@ -88,8 +87,6 @@ func OverwriteSyncedState(syncedOverwrite bool) {
 
 func configure(_ *node.Plugin) {
 	log = logger.NewLogger(PluginName)
-	wantedAnchorPointsCount := config.Node().GetInt(CfgSyncAnchorPointsCount)
-	anchorPoints = newAnchorPoints(wantedAnchorPointsCount)
 }
 
 func run(_ *node.Plugin) {
@@ -104,161 +101,16 @@ func run(_ *node.Plugin) {
 	monitorForDesynchronization()
 }
 
-// marks the node as synced and spawns the background worker to monitor desynchronization.
+// MarkSynced marks the node as synced and spawns the background worker to monitor desynchronization.
 func MarkSynced() {
-	if Synced() {
-		return
-	}
 	synced.Store(true)
-	isRunning := false
-	for _, worker := range daemon.GetRunningBackgroundWorkers() {
-		if worker == "Desync-Monitor" {
-			isRunning = true
-			break
-		}
-	}
-	if !isRunning {
-		monitorForDesynchronization()
-	}
+	monitorForDesynchronization()
 }
 
-// marks the node as desynced and spawns the background worker to monitor synchronization.
+// MarkDesynced marks the node as desynced and spawns the background worker to monitor synchronization.
 func MarkDesynced() {
-	if !Synced() {
-		return
-	}
 	synced.Store(false)
-	isRunning := false
-	for _, worker := range daemon.GetRunningBackgroundWorkers() {
-		if worker == "Sync-Monitor" {
-			isRunning = true
-			break
-		}
-	}
-
-	if !isRunning {
-		monitorForSynchronization()
-	}
-}
-
-// AnchorPoints gets the messages of the anchor points
-func AnchorPoints() []message.Id {
-	var messageIds []message.Id
-	for messageId, _ := range anchorPoints.ids {
-		messageIds = append(messageIds, messageId)
-	}
-	return messageIds
-}
-
-func monitorSyncAndDesynchronization() {
-	wantedAnchorPointsCount := config.Node().GetInt(CfgSyncAnchorPointsCount)
-	anchorPoints = newAnchorPoints(wantedAnchorPointsCount)
-	log.Infof("monitoring for synchronization, awaiting %d anchor point messages to become solid", wantedAnchorPointsCount)
-
-
-	// monitors the peer count of the manager and sets the node as desynced if it has no more peers.
-	noPeers := make(chan types.Empty)
-	monitorPeerCountClosure := events.NewClosure(func(_ *gossipPkg.Neighbor) {
-		anyPeers := len(gossip.Manager().AllNeighbors()) > 0
-		if anyPeers {
-			return
-		}
-		noPeers <- types.Empty{}
-	})
-
-
-	msgReceived := make(chan types.Empty, 1)
-	synced := make(chan types.Empty)
-
-	monitorMessageInflowClosure := events.NewClosure(func(cachedMessage *message.CachedMessage, cachedMessageMetadata *tangle.CachedMessageMetadata) {
-		defer cachedMessage.Release()
-		defer cachedMessageMetadata.Release()
-		// ignore messages sent by the node itself
-		if local.GetInstance().LocalIdentity().PublicKey() == cachedMessage.Unwrap().IssuerPublicKey() {
-			return
-		}
-		select {
-		case msgReceived <- types.Empty{}:
-		default:
-			// via this default clause, a slow desync-monitor select-loop
-			// worker should not increase latency as it auto. falls through
-		}
-	})
-	initAnchorPointClosure := events.NewClosure(func(cachedMessage *message.CachedMessage, cachedMessageMetadata *tangle.CachedMessageMetadata) {
-		defer cachedMessage.Release()
-		defer cachedMessageMetadata.Release()
-		if addedAnchorID := initAnchorPoint(anchorPoints, cachedMessage.Unwrap()); addedAnchorID != nil {
-			anchorPoints.Lock()
-			defer anchorPoints.Unlock()
-			log.Infof("added message %s as anchor point (%d of %d collected)", addedAnchorID.String()[:10], anchorPoints.collectedCount(), anchorPoints.wanted)
-		}
-	})
-
-	checkAnchorPointSolidityClosure := events.NewClosure(func(cachedMessage *message.CachedMessage, cachedMessageMetadata *tangle.CachedMessageMetadata) {
-		defer cachedMessage.Release()
-		defer cachedMessageMetadata.Release()
-		allSolid, newSolidAnchorID := checkAnchorPointSolidity(anchorPoints, cachedMessage.Unwrap())
-
-		if newSolidAnchorID != nil {
-			log.Infof("anchor message %s has become solid", newSolidAnchorID.String()[:10])
-		}
-
-		if !allSolid {
-			return
-		}
-		synced <- types.Empty{}
-	})
-
-	if err := daemon.BackgroundWorker("Sync-Monitor", func(shutdownSignal <-chan struct{}) {
-		messagelayer.Tangle().Events.MessageAttached.Attach(initAnchorPointClosure)
-		defer messagelayer.Tangle().Events.MessageAttached.Detach(initAnchorPointClosure)
-		messagelayer.Tangle().Events.MessageSolid.Attach(checkAnchorPointSolidityClosure)
-		defer messagelayer.Tangle().Events.MessageSolid.Detach(checkAnchorPointSolidityClosure)
-
-		cleanupDelta := config.Node().GetDuration(CfgSyncAnchorPointsCleanupAfterSec) * time.Second
-		timer := time.NewTimer(1 * time.Second)
-		defer timer.Stop()
-		for {
-			select {
-			case <-timer.C:
-				anchorPoints.Lock()
-				for id, itGotAdded := range anchorPoints.ids {
-					if time.Since(itGotAdded) > cleanupDelta {
-						log.Infof("freeing anchor point slot of %s as it didn't become solid within %v", id.String()[:10], cleanupDelta)
-						delete(anchorPoints.ids, id)
-					}
-				}
-				anchorPoints.Unlock()
-			case <-shutdownSignal:
-				return
-			case <-synced:
-				log.Infof("all anchor messages have become solid, marking node as synced")
-				MarkSynced()
-				return
-
-			case <-msgReceived:
-				// we received a message, therefore reset the timer to check for message receives
-				if !timer.Stop() {
-					<-timer.C
-				}
-				// TODO: perhaps find a better way instead of constantly resetting the timer
-				timer.Reset(timeForDesync)
-
-			case <-timer.C:
-				log.Infof("no message received in %d seconds, marking node as desynced", int(timeForDesync.Seconds()))
-				MarkDesynced()
-				return
-
-			case <-noPeers:
-				log.Info("all peers have been lost, marking node as desynced")
-				MarkDesynced()
-				return
-			}
-		}
-	}, shutdown.PrioritySynchronization); err != nil {
-		log.Panicf("Failed to start as daemon: %s", err)
-	}
-
+	monitorForSynchronization()
 }
 
 // starts a background worker and event handlers to check whether the node is desynchronized by checking
@@ -335,7 +187,7 @@ func monitorForDesynchronization() {
 // a set of newly received messages and then waiting for them to become solid.
 func monitorForSynchronization() {
 	wantedAnchorPointsCount := config.Node().GetInt(CfgSyncAnchorPointsCount)
-	anchorPoints = newAnchorPoints(wantedAnchorPointsCount)
+	anchorPoints := newAnchorPoints(wantedAnchorPointsCount)
 	log.Infof("monitoring for synchronization, awaiting %d anchor point messages to become solid", wantedAnchorPointsCount)
 
 	synced := make(chan types.Empty)

--- a/plugins/sync/plugin.go
+++ b/plugins/sync/plugin.go
@@ -103,14 +103,39 @@ func run(_ *node.Plugin) {
 
 // marks the node as synced and spawns the background worker to monitor desynchronization.
 func MarkSynced() {
+	if Synced() {
+		return
+	}
 	synced.Store(true)
-	monitorForDesynchronization()
+	isRunning := false
+	for _, worker := range daemon.GetRunningBackgroundWorkers() {
+		if worker == "Desync-Monitor" {
+			isRunning = true
+			break
+		}
+	}
+	if !isRunning {
+		monitorForDesynchronization()
+	}
 }
 
 // marks the node as desynced and spawns the background worker to monitor synchronization.
 func MarkDesynced() {
+	if !Synced() {
+		return
+	}
 	synced.Store(false)
-	monitorForSynchronization()
+	isRunning := false
+	for _, worker := range daemon.GetRunningBackgroundWorkers() {
+		if worker == "Sync-Monitor" {
+			isRunning = true
+			break
+		}
+	}
+
+	if !isRunning {
+		monitorForSynchronization()
+	}
 }
 
 // starts a background worker and event handlers to check whether the node is desynchronized by checking

--- a/plugins/sync/plugin.go
+++ b/plugins/sync/plugin.go
@@ -104,13 +104,32 @@ func run(_ *node.Plugin) {
 // MarkSynced marks the node as synced and spawns the background worker to monitor desynchronization.
 func MarkSynced() {
 	synced.Store(true)
-	monitorForDesynchronization()
+	isRunning := false
+	for _, worker := range daemon.GetRunningBackgroundWorkers() {
+		if worker == "Desync-Monitor" {
+			isRunning = true
+			break
+		}
+	}
+	if !isRunning {
+		monitorForDesynchronization()
+	}
 }
 
 // MarkDesynced marks the node as desynced and spawns the background worker to monitor synchronization.
 func MarkDesynced() {
 	synced.Store(false)
-	monitorForSynchronization()
+	isRunning := false
+	for _, worker := range daemon.GetRunningBackgroundWorkers() {
+		if worker == "Sync-Monitor" {
+			isRunning = true
+			break
+		}
+	}
+
+	if !isRunning {
+		monitorForSynchronization()
+	}
 }
 
 // starts a background worker and event handlers to check whether the node is desynchronized by checking

--- a/plugins/syncbeacon/payload.go
+++ b/plugins/syncbeacon/payload.go
@@ -108,17 +108,12 @@ func IsSyncBeaconPayload(p *Payload) bool {
 }
 
 func init() {
-	payload.RegisterType(Type, ObjectName, GenericPayloadUnmarshalerFactory(Type))
-}
-
-// GenericPayloadUnmarshalerFactory sets the generic unmarshaler.
-func GenericPayloadUnmarshalerFactory(payloadType payload.Type) payload.Unmarshaler {
-	return func(data []byte) (payload payload.Payload, err error) {
+	payload.RegisterType(Type, ObjectName, func(data []byte) (payload payload.Payload, err error) {
 		payload = &Payload{
-			payloadType: payloadType,
+			payloadType: Type,
 		}
 		err = payload.Unmarshal(data)
 
 		return
-	}
+	})
 }

--- a/plugins/syncbeacon/payload.go
+++ b/plugins/syncbeacon/payload.go
@@ -1,7 +1,6 @@
 package syncbeacon
 
 import (
-	"github.com/iotaledger/goshimmer/packages/binary/messagelayer/message"
 	"github.com/iotaledger/goshimmer/packages/binary/messagelayer/payload"
 	"github.com/iotaledger/hive.go/marshalutil"
 	"github.com/iotaledger/hive.go/stringify"
@@ -12,6 +11,7 @@ const (
 	ObjectName = "syncbeacon"
 )
 
+// Type is the type of the syncbeacon payload.
 var Type = payload.Type(200)
 
 // Payload represents the syncbeacon payload
@@ -71,7 +71,7 @@ func (p *Payload) Type() payload.Type {
 	return p.payloadType
 }
 
-// Status returns the sync sync status of the  Payload.
+// SyncStatus returns the sync sync status of the  Payload.
 func (p *Payload) SyncStatus() bool {
 	return p.syncStatus
 }
@@ -110,8 +110,8 @@ func (p *Payload) String() string {
 }
 
 // IsSyncBeaconPayload checks if the message is sync beacon payload.
-func IsSyncBeaconPayload(msg *message.Message) bool {
-	return msg.Payload().Type() == Type
+func IsSyncBeaconPayload(p *Payload) bool {
+	return p.Type() == Type
 }
 
 func init() {

--- a/plugins/syncbeacon/payload.go
+++ b/plugins/syncbeacon/payload.go
@@ -49,6 +49,10 @@ func FromBytes(bytes []byte, optionalTargetObject ...*Payload) (result *Payload,
 	if err != nil {
 		return
 	}
+	_, err = marshalUtil.ReadUint32()
+	if err != nil {
+		return
+	}
 	result.sentTime, err = marshalUtil.ReadInt64()
 	if err != nil {
 		return
@@ -74,9 +78,11 @@ func (p *Payload) SentTime() int64 {
 func (p *Payload) Bytes() []byte {
 	// initialize helper
 	marshalUtil := marshalutil.New()
+	objectLength := marshalutil.INT64_SIZE
 
 	// marshal the p specific information
-	marshalUtil.WriteUint32(p.payloadType)
+	marshalUtil.WriteUint32(Type)
+	marshalUtil.WriteUint32(uint32(objectLength))
 	marshalUtil.WriteInt64(p.sentTime)
 
 	// return result
@@ -99,15 +105,6 @@ func (p *Payload) String() string {
 // IsSyncBeaconPayload checks if the message is sync beacon payload.
 func IsSyncBeaconPayload(p *Payload) bool {
 	return p.Type() == Type
-}
-
-func init() {
-	payload.RegisterType(Type, ObjectName, func(data []byte) (payload payload.Payload, err error) {
-		payload = &Payload{}
-		err = payload.Unmarshal(data)
-
-		return
-	})
 }
 
 func init() {

--- a/plugins/syncbeacon/payload.go
+++ b/plugins/syncbeacon/payload.go
@@ -109,9 +109,7 @@ func IsSyncBeaconPayload(p *Payload) bool {
 
 func init() {
 	payload.RegisterType(Type, ObjectName, func(data []byte) (payload payload.Payload, err error) {
-		payload = &Payload{
-			payloadType: Type,
-		}
+		payload = &Payload{}
 		err = payload.Unmarshal(data)
 
 		return

--- a/plugins/syncbeacon/payload.go
+++ b/plugins/syncbeacon/payload.go
@@ -17,15 +17,13 @@ var Type = payload.Type(200)
 // Payload represents the syncbeacon payload
 type Payload struct {
 	payloadType payload.Type
-	syncStatus  bool
 	sentTime    int64
 }
 
 // NewSyncBeaconPayload creates a new syncbeacon payload
-func NewSyncBeaconPayload(status bool, sentTime int64) *Payload {
+func NewSyncBeaconPayload(sentTime int64) *Payload {
 	return &Payload{
 		payloadType: Type,
-		syncStatus:  status,
 		sentTime:    sentTime,
 	}
 }
@@ -51,10 +49,6 @@ func FromBytes(bytes []byte, optionalTargetObject ...*Payload) (result *Payload,
 	if err != nil {
 		return
 	}
-	result.syncStatus, err = marshalUtil.ReadBool()
-	if err != nil {
-		return
-	}
 	result.sentTime, err = marshalUtil.ReadInt64()
 	if err != nil {
 		return
@@ -71,11 +65,6 @@ func (p *Payload) Type() payload.Type {
 	return p.payloadType
 }
 
-// SyncStatus returns the sync sync status of the  Payload.
-func (p *Payload) SyncStatus() bool {
-	return p.syncStatus
-}
-
 // SentTime returns the time that payload was sent.
 func (p *Payload) SentTime() int64 {
 	return p.sentTime
@@ -88,7 +77,6 @@ func (p *Payload) Bytes() []byte {
 
 	// marshal the p specific information
 	marshalUtil.WriteUint32(p.payloadType)
-	marshalUtil.WriteBool(p.syncStatus)
 	marshalUtil.WriteInt64(p.sentTime)
 
 	// return result
@@ -105,7 +93,6 @@ func (p *Payload) Unmarshal(data []byte) (err error) {
 // String returns a human readable version of syncbeacon payload (for debug purposes).
 func (p *Payload) String() string {
 	return stringify.Struct("syncBeaconPayload",
-		stringify.StructField("syncStatus", p.syncStatus),
 		stringify.StructField("sentTime", p.sentTime))
 }
 

--- a/plugins/syncbeacon/payload.go
+++ b/plugins/syncbeacon/payload.go
@@ -1,0 +1,140 @@
+package syncbeacon
+
+import (
+	"github.com/iotaledger/goshimmer/packages/binary/messagelayer/message"
+	"github.com/iotaledger/goshimmer/packages/binary/messagelayer/payload"
+	"github.com/iotaledger/hive.go/marshalutil"
+	"github.com/iotaledger/hive.go/stringify"
+)
+
+const (
+	// ObjectName defines the name of the syncbeacon object.
+	ObjectName = "syncbeacon"
+)
+
+var Type = payload.Type(200)
+
+// Payload represents the syncbeacon payload
+type Payload struct {
+	payloadType payload.Type
+	syncStatus  bool
+	sentTime    int64
+}
+
+// NewSyncBeaconPayload creates a new syncbeacon payload
+func NewSyncBeaconPayload(status bool, sentTime int64) *Payload {
+	return &Payload{
+		payloadType: Type,
+		syncStatus:  status,
+		sentTime:    sentTime,
+	}
+}
+
+// FromBytes parses the marshaled version of a Payload into an object.
+// It either returns a new Payload or fills an optionally provided Payload with the parsed information.
+func FromBytes(bytes []byte, optionalTargetObject ...*Payload) (result *Payload, err error, consumedBytes int) {
+	// determine the target object that will hold the unmarshaled information
+	switch len(optionalTargetObject) {
+	case 0:
+		result = &Payload{}
+	case 1:
+		result = optionalTargetObject[0]
+	default:
+		panic("too many arguments in call to FromBytes")
+	}
+
+	// initialize helper
+	marshalUtil := marshalutil.New(bytes)
+
+	// read data
+	result.payloadType, err = marshalUtil.ReadUint32()
+	if err != nil {
+		return
+	}
+	result.syncStatus, err = marshalUtil.ReadBool()
+	if err != nil {
+		return
+	}
+	result.sentTime, err = marshalUtil.ReadInt64()
+	if err != nil {
+		return
+	}
+
+	// return the number of bytes we processed
+	consumedBytes = marshalUtil.ReadOffset()
+
+	return
+}
+
+// Type returns the type of the Payload.
+func (p *Payload) Type() payload.Type {
+	return p.payloadType
+}
+
+// Status returns the sync sync status of the  Payload.
+func (p *Payload) SyncStatus() bool {
+	return p.syncStatus
+}
+
+// SentTime returns the time that payload was sent.
+func (p *Payload) SentTime() int64 {
+	return p.sentTime
+}
+
+// Bytes marshals the data payload into a sequence of bytes.
+func (p *Payload) Bytes() []byte {
+	// initialize helper
+	marshalUtil := marshalutil.New()
+
+	// marshal the p specific information
+	marshalUtil.WriteUint32(p.payloadType)
+	marshalUtil.WriteBool(p.syncStatus)
+	marshalUtil.WriteInt64(p.sentTime)
+
+	// return result
+	return marshalUtil.Bytes()
+}
+
+// Unmarshal unmarshals a given slice of bytes and fills the object.
+func (p *Payload) Unmarshal(data []byte) (err error) {
+	_, err, _ = FromBytes(data, p)
+
+	return
+}
+
+// String returns a human readable version of syncbeacon payload (for debug purposes).
+func (p *Payload) String() string {
+	return stringify.Struct("syncBeaconPayload",
+		stringify.StructField("syncStatus", p.syncStatus),
+		stringify.StructField("sentTime", p.sentTime))
+}
+
+// IsSyncBeaconPayload checks if the message is sync beacon payload.
+func IsSyncBeaconPayload(msg *message.Message) bool {
+	return msg.Payload().Type() == Type
+}
+
+func init() {
+	payload.RegisterType(Type, ObjectName, func(data []byte) (payload payload.Payload, err error) {
+		payload = &Payload{}
+		err = payload.Unmarshal(data)
+
+		return
+	})
+}
+
+func init() {
+	payload.RegisterType(Type, ObjectName, GenericPayloadUnmarshalerFactory(Type))
+}
+
+// GenericPayloadUnmarshalerFactory sets the generic unmarshaler.
+func GenericPayloadUnmarshalerFactory(payloadType payload.Type) payload.Unmarshaler {
+	return func(data []byte) (payload payload.Payload, err error) {
+		payload = &Payload{
+			payloadType: payloadType,
+		}
+		err = payload.Unmarshal(data)
+
+		return
+	}
+}

--- a/plugins/syncbeacon/payload.go
+++ b/plugins/syncbeacon/payload.go
@@ -70,7 +70,7 @@ func (p *Payload) SentTime() int64 {
 	return p.sentTime
 }
 
-// Bytes marshals the data payload into a sequence of bytes.
+// Bytes marshals the syncbeacon payload into a sequence of bytes.
 func (p *Payload) Bytes() []byte {
 	// initialize helper
 	marshalUtil := marshalutil.New()

--- a/plugins/syncbeacon/payload_test.go
+++ b/plugins/syncbeacon/payload_test.go
@@ -7,24 +7,24 @@ import (
 )
 
 func TestPayload(t *testing.T) {
-	originalPayload := NewSyncBeaconPayload(true, time.Now().UnixNano())
+	originalPayload := NewSyncBeaconPayload(time.Now().UnixNano())
 	clonedPayload1, err, _ := FromBytes(originalPayload.Bytes())
 	if err != nil {
 		panic(err)
 	}
 
-	assert.Equal(t, originalPayload.SyncStatus(), clonedPayload1.SyncStatus())
+	assert.Equal(t, originalPayload.SentTime(), clonedPayload1.SentTime())
 
 	clonedPayload2, err, _ := FromBytes(clonedPayload1.Bytes())
 	if err != nil {
 		panic(err)
 	}
 
-	assert.Equal(t, originalPayload.SyncStatus(), clonedPayload2.SyncStatus())
+	assert.Equal(t, originalPayload.SentTime(), clonedPayload2.SentTime())
 }
 
 func TestIsSyncBeaconPayload(t *testing.T) {
-	p := NewSyncBeaconPayload(true, time.Now().UnixNano())
+	p := NewSyncBeaconPayload(time.Now().UnixNano())
 
 	isSyncBeaconPayload := IsSyncBeaconPayload(p)
 	assert.True(t, isSyncBeaconPayload)

--- a/plugins/syncbeacon/payload_test.go
+++ b/plugins/syncbeacon/payload_test.go
@@ -1,0 +1,24 @@
+package syncbeacon
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestPayload(t *testing.T) {
+	originalPayload := NewSyncBeaconPayload(true, time.Now().UnixNano())
+	clonedPayload1, err, _ := FromBytes(originalPayload.Bytes())
+	if err != nil {
+		panic(err)
+	}
+
+	assert.Equal(t, originalPayload.SyncStatus(), clonedPayload1.SyncStatus())
+
+	clonedPayload2, err, _ := FromBytes(clonedPayload1.Bytes())
+	if err != nil {
+		panic(err)
+	}
+
+	assert.Equal(t, originalPayload.SyncStatus(), clonedPayload2.SyncStatus())
+}

--- a/plugins/syncbeacon/payload_test.go
+++ b/plugins/syncbeacon/payload_test.go
@@ -22,3 +22,10 @@ func TestPayload(t *testing.T) {
 
 	assert.Equal(t, originalPayload.SyncStatus(), clonedPayload2.SyncStatus())
 }
+
+func TestIsSyncBeaconPayload(t *testing.T) {
+	p := NewSyncBeaconPayload(true, time.Now().UnixNano())
+
+	isSyncBeaconPayload := IsSyncBeaconPayload(p)
+	assert.True(t, isSyncBeaconPayload)
+}

--- a/plugins/syncbeacon/plugin.go
+++ b/plugins/syncbeacon/plugin.go
@@ -1,15 +1,12 @@
 package syncbeacon
 
 import (
-	"github.com/iotaledger/goshimmer/packages/binary/messagelayer/message"
 	gossipPkg "github.com/iotaledger/goshimmer/packages/gossip"
 	"github.com/iotaledger/goshimmer/packages/shutdown"
 	"github.com/iotaledger/goshimmer/plugins/config"
 	"github.com/iotaledger/goshimmer/plugins/gossip"
-	"github.com/iotaledger/goshimmer/plugins/messagelayer"
 	"github.com/iotaledger/goshimmer/plugins/sync"
 	"github.com/iotaledger/hive.go/autopeering/peer"
-	"github.com/iotaledger/hive.go/crypto/ed25519"
 	"github.com/iotaledger/hive.go/daemon"
 	"github.com/iotaledger/hive.go/events"
 	"github.com/iotaledger/hive.go/logger"
@@ -36,25 +33,33 @@ const (
 	// CfgSyncBeaconBroadcastIntervalSec is the interval in seconds at which the node broadcasts its sync status.
 	CfgSyncBeaconBroadcastIntervalSec = "syncbeacon.broadcastInterval"
 
+	// CfgSyncBeaconMaxTimeOfflineSec defines the maximum time a beacon node can stay without receiving updates.
+	CfgSyncBeaconMaxTimeOfflineSec = "syncbeacon.maxTimeOffline"
+
+	// CfgSyncBeaconCleanupInterval defines the interval that old beacon status are cleaned up.
+	CfgSyncBeaconCleanupInterval = "syncbeacon.cleanupInterval"
+
 	// The percentage of following nodes that have to be synced
-	syncPercentage = 2.0 / 3.0
+	syncPercentage = 0.6
 )
 
 func init() {
-	// TODO: Check the defaults here
-	flag.StringSlice(CfgSyncBeaconFollowNodes, []string{"2PV5487xMw5rasGBXXWeqSi4hLz7r19YBt8Y1TGAsQ"}, "list of trusted nodes to follow their sync status")
+	flag.StringSlice(CfgSyncBeaconFollowNodes, []string{"Gm7W191NDnqyF7KJycZqK7V6ENLwqxTwoKQN4SmpkB24", "9DB3j9cWYSuEEtkvanrzqkzCQMdH1FGv3TawJdVbDxkd"}, "list of trusted nodes to follow their sync status")
 	flag.Bool(CfgSyncBeaconPrimary, false, "if this node should be a sync beacon")
 	flag.Int(CfgSyncBeaconBroadcastIntervalSec, 30, "the interval at which the node will broadcast ist sync status")
 	flag.Int(CfgSyncBeaconMaxTimeWindowSec, 10, "the maximum time window for which a sync payload would be considerable")
+	flag.Int(CfgSyncBeaconMaxTimeOfflineSec, 40, "the maximum time the node should stay without receiving updates")
+	flag.Int(CfgSyncBeaconCleanupInterval, 10, "the interval at which cleanups are done")
 }
 
 var (
 	// plugin is the plugin instance of the sync beacon plugin.
-	plugin               *node.Plugin
-	once                 goSync.Once
-	log                  *logger.Logger
-	mgr                  *gossipPkg.Manager
-	beaconNodesStatusMap map[string]Payload
+	plugin                *node.Plugin
+	once                  goSync.Once
+	log                   *logger.Logger
+	mgr                   *gossipPkg.Manager
+	beaconNodesStatusMap  map[string]Payload
+	beaconNodesPublicKeys []string
 )
 
 // Plugin gets the plugin instance.
@@ -68,25 +73,33 @@ func Plugin() *node.Plugin {
 // configure events
 func configure(_ *node.Plugin) {
 	log = logger.NewLogger(PluginName)
-	gossip.Manager().Events().MessageReceived.Attach(events.NewClosure(func(event gossipPkg.MessageReceivedEvent) {
-		messagelayer.MessageParser().Parse(event.Data, event.Peer)
-	}))
-	messagelayer.MessageParser().Events.MessageParsed.Attach(events.NewClosure(func(message *message.Message, peer *peer.Peer) {
-		handleMessage(message, peer)
+	beaconNodesPublicKeys = config.Node().GetStringSlice(CfgSyncBeaconFollowNodes)
+	beaconNodesStatusMap = make(map[string]Payload, len(beaconNodesPublicKeys))
+	for _, key := range beaconNodesPublicKeys {
+		beaconNodesStatusMap[key] = Payload{}
+	}
+	mgr = gossip.Manager()
+
+	gossip.Manager().Events().MessageReceived.Attach(events.NewClosure(func(event *gossipPkg.MessageReceivedEvent) {
+		payload := &Payload{}
+		err := payload.Unmarshal(event.Data)
+		if err != nil {
+			log.Info("error unmarshalling", err)
+		} else {
+			handlePayload(payload, event.Peer)
+		}
 	}))
 }
 
-// handleMessage handles the received message. It does the following checks:
+// handlePayload handles the received payload. It does the following checks:
 // - The payload is a syncbeacon payload. Then it checks that the issuer of the payload is a followed node.
 // - The time that payload was sent is not greater than  CfgSyncBeaconMaxTimeWindowSec. If the duration is longer than CfgSyncBeaconMaxTimeWindowSec, we consider that beacon to be out of sync till we receive a newer payload.
 // - If the node is synced and more than syncPercentage of followed nodes are also synced, the node is set to synced. Otherwise, its set as desynced.
-func handleMessage(message *message.Message, peer *peer.Peer) {
-	if !IsSyncBeaconPayload(message) {
+func handlePayload(syncBeaconPayload *Payload, peer *peer.Peer) {
+	if !IsSyncBeaconPayload(syncBeaconPayload) {
 		return
 	}
 	peerPublicKey := peer.PublicKey().String()
-	beaconNodesPublicKeys := config.Node().GetStringSlice(CfgSyncBeaconFollowNodes)
-	beaconNodesStatusMap = make(map[string]Payload, len(beaconNodesPublicKeys))
 
 	//check if peer is in configured beacon follow list
 	shouldAccept := false
@@ -100,30 +113,29 @@ func handleMessage(message *message.Message, peer *peer.Peer) {
 		return
 	}
 
-	syncBeaconPayload := &Payload{}
-	err := syncBeaconPayload.Unmarshal(message.Payload().Bytes())
-	if err != nil {
-		log.Errorf("error unmarshalling syncbeacon payload %s", err)
-		return
-	}
-
-	log.Infof("syncbeacon payload received from %s", peerPublicKey)
-
-	dur := time.Now().Sub(time.Unix(0, syncBeaconPayload.sentTime))
+	dur := time.Since(time.Unix(0, syncBeaconPayload.sentTime))
 	if dur.Seconds() > float64(config.Node().GetInt(CfgSyncBeaconMaxTimeWindowSec)) {
 		log.Infof("syncbeacon payload received from %s is too old", peerPublicKey)
 		syncBeaconPayload.syncStatus = false
 	}
 
 	beaconNodesStatusMap[peerPublicKey] = *syncBeaconPayload
+	updateSynced()
+}
+
+// updateSynced checks the beacon nodes and update the nodes sync status
+func updateSynced() {
 	beaconNodesSyncedCount := 0.0
 	for _, p := range beaconNodesStatusMap {
 		if p.SyncStatus() {
 			beaconNodesSyncedCount++
 		}
 	}
+	isBeaconSynced := true
+	if len(beaconNodesStatusMap) > 0 {
+		isBeaconSynced = beaconNodesSyncedCount/float64(len(beaconNodesStatusMap)) >= syncPercentage
+	}
 	isLocalSynced := sync.Synced()
-	isBeaconSynced := (beaconNodesSyncedCount / float64(len(beaconNodesPublicKeys))) > syncPercentage
 	if isLocalSynced && isBeaconSynced {
 		sync.MarkSynced()
 	} else {
@@ -134,21 +146,47 @@ func handleMessage(message *message.Message, peer *peer.Peer) {
 // broadcastSyncBeaconPayload broadcasts its sync status to its neighbors.
 func broadcastSyncBeaconPayload() {
 	syncBeaconPayload := NewSyncBeaconPayload(sync.Synced(), time.Now().UnixNano())
-	msg := message.New(message.EmptyId, message.EmptyId, time.Now(), ed25519.PublicKey{}, 0, syncBeaconPayload, 0, ed25519.Signature{})
-	mgr.SendMessage(msg.Bytes())
+	//msg := message.New(message.EmptyId, message.EmptyId, time.Now(), local.GetInstance().LocalIdentity().PublicKey(), 0, syncBeaconPayload, 0, ed25519.Signature{})
+	mgr.SendMessage(syncBeaconPayload.Bytes())
+}
+
+// cleanupFollowNodes cleans up offline nodes by setting their sync status to false after a configurable time window.
+func cleanupFollowNodes() {
+	for publicKey, syncBeaconPayload := range beaconNodesStatusMap {
+		dur := time.Since(time.Unix(0, syncBeaconPayload.sentTime))
+		if dur.Seconds() > float64(config.Node().GetInt(CfgSyncBeaconMaxTimeOfflineSec)) {
+			syncBeaconPayload.syncStatus = false
+			beaconNodesStatusMap[publicKey] = syncBeaconPayload
+		}
+	}
+	updateSynced()
 }
 
 func run(_ *node.Plugin) {
-	if !config.Node().GetBool(CfgSyncBeaconPrimary) {
-		return
+	if config.Node().GetBool(CfgSyncBeaconPrimary) {
+		if err := daemon.BackgroundWorker("Sync-Beacon-Broadcast", func(shutdownSignal <-chan struct{}) {
+			ticker := time.NewTicker(config.Node().GetDuration(CfgSyncBeaconBroadcastIntervalSec) * time.Second)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ticker.C:
+					broadcastSyncBeaconPayload()
+				case <-shutdownSignal:
+					return
+				}
+			}
+		}, shutdown.PrioritySynchronization); err != nil {
+			log.Panicf("Failed to start as daemon: %s", err)
+		}
 	}
-	if err := daemon.BackgroundWorker("Sync-Beacon", func(shutdownSignal <-chan struct{}) {
-		ticker := time.NewTicker(config.Node().GetDuration(CfgSyncBeaconBroadcastIntervalSec) * time.Second)
+
+	if err := daemon.BackgroundWorker("Sync-Beacon-Cleanup", func(shutdownSignal <-chan struct{}) {
+		ticker := time.NewTicker(config.Node().GetDuration(CfgSyncBeaconCleanupInterval) * time.Second)
 		defer ticker.Stop()
 		for {
 			select {
 			case <-ticker.C:
-				broadcastSyncBeaconPayload()
+				cleanupFollowNodes()
 			case <-shutdownSignal:
 				return
 			}

--- a/plugins/syncbeacon/plugin.go
+++ b/plugins/syncbeacon/plugin.go
@@ -47,8 +47,12 @@ func configure(_ *node.Plugin) {
 // broadcastSyncBeaconPayload broadcasts a sync beacon via communication layer.
 func broadcastSyncBeaconPayload() {
 	syncBeaconPayload := NewSyncBeaconPayload(time.Now().UnixNano())
-	msg := messagelayer.MessageFactory().IssuePayload(syncBeaconPayload)
-	log.Infof("issued sync beacon %s", msg.Id())
+	msg, err := messagelayer.MessageFactory().IssuePayload(syncBeaconPayload)
+	if err != nil {
+		log.Infof("error issuing sync beacon. %w", err)
+	} else {
+		log.Infof("issued sync beacon %s", msg.Id())
+	}
 }
 
 func run(_ *node.Plugin) {

--- a/plugins/syncbeacon/plugin.go
+++ b/plugins/syncbeacon/plugin.go
@@ -1,19 +1,14 @@
 package syncbeacon
 
 import (
-	"github.com/iotaledger/goshimmer/packages/binary/messagelayer/message"
-	"github.com/iotaledger/goshimmer/packages/binary/messagelayer/tangle"
 	"github.com/iotaledger/goshimmer/packages/shutdown"
 	"github.com/iotaledger/goshimmer/plugins/config"
 	"github.com/iotaledger/goshimmer/plugins/messagelayer"
-	"github.com/iotaledger/goshimmer/plugins/sync"
-	"github.com/iotaledger/hive.go/crypto/ed25519"
 	"github.com/iotaledger/hive.go/daemon"
-	"github.com/iotaledger/hive.go/events"
 	"github.com/iotaledger/hive.go/logger"
 	"github.com/iotaledger/hive.go/node"
 	flag "github.com/spf13/pflag"
-	goSync "sync"
+	"sync"
 	"time"
 )
 
@@ -21,51 +16,19 @@ const (
 	// PluginName is the plugin name of the sync beacon plugin.
 	PluginName = "Sync Beacon"
 
-	// CfgSyncBeaconFollowNodes defines the list of nodes this node should follow to determine its sync status.
-	CfgSyncBeaconFollowNodes = "syncbeacon.followNodes"
-
-	// CfgSyncBeaconPrimary defines whether this node should be a beacon.
-	// If set to true, the node will broadcast its sync status on every heartbeat to its followers.
-	CfgSyncBeaconPrimary = "syncbeacon.primary"
-
-	// CfgSyncBeaconMaxTimeWindowSec defines the maximum time window for which a sync payload would be considerable.
-	CfgSyncBeaconMaxTimeWindowSec = "syncbeacon.maxTimeWindowSec"
-
 	// CfgSyncBeaconBroadcastIntervalSec is the interval in seconds at which the node broadcasts its sync status.
 	CfgSyncBeaconBroadcastIntervalSec = "syncbeacon.broadcastInterval"
-
-	// CfgSyncBeaconMaxTimeOfflineSec defines the maximum time a beacon node can stay without receiving updates.
-	CfgSyncBeaconMaxTimeOfflineSec = "syncbeacon.maxTimeOffline"
-
-	// CfgSyncBeaconCleanupInterval defines the interval that old beacon status are cleaned up.
-	CfgSyncBeaconCleanupInterval = "syncbeacon.cleanupInterval"
-
-	// The percentage of following nodes that have to be synced.
-	syncPercentage = 0.6
 )
 
-// beaconSync represents the beacon payload and the sync status.
-type beaconSync struct {
-	payload *Payload
-	synced  bool
-}
-
 func init() {
-	flag.StringSlice(CfgSyncBeaconFollowNodes, []string{"Gm7W191NDnqyF7KJycZqK7V6ENLwqxTwoKQN4SmpkB24", "9DB3j9cWYSuEEtkvanrzqkzCQMdH1FGv3TawJdVbDxkd"}, "list of trusted nodes to follow their sync status")
-	flag.Bool(CfgSyncBeaconPrimary, false, "if this node should be a sync beacon")
 	flag.Int(CfgSyncBeaconBroadcastIntervalSec, 30, "the interval at which the node will broadcast ist sync status")
-	flag.Int(CfgSyncBeaconMaxTimeWindowSec, 10, "the maximum time window for which a sync payload would be considerable")
-	flag.Int(CfgSyncBeaconMaxTimeOfflineSec, 40, "the maximum time the node should stay without receiving updates")
-	flag.Int(CfgSyncBeaconCleanupInterval, 10, "the interval at which cleanups are done")
 }
 
 var (
 	// plugin is the plugin instance of the sync beacon plugin.
-	plugin                *node.Plugin
-	once                  goSync.Once
-	log                   *logger.Logger
-	beaconSyncMap         map[string]beaconSync
-	beaconNodesPublicKeys []string
+	plugin *node.Plugin
+	once   sync.Once
+	log    *logger.Logger
 )
 
 // Plugin gets the plugin instance.
@@ -79,83 +42,6 @@ func Plugin() *node.Plugin {
 // configure events
 func configure(_ *node.Plugin) {
 	log = logger.NewLogger(PluginName)
-	beaconNodesPublicKeys = config.Node().GetStringSlice(CfgSyncBeaconFollowNodes)
-	beaconSyncMap = make(map[string]beaconSync, len(beaconNodesPublicKeys))
-	for _, pubKey := range beaconNodesPublicKeys {
-		beaconSyncMap[pubKey] = beaconSync{
-			payload: nil,
-			synced:  false,
-		}
-	}
-
-	messagelayer.Tangle().Events.MessageSolid.Attach(events.NewClosure(func(cachedMessage *message.CachedMessage, cachedMessageMetadata *tangle.CachedMessageMetadata) {
-		cachedMessageMetadata.Release()
-		cachedMessage.Consume(func(msg *message.Message) {
-			payload := &Payload{}
-			err := payload.Unmarshal(msg.Payload().Bytes())
-			if err != nil {
-				return
-			}
-			if !IsSyncBeaconPayload(payload) {
-				return
-			}
-
-			handlePayload(payload, msg.IssuerPublicKey())
-		})
-	}))
-}
-
-// handlePayload handles the received payload. It does the following checks:
-// It checks that the issuer of the payload is a followed node.
-// The time that payload was sent is not greater than  CfgSyncBeaconMaxTimeWindowSec. If the duration is longer than CfgSyncBeaconMaxTimeWindowSec, we consider that beacon to be out of sync till we receive a newer payload.
-// More than syncPercentage of followed nodes are also synced, the node is set to synced. Otherwise, its set as desynced.
-func handlePayload(syncBeaconPayload *Payload, issuerPublicKey ed25519.PublicKey) {
-	issuerPublicKeyStr := issuerPublicKey.String()
-	//check if issuer is in configured beacon follow list
-	shouldAccept := false
-	for _, pubKey := range beaconNodesPublicKeys {
-		if pubKey == issuerPublicKeyStr {
-			shouldAccept = true
-			break
-		}
-	}
-	if !shouldAccept {
-		return
-	}
-	_beaconSync := beaconSync{
-		payload: syncBeaconPayload,
-		synced:  true,
-	}
-
-	dur := time.Since(time.Unix(0, syncBeaconPayload.sentTime))
-	if dur.Seconds() > float64(config.Node().GetInt(CfgSyncBeaconMaxTimeWindowSec)) {
-		log.Infof("syncbeacon received from %s is too old", issuerPublicKey)
-		_beaconSync.synced = false
-	}
-
-	beaconSyncMap[issuerPublicKeyStr] = _beaconSync
-	updateSynced()
-}
-
-// updateSynced checks the beacon nodes and update the nodes sync status
-func updateSynced() {
-	beaconNodesSyncedCount := 0.0
-	for _, beaconSync := range beaconSyncMap {
-		if beaconSync.synced {
-			beaconNodesSyncedCount++
-		}
-	}
-	synced := true
-	if len(beaconSyncMap) > 0 {
-		synced = beaconNodesSyncedCount/float64(len(beaconSyncMap)) >= syncPercentage
-	}
-
-	if synced {
-		sync.MarkSynced()
-		log.Info("synced from beacon")
-	} else {
-		sync.MarkDesynced()
-	}
 }
 
 // broadcastSyncBeaconPayload broadcasts sends a sync beacon to the message layer
@@ -165,48 +51,14 @@ func broadcastSyncBeaconPayload() {
 	log.Info("issued sync beacon")
 }
 
-// cleanupFollowNodes cleans up offline nodes by setting their sync status to false after a configurable time window.
-func cleanupFollowNodes() {
-	if len(beaconNodesPublicKeys) == 0 {
-		return
-	}
-	for publicKey, beaconSync := range beaconSyncMap {
-		if beaconSync.payload != nil {
-			dur := time.Since(time.Unix(0, beaconSync.payload.sentTime))
-			if dur.Seconds() > float64(config.Node().GetInt(CfgSyncBeaconMaxTimeOfflineSec)) {
-				beaconSync.synced = false
-				beaconSyncMap[publicKey] = beaconSync
-			}
-		}
-	}
-	updateSynced()
-}
-
 func run(_ *node.Plugin) {
-	if config.Node().GetBool(CfgSyncBeaconPrimary) {
-		if err := daemon.BackgroundWorker("Sync-Beacon-Broadcast", func(shutdownSignal <-chan struct{}) {
-			ticker := time.NewTicker(config.Node().GetDuration(CfgSyncBeaconBroadcastIntervalSec) * time.Second)
-			defer ticker.Stop()
-			for {
-				select {
-				case <-ticker.C:
-					broadcastSyncBeaconPayload()
-				case <-shutdownSignal:
-					return
-				}
-			}
-		}, shutdown.PrioritySynchronization); err != nil {
-			log.Panicf("Failed to start as daemon: %s", err)
-		}
-	}
-
-	if err := daemon.BackgroundWorker("Sync-Beacon-Cleanup", func(shutdownSignal <-chan struct{}) {
-		ticker := time.NewTicker(config.Node().GetDuration(CfgSyncBeaconCleanupInterval) * time.Second)
+	if err := daemon.BackgroundWorker("Sync-Beacon", func(shutdownSignal <-chan struct{}) {
+		ticker := time.NewTicker(config.Node().GetDuration(CfgSyncBeaconBroadcastIntervalSec) * time.Second)
 		defer ticker.Stop()
 		for {
 			select {
 			case <-ticker.C:
-				cleanupFollowNodes()
+				broadcastSyncBeaconPayload()
 			case <-shutdownSignal:
 				return
 			}

--- a/plugins/syncbeacon/plugin.go
+++ b/plugins/syncbeacon/plugin.go
@@ -157,12 +157,13 @@ func broadcastSyncBeaconPayload() {
 	syncBeaconPayload := NewSyncBeaconPayload(time.Now().UnixNano())
 	_, err := issuer.IssuePayload(syncBeaconPayload)
 	if err != nil {
-		log.Info("sync beacon issued")
+		log.Infof("error broadcasting sync payload: %w", err)
 	}
 }
 
 // cleanupFollowNodes cleans up offline nodes by setting their sync status to false after a configurable time window.
 func cleanupFollowNodes() {
+	log.Info("cleaning up stale beacons... ", beaconSyncMap)
 	for publicKey, beaconSync := range beaconSyncMap {
 		dur := time.Since(time.Unix(0, beaconSync.payload.sentTime))
 		if dur.Seconds() > float64(config.Node().GetInt(CfgSyncBeaconMaxTimeOfflineSec)) {
@@ -170,6 +171,7 @@ func cleanupFollowNodes() {
 			beaconSyncMap[publicKey] = beaconSync
 		}
 	}
+	log.Info("done clean up", beaconSyncMap)
 	updateSynced()
 }
 

--- a/plugins/syncbeacon/plugin.go
+++ b/plugins/syncbeacon/plugin.go
@@ -44,11 +44,11 @@ func configure(_ *node.Plugin) {
 	log = logger.NewLogger(PluginName)
 }
 
-// broadcastSyncBeaconPayload broadcasts sends a sync beacon to the message layer
+// broadcastSyncBeaconPayload broadcasts a sync beacon via communication layer.
 func broadcastSyncBeaconPayload() {
 	syncBeaconPayload := NewSyncBeaconPayload(time.Now().UnixNano())
-	messagelayer.MessageFactory().IssuePayload(syncBeaconPayload)
-	log.Info("issued sync beacon")
+	msg := messagelayer.MessageFactory().IssuePayload(syncBeaconPayload)
+	log.Infof("issued sync beacon %s", msg.Id())
 }
 
 func run(_ *node.Plugin) {

--- a/plugins/syncbeacon/plugin.go
+++ b/plugins/syncbeacon/plugin.go
@@ -108,8 +108,8 @@ func handlePayload(syncBeaconPayload *Payload, issuerPublicKey ed25519.PublicKey
 	issuerPublicKeyStr := issuerPublicKey.String()
 	//check if issuer is in configured beacon follow list
 	shouldAccept := false
-	for i := 0; i < len(beaconNodesPublicKeys); i++ {
-		if beaconNodesPublicKeys[i] == issuerPublicKeyStr {
+	for _, pubKey := range beaconNodesPublicKeys {
+		if pubKey == issuerPublicKeyStr {
 			shouldAccept = true
 			break
 		}
@@ -145,8 +145,7 @@ func updateSynced() {
 		synced = beaconNodesSyncedCount/float64(len(beaconSyncMap)) >= syncPercentage
 	}
 
-	isLocalSynced := sync.Synced()
-	if isLocalSynced && synced {
+	if synced {
 		sync.MarkSynced()
 	} else {
 		sync.MarkDesynced()

--- a/plugins/syncbeacon/plugin.go
+++ b/plugins/syncbeacon/plugin.go
@@ -1,0 +1,159 @@
+package syncbeacon
+
+import (
+	"github.com/iotaledger/goshimmer/packages/binary/messagelayer/message"
+	gossipPkg "github.com/iotaledger/goshimmer/packages/gossip"
+	"github.com/iotaledger/goshimmer/packages/shutdown"
+	"github.com/iotaledger/goshimmer/plugins/config"
+	"github.com/iotaledger/goshimmer/plugins/gossip"
+	"github.com/iotaledger/goshimmer/plugins/messagelayer"
+	"github.com/iotaledger/goshimmer/plugins/sync"
+	"github.com/iotaledger/hive.go/autopeering/peer"
+	"github.com/iotaledger/hive.go/crypto/ed25519"
+	"github.com/iotaledger/hive.go/daemon"
+	"github.com/iotaledger/hive.go/events"
+	"github.com/iotaledger/hive.go/logger"
+	"github.com/iotaledger/hive.go/node"
+	flag "github.com/spf13/pflag"
+	goSync "sync"
+	"time"
+)
+
+const (
+	// PluginName is the plugin name of the sync beacon plugin.
+	PluginName = "Sync Beacon"
+
+	// CfgSyncBeaconFollowNodes defines the list of nodes this node should follow to determine its sync status.
+	CfgSyncBeaconFollowNodes = "syncbeacon.followNodes"
+
+	// CfgSyncBeaconPrimary defines whether this node should be a beacon.
+	// If set to true, the node will broadcast its sync status on every heartbeat to its followers.
+	CfgSyncBeaconPrimary = "syncbeacon.primary"
+
+	// CfgSyncBeaconMaxTimeWindowSec defines the maximum time window for which a sync payload would be considerable.
+	CfgSyncBeaconMaxTimeWindowSec = "syncbeacon.maxTimeWindowSec"
+
+	// CfgSyncBeaconBroadcastIntervalSec is the interval in seconds at which the node broadcasts its sync status.
+	CfgSyncBeaconBroadcastIntervalSec = "syncbeacon.broadcastInterval"
+
+	// The percentage of following nodes that have to be synced
+	syncPercentage = 2.0 / 3.0
+)
+
+func init() {
+	// TODO: Check the defaults here
+	flag.StringSlice(CfgSyncBeaconFollowNodes, []string{"2PV5487xMw5rasGBXXWeqSi4hLz7r19YBt8Y1TGAsQ"}, "list of trusted nodes to follow their sync status")
+	flag.Bool(CfgSyncBeaconPrimary, false, "if this node should be a sync beacon")
+	flag.Int(CfgSyncBeaconBroadcastIntervalSec, 30, "the interval at which the node will broadcast ist sync status")
+	flag.Int(CfgSyncBeaconMaxTimeWindowSec, 10, "the maximum time window for which a sync payload would be considerable")
+}
+
+var (
+	// plugin is the plugin instance of the sync beacon plugin.
+	plugin               *node.Plugin
+	once                 goSync.Once
+	log                  *logger.Logger
+	mgr                  *gossipPkg.Manager
+	beaconNodesStatusMap map[string]Payload
+)
+
+// Plugin gets the plugin instance.
+func Plugin() *node.Plugin {
+	once.Do(func() {
+		plugin = node.NewPlugin(PluginName, node.Disabled, configure, run)
+	})
+	return plugin
+}
+
+// configure events
+func configure(_ *node.Plugin) {
+	log = logger.NewLogger(PluginName)
+	gossip.Manager().Events().MessageReceived.Attach(events.NewClosure(func(event gossipPkg.MessageReceivedEvent) {
+		messagelayer.MessageParser().Parse(event.Data, event.Peer)
+	}))
+	messagelayer.MessageParser().Events.MessageParsed.Attach(events.NewClosure(func(message *message.Message, peer *peer.Peer) {
+		handleMessage(message, peer)
+	}))
+}
+
+// handleMessage handles the received message. It does the following checks:
+// - The payload is a syncbeacon payload. Then it checks that the issuer of the payload is a followed node.
+// - The time that payload was sent is not greater than  CfgSyncBeaconMaxTimeWindowSec. If the duration is longer than CfgSyncBeaconMaxTimeWindowSec, we consider that beacon to be out of sync till we receive a newer payload.
+// - If the node is synced and more than syncPercentage of followed nodes are also synced, the node is set to synced. Otherwise, its set as desynced.
+func handleMessage(message *message.Message, peer *peer.Peer) {
+	if !IsSyncBeaconPayload(message) {
+		return
+	}
+	peerPublicKey := peer.PublicKey().String()
+	beaconNodesPublicKeys := config.Node().GetStringSlice(CfgSyncBeaconFollowNodes)
+	beaconNodesStatusMap = make(map[string]Payload, len(beaconNodesPublicKeys))
+
+	//check if peer is in configured beacon follow list
+	shouldAccept := false
+	for i := 0; i < len(beaconNodesPublicKeys); i++ {
+		if beaconNodesPublicKeys[i] == peerPublicKey {
+			shouldAccept = true
+			break
+		}
+	}
+	if !shouldAccept {
+		return
+	}
+
+	syncBeaconPayload := &Payload{}
+	err := syncBeaconPayload.Unmarshal(message.Payload().Bytes())
+	if err != nil {
+		log.Errorf("error unmarshalling syncbeacon payload %s", err)
+		return
+	}
+
+	log.Infof("syncbeacon payload received from %s", peerPublicKey)
+
+	dur := time.Now().Sub(time.Unix(0, syncBeaconPayload.sentTime))
+	if dur.Seconds() > float64(config.Node().GetInt(CfgSyncBeaconMaxTimeWindowSec)) {
+		log.Infof("syncbeacon payload received from %s is too old", peerPublicKey)
+		syncBeaconPayload.syncStatus = false
+	}
+
+	beaconNodesStatusMap[peerPublicKey] = *syncBeaconPayload
+	beaconNodesSyncedCount := 0.0
+	for _, p := range beaconNodesStatusMap {
+		if p.SyncStatus() {
+			beaconNodesSyncedCount++
+		}
+	}
+	isLocalSynced := sync.Synced()
+	isBeaconSynced := (beaconNodesSyncedCount / float64(len(beaconNodesPublicKeys))) > syncPercentage
+	if isLocalSynced && isBeaconSynced {
+		sync.MarkSynced()
+	} else {
+		sync.MarkDesynced()
+	}
+}
+
+// broadcastSyncBeaconPayload broadcasts its sync status to its neighbors.
+func broadcastSyncBeaconPayload() {
+	syncBeaconPayload := NewSyncBeaconPayload(sync.Synced(), time.Now().UnixNano())
+	msg := message.New(message.EmptyId, message.EmptyId, time.Now(), ed25519.PublicKey{}, 0, syncBeaconPayload, 0, ed25519.Signature{})
+	mgr.SendMessage(msg.Bytes())
+}
+
+func run(_ *node.Plugin) {
+	if !config.Node().GetBool(CfgSyncBeaconPrimary) {
+		return
+	}
+	if err := daemon.BackgroundWorker("Sync-Beacon", func(shutdownSignal <-chan struct{}) {
+		ticker := time.NewTicker(config.Node().GetDuration(CfgSyncBeaconBroadcastIntervalSec) * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				broadcastSyncBeaconPayload()
+			case <-shutdownSignal:
+				return
+			}
+		}
+	}, shutdown.PrioritySynchronization); err != nil {
+		log.Panicf("Failed to start as daemon: %s", err)
+	}
+}

--- a/plugins/syncbeaconfollower/plugin.go
+++ b/plugins/syncbeaconfollower/plugin.go
@@ -1,0 +1,194 @@
+package syncbeaconfollower
+
+import (
+	"errors"
+	"github.com/iotaledger/goshimmer/packages/binary/messagelayer/message"
+	"github.com/iotaledger/goshimmer/packages/binary/messagelayer/tangle"
+	"github.com/iotaledger/goshimmer/packages/shutdown"
+	"github.com/iotaledger/goshimmer/plugins/config"
+	"github.com/iotaledger/goshimmer/plugins/messagelayer"
+	"github.com/iotaledger/goshimmer/plugins/sync"
+	"github.com/iotaledger/goshimmer/plugins/syncbeacon"
+	"github.com/iotaledger/hive.go/crypto/ed25519"
+	"github.com/iotaledger/hive.go/daemon"
+	"github.com/iotaledger/hive.go/events"
+	"github.com/iotaledger/hive.go/logger"
+	"github.com/iotaledger/hive.go/node"
+	flag "github.com/spf13/pflag"
+	goSync "sync"
+	"time"
+)
+
+const (
+	// PluginName is the plugin name of the sync beacon plugin.
+	PluginName = "Sync Beacon Follower"
+
+	// CfgSyncBeaconFollowNodes defines the list of nodes this node should follow to determine its sync status.
+	CfgSyncBeaconFollowNodes = "syncbeaconfollower.followNodes"
+
+	// CfgSyncBeaconMaxTimeWindowSec defines the maximum time window for which a sync payload would be considerable.
+	CfgSyncBeaconMaxTimeWindowSec = "syncbeaconfollower.maxTimeWindowSec"
+
+	// CfgSyncBeaconMaxTimeOfflineSec defines the maximum time a beacon node can stay without receiving updates.
+	CfgSyncBeaconMaxTimeOfflineSec = "syncbeaconfollower.maxTimeOffline"
+
+	// CfgSyncBeaconCleanupInterval defines the interval that old beacon status are cleaned up.
+	CfgSyncBeaconCleanupInterval = "syncbeaconfollower.cleanupInterval"
+
+	// The percentage of following nodes that have to be synced.
+	syncPercentage = 0.6
+)
+
+// beaconSync represents the beacon payload and the sync status.
+type beaconSync struct {
+	payload *syncbeacon.Payload
+	synced  bool
+}
+
+func init() {
+	flag.StringSlice(CfgSyncBeaconFollowNodes, []string{"Gm7W191NDnqyF7KJycZqK7V6ENLwqxTwoKQN4SmpkB24", "9DB3j9cWYSuEEtkvanrzqkzCQMdH1FGv3TawJdVbDxkd"}, "list of trusted nodes to follow their sync status")
+	flag.Int(CfgSyncBeaconMaxTimeWindowSec, 10, "the maximum time window for which a sync payload would be considerable")
+	flag.Int(CfgSyncBeaconMaxTimeOfflineSec, 40, "the maximum time the node should stay without receiving updates")
+	flag.Int(CfgSyncBeaconCleanupInterval, 10, "the interval at which cleanups are done")
+}
+
+var (
+	// plugin is the plugin instance of the sync beacon plugin.
+	plugin         *node.Plugin
+	once           goSync.Once
+	log            *logger.Logger
+	currentBeacons map[string]beaconSync
+	mutex          goSync.RWMutex
+)
+
+var (
+	// ErrMissingFollowNodes is returned if the node starts with no follow nodes list
+	ErrMissingFollowNodes = errors.New("follow nodes list is required")
+)
+
+// Plugin gets the plugin instance.
+func Plugin() *node.Plugin {
+	once.Do(func() {
+		plugin = node.NewPlugin(PluginName, node.Disabled, configure, run)
+	})
+	return plugin
+}
+
+// configure events
+func configure(_ *node.Plugin) {
+	pubKeys := config.Node().GetStringSlice(CfgSyncBeaconFollowNodes)
+
+	if len(pubKeys) == 0 {
+		log.Panicf("Follow node list cannot be empty: %w", ErrMissingFollowNodes)
+	}
+
+	log = logger.NewLogger(PluginName)
+	currentBeacons = make(map[string]beaconSync, len(pubKeys))
+
+	for _, pubKey := range pubKeys {
+		currentBeacons[pubKey] = beaconSync{
+			payload: nil,
+			synced:  false,
+		}
+	}
+
+	messagelayer.Tangle().Events.MessageSolid.Attach(events.NewClosure(func(cachedMessage *message.CachedMessage, cachedMessageMetadata *tangle.CachedMessageMetadata) {
+		cachedMessageMetadata.Release()
+		cachedMessage.Consume(func(msg *message.Message) {
+			messagePayload := msg.Payload()
+			if messagePayload.Type() != syncbeacon.Type {
+				return
+			}
+
+			payload, ok := messagePayload.(*syncbeacon.Payload)
+			if !ok {
+				log.Info("could not cast payload to network delay object")
+				return
+			}
+			handlePayload(payload, msg.IssuerPublicKey())
+		})
+	}))
+}
+
+// handlePayload handles the received payload. It does the following checks:
+// It checks that the issuer of the payload is a followed node.
+// The time that payload was sent is not greater than  CfgSyncBeaconMaxTimeWindowSec. If the duration is longer than CfgSyncBeaconMaxTimeWindowSec, we consider that beacon to be out of sync till we receive a newer payload.
+// More than syncPercentage of followed nodes are also synced, the node is set to synced. Otherwise, its set as desynced.
+func handlePayload(syncBeaconPayload *syncbeacon.Payload, issuerPublicKey ed25519.PublicKey) {
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	issuerPublicKeyStr := issuerPublicKey.String()
+	//check if issuer is in configured beacon follow list
+	if _, ok := currentBeacons[issuerPublicKeyStr]; !ok {
+		return
+	}
+
+	_beaconSync := beaconSync{
+		payload: syncBeaconPayload,
+		synced:  true,
+	}
+
+	dur := time.Since(time.Unix(0, syncBeaconPayload.SentTime()))
+	if dur.Seconds() > float64(config.Node().GetInt(CfgSyncBeaconMaxTimeWindowSec)) {
+		log.Infof("syncbeacon received from %s is too old", issuerPublicKey)
+		_beaconSync.synced = false
+	}
+
+	currentBeacons[issuerPublicKeyStr] = _beaconSync
+	updateSynced()
+}
+
+// updateSynced checks the beacon nodes and update the nodes sync status
+func updateSynced() {
+	beaconNodesSyncedCount := 0.0
+	for _, beaconSync := range currentBeacons {
+		if beaconSync.synced {
+			beaconNodesSyncedCount++
+		}
+	}
+	synced := true
+	if len(currentBeacons) > 0 {
+		synced = beaconNodesSyncedCount/float64(len(currentBeacons)) >= syncPercentage
+	}
+
+	// TODO: get rid of sync plugin
+	if synced {
+		sync.MarkSynced()
+	} else {
+		sync.MarkDesynced()
+	}
+}
+
+// cleanupFollowNodes cleans up offline nodes by setting their sync status to false after a configurable time window.
+func cleanupFollowNodes() {
+	mutex.Lock()
+	defer mutex.Unlock()
+	for publicKey, beaconSync := range currentBeacons {
+		if beaconSync.payload != nil {
+			dur := time.Since(time.Unix(0, beaconSync.payload.SentTime()))
+			if dur.Seconds() > float64(config.Node().GetInt(CfgSyncBeaconMaxTimeOfflineSec)) {
+				beaconSync.synced = false
+				currentBeacons[publicKey] = beaconSync
+			}
+		}
+	}
+	updateSynced()
+}
+
+func run(_ *node.Plugin) {
+	if err := daemon.BackgroundWorker("Sync-Beacon-Cleanup", func(shutdownSignal <-chan struct{}) {
+		ticker := time.NewTicker(config.Node().GetDuration(CfgSyncBeaconCleanupInterval) * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				cleanupFollowNodes()
+			case <-shutdownSignal:
+				return
+			}
+		}
+	}, shutdown.PrioritySynchronization); err != nil {
+		log.Panicf("Failed to start as daemon: %s", err)
+	}
+}

--- a/plugins/syncbeaconfollower/plugin.go
+++ b/plugins/syncbeaconfollower/plugin.go
@@ -14,6 +14,7 @@ import (
 	"github.com/iotaledger/hive.go/events"
 	"github.com/iotaledger/hive.go/logger"
 	"github.com/iotaledger/hive.go/node"
+	"github.com/mr-tron/base58"
 	flag "github.com/spf13/pflag"
 	goSync "sync"
 	"time"
@@ -83,9 +84,15 @@ func configure(_ *node.Plugin) {
 	log = logger.NewLogger(PluginName)
 
 	currentBeacons = make(map[ed25519.PublicKey]*beaconSync, len(pubKeys))
+	currentBeaconPubKeys = make(map[ed25519.PublicKey]string, len(pubKeys))
 
 	for _, str := range pubKeys {
-		pubKey, _, err := ed25519.PublicKeyFromBytes([]byte(str))
+		bytes, err := base58.Decode(str)
+		if err != nil {
+			log.Warnf("error decoding public key: %w", err)
+			continue
+		}
+		pubKey, _, err := ed25519.PublicKeyFromBytes(bytes)
 		if err != nil {
 			log.Warnf("%s is not a valid public key: %w", err)
 			continue

--- a/tools/integration-tests/runTests.sh
+++ b/tools/integration-tests/runTests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-TEST_NAMES='autopeering common drng message value consensus faucet'
+TEST_NAMES='autopeering common drng message value consensus faucet syncbeacon'
 
 echo "Build GoShimmer image"
 docker build -t iotaledger/goshimmer ../../.

--- a/tools/integration-tests/tester/framework/docker.go
+++ b/tools/integration-tests/tester/framework/docker.go
@@ -118,7 +118,7 @@ func (d *DockerContainer) CreateGoShimmerPeer(config GoShimmerConfig) error {
 			fmt.Sprintf("--drng.committeeMembers=%s", config.DRNGCommittee),
 			fmt.Sprintf("--drng.distributedPubKey=%s", config.DRNGDistKey),
 			fmt.Sprintf("--syncbeacon.primary=%v", config.SyncBeaconPrimary),
-			fmt.Sprintf("--syncbeacon.followNodes=%v", config.SyncBeaconFollowNodes),
+			fmt.Sprintf("--syncbeacon.followNodes=%s", config.SyncBeaconFollowNodes),
 			fmt.Sprintf("--syncbeacon.broadcastInterval=%d", config.SyncBeaconBroadcastInterval),
 		},
 	}

--- a/tools/integration-tests/tester/framework/docker.go
+++ b/tools/integration-tests/tester/framework/docker.go
@@ -95,8 +95,11 @@ func (d *DockerContainer) CreateGoShimmerPeer(config GoShimmerConfig) error {
 				if config.Faucet {
 					plugins = append(plugins, "faucet")
 				}
-				if config.SyncBeaconPrimary || config.SyncBeaconFollowNodes != "" {
+				if config.SyncBeacon {
 					plugins = append(plugins, "Sync Beacon")
+				}
+				if config.SyncBeaconFollower {
+					plugins = append(plugins, "Sync Beacon Follower")
 				}
 				return strings.Join(plugins[:], ",")
 			}()),
@@ -117,8 +120,7 @@ func (d *DockerContainer) CreateGoShimmerPeer(config GoShimmerConfig) error {
 			fmt.Sprintf("--drng.threshold=%d", config.DRNGThreshold),
 			fmt.Sprintf("--drng.committeeMembers=%s", config.DRNGCommittee),
 			fmt.Sprintf("--drng.distributedPubKey=%s", config.DRNGDistKey),
-			fmt.Sprintf("--syncbeacon.primary=%v", config.SyncBeaconPrimary),
-			fmt.Sprintf("--syncbeacon.followNodes=%s", config.SyncBeaconFollowNodes),
+			fmt.Sprintf("--syncbeaconfollower.followNodes=%s", config.SyncBeaconFollowNodes),
 			fmt.Sprintf("--syncbeacon.broadcastInterval=%d", config.SyncBeaconBroadcastInterval),
 		},
 	}

--- a/tools/integration-tests/tester/framework/docker.go
+++ b/tools/integration-tests/tester/framework/docker.go
@@ -95,6 +95,9 @@ func (d *DockerContainer) CreateGoShimmerPeer(config GoShimmerConfig) error {
 				if config.Faucet {
 					plugins = append(plugins, "faucet")
 				}
+				if config.SyncBeaconPrimary || config.SyncBeaconFollowNodes != "" {
+					plugins = append(plugins, "Sync Beacon")
+				}
 				return strings.Join(plugins[:], ",")
 			}()),
 			// define the faucet seed in case the faucet dApp is enabled
@@ -114,6 +117,9 @@ func (d *DockerContainer) CreateGoShimmerPeer(config GoShimmerConfig) error {
 			fmt.Sprintf("--drng.threshold=%d", config.DRNGThreshold),
 			fmt.Sprintf("--drng.committeeMembers=%s", config.DRNGCommittee),
 			fmt.Sprintf("--drng.distributedPubKey=%s", config.DRNGDistKey),
+			fmt.Sprintf("--syncbeacon.primary=%v", config.SyncBeaconPrimary),
+			fmt.Sprintf("--syncbeacon.followNodes=%v", config.SyncBeaconFollowNodes),
+			fmt.Sprintf("--syncbeacon.broadcastInterval=%d", config.SyncBeaconBroadcastInterval),
 		},
 	}
 

--- a/tools/integration-tests/tester/framework/framework.go
+++ b/tools/integration-tests/tester/framework/framework.go
@@ -88,6 +88,9 @@ func (f *Framework) CreateNetwork(name string, peers int, minimumNeighbors int, 
 			}(i),
 			BootstrapInitialIssuanceTimePeriodSec: bootstrapInitialIssuanceTimePeriodSec,
 			Faucet:                                i == 0,
+			SyncBeaconPrimary:                     true,
+			SyncBeaconFollowNodes:                 "",
+			SyncBeaconBroadcastInterval:           10,
 		}
 		if _, err = network.CreatePeer(config); err != nil {
 			return nil, err

--- a/tools/integration-tests/tester/framework/framework.go
+++ b/tools/integration-tests/tester/framework/framework.go
@@ -88,9 +88,6 @@ func (f *Framework) CreateNetwork(name string, peers int, minimumNeighbors int, 
 			}(i),
 			BootstrapInitialIssuanceTimePeriodSec: bootstrapInitialIssuanceTimePeriodSec,
 			Faucet:                                i == 0,
-			SyncBeaconPrimary:                     true,
-			SyncBeaconFollowNodes:                 "",
-			SyncBeaconBroadcastInterval:           10,
 		}
 		if _, err = network.CreatePeer(config); err != nil {
 			return nil, err

--- a/tools/integration-tests/tester/framework/parameters.go
+++ b/tools/integration-tests/tester/framework/parameters.go
@@ -64,7 +64,10 @@ type GoShimmerConfig struct {
 	DRNGInstance  int
 	DRNGThreshold int
 
-	Faucet bool
+	Faucet                      bool
+	SyncBeaconPrimary           bool
+	SyncBeaconFollowNodes       string
+	SyncBeaconBroadcastInterval int
 }
 
 // NetworkConfig defines the config of a GoShimmer Docker network.

--- a/tools/integration-tests/tester/framework/parameters.go
+++ b/tools/integration-tests/tester/framework/parameters.go
@@ -65,7 +65,8 @@ type GoShimmerConfig struct {
 	DRNGThreshold int
 
 	Faucet                      bool
-	SyncBeaconPrimary           bool
+	SyncBeacon                  bool
+	SyncBeaconFollower 			bool
 	SyncBeaconFollowNodes       string
 	SyncBeaconBroadcastInterval int
 }

--- a/tools/integration-tests/tester/tests/syncbeacon/main_test.go
+++ b/tools/integration-tests/tester/tests/syncbeacon/main_test.go
@@ -1,0 +1,24 @@
+package syncbeacon
+
+import (
+	"os"
+	"testing"
+
+	"github.com/iotaledger/goshimmer/tools/integration-tests/tester/framework"
+)
+
+var f *framework.Framework
+
+// TestMain gets called by the test utility and is executed before any other test in this package.
+// It is therefore used to initialize the integration testing framework.
+func TestMain(m *testing.M) {
+	var err error
+	f, err = framework.Instance()
+	if err != nil {
+		panic(err)
+	}
+
+	// call the tests
+	os.Exit(m.Run())
+}
+

--- a/tools/integration-tests/tester/tests/syncbeacon/syncbeacon_test.go
+++ b/tools/integration-tests/tester/tests/syncbeacon/syncbeacon_test.go
@@ -1,0 +1,74 @@
+package syncbeacon
+
+import (
+	"github.com/iotaledger/goshimmer/tools/integration-tests/tester/framework"
+	"github.com/iotaledger/goshimmer/tools/integration-tests/tester/tests"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"log"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestSyncBeacon checks that sync payloads are being gossiped through the network,
+// and follower nodes are using those payloads to determine if they are synced or not.
+func TestSyncBeacon(t *testing.T) {
+	framework.ParaPoWDifficulty = 0
+	initialPeers := 4
+	n, err := f.CreateNetwork("syncbeacon_TestSyncBeacon", initialPeers, 2)
+	require.NoError(t, err)
+	defer tests.ShutdownNetwork(t, n)
+
+	// wait for peers to change their state to synchronized
+	time.Sleep(10 * time.Second)
+
+	peers := n.Peers()
+	var beaconPublicKeys []string
+	for _, peer := range peers {
+		beaconPublicKeys = append(beaconPublicKeys, peer.PublicKey().String())
+	}
+
+	// 1. Follow all nodes as beacon nodes
+	peer, err := n.CreatePeer(framework.GoShimmerConfig{
+		SyncBeaconFollowNodes: strings.Join(beaconPublicKeys, ","),
+	})
+
+	// wait for peers to change their state to synchronized
+	time.Sleep(10 * time.Second)
+
+	// issue some messages on old peers so that new peer can solidify
+	ids := tests.SendDataMessagesOnRandomPeer(t, n.Peers()[:initialPeers], 10)
+
+	log.Println("Waiting...")
+	// wait for beacon nodes to broadcast their sync status
+	time.Sleep(40 * time.Second)
+	log.Println("done waiting.")
+
+	// expect all beacon nodes to be synced and send their statuses.
+	// node is also synced internally. So it should be synced.
+	resp, err := peer.Info()
+	require.NoError(t, err)
+	assert.Truef(t, resp.Synced, "Peer %s should be synced but is desynced!", peer.String())
+
+	// 2. shutdown all but 1 beacon node
+	for _, p := range peers[:len(peers) - 2] {
+		p.Stop()
+	}
+
+	// send some messages to the still running nodes
+	// last node is the test node.
+	ids = tests.SendDataMessagesOnRandomPeer(t, n.Peers()[initialPeers - 2 : initialPeers - 1], 10, ids)
+
+	// wait for peers to sync and broadcast
+	log.Println("Waiting...")
+	time.Sleep(40 * time.Second)
+	log.Println("done waiting.")
+
+
+	// expect majority of nodes to not have updated their status. Hence should be false.
+	// even though this node should be synced internally wrt to anchor points, it should be desynced wrt to its beacons.
+	resp, err = peer.Info()
+	require.NoError(t, err)
+	assert.Falsef(t, resp.Synced, "Peer %s should be desynced but is synced!", peer.String())
+}

--- a/tools/integration-tests/tester/tests/syncbeacon/syncbeacon_test.go
+++ b/tools/integration-tests/tester/tests/syncbeacon/syncbeacon_test.go
@@ -19,28 +19,25 @@ func TestSyncBeacon(t *testing.T) {
 	require.NoError(t, err)
 	defer tests.ShutdownNetwork(t, n)
 
+	// create sync beacon nodes
+	var beaconPublicKeys []string
 	for i := 0; i < initialPeers; i++ {
-		_, err := n.CreatePeer(framework.GoShimmerConfig{
-			SyncBeaconPrimary:           true,
-			SyncBeaconFollowNodes:       "",
+		peer, err := n.CreatePeer(framework.GoShimmerConfig{
+			SyncBeacon:                  true,
 			SyncBeaconBroadcastInterval: 20,
 		})
 		require.NoError(t, err)
+		beaconPublicKeys = append(beaconPublicKeys, peer.PublicKey().String())
 	}
+	peers := n.Peers()
 	err = n.WaitForAutopeering(3)
 	require.NoError(t, err)
 
-	peers := n.Peers()
-	var beaconPublicKeys []string
-	for _, peer := range peers {
-		beaconPublicKeys = append(beaconPublicKeys, peer.PublicKey().String())
-	}
 
-	// follow all nodes as beacon nodes
+	// beacon follower node to follow all previous nodes
 	peer, err := n.CreatePeer(framework.GoShimmerConfig{
-		SyncBeaconPrimary:           false,
-		SyncBeaconFollowNodes:       strings.Join(beaconPublicKeys, ","),
-		SyncBeaconBroadcastInterval: 20,
+		SyncBeaconFollower:    true,
+		SyncBeaconFollowNodes: strings.Join(beaconPublicKeys, ","),
 	})
 	require.NoError(t, err)
 	err = n.WaitForAutopeering(3)


### PR DESCRIPTION
# Description

Adds a sync beacon plugin where a node uses a list of beacon nodes to determine if it is synced or not.

A node becomes a sync beacon if it enables `--syncbeacon.primary = true`. Then it'll periodically emit the sync beacon to the message layer.

A node can follow a list of nodes as beacons. e.g `--syncbeacon.followNodes ="pubicKey1,publickKey2"`. The node will handle sync beacon payloads sent from these nodes. All others are discarded.

A node can be primary and also does not follow any other nodes. `--syncbeacon.primary = true --syncbeacon.followNodes=""`
Such a node will broadcast its sync status but will not depend on any other node.

If a node receives a sync beacon payload that is older than a configurable max time window, we consider the beacon to be desynced.
If the beacon is solidified, then the node is considered to be synced wrt the issuer of the beacon.
However, if not synced with more than 2/3 of its following nodes, its said to be desynced.

At every `syncbeacon.clearInterval`, nodes that have not been updated within a configurable time frame are set to be desynced.

This plugin is disabled by default.

Fixes #639 
