### PR TITLE
Add RetrieveAllTips from the Tangle

### DIFF
--- a/packages/binary/messagelayer/tangle/tangle.go
+++ b/packages/binary/messagelayer/tangle/tangle.go
@@ -354,7 +354,7 @@ func (tangle *Tangle) StoreMessageWorkerPoolStatus() (name string, load int) {
 	return "StoreMessage", tangle.storeMessageWorkerPool.RunningWorkers()
 }
 
-// RetrieveTips returns the tips (i.e., solid messages that are not part of the approvers list).
+// RetrieveAllTips returns the tips (i.e., solid messages that are not part of the approvers list).
 // It iterates over the messageMetadataStorage, thus only use this method if necessary.
 // TODO: improve this function.
 func (tangle *Tangle) RetrieveAllTips() (tips []message.Id) {

--- a/packages/binary/messagelayer/test/retrievealltips_test.go
+++ b/packages/binary/messagelayer/test/retrievealltips_test.go
@@ -1,0 +1,48 @@
+package test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/iotaledger/goshimmer/packages/binary/messagelayer/message"
+	"github.com/iotaledger/goshimmer/packages/binary/messagelayer/payload"
+	"github.com/iotaledger/goshimmer/packages/binary/messagelayer/tangle"
+	"github.com/iotaledger/hive.go/crypto/ed25519"
+	"github.com/iotaledger/hive.go/events"
+	"github.com/iotaledger/hive.go/kvstore/mapdb"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRetrieveAllTips(t *testing.T) {
+	messageTangle := tangle.New(mapdb.NewMapDB())
+
+	messageA := newTestMessage("A", message.EmptyId, message.EmptyId)
+	messageB := newTestMessage("B", messageA.Id(), message.EmptyId)
+	messageC := newTestMessage("C", messageA.Id(), message.EmptyId)
+
+	var wg sync.WaitGroup
+
+	messageTangle.Events.MessageSolid.Attach(events.NewClosure(func(cachedMessage *message.CachedMessage, cachedMessageMetadata *tangle.CachedMessageMetadata) {
+		cachedMessage.Release()
+		cachedMessageMetadata.Release()
+		wg.Done()
+	}))
+
+	wg.Add(3)
+	messageTangle.AttachMessage(messageA)
+	messageTangle.AttachMessage(messageB)
+	messageTangle.AttachMessage(messageC)
+
+	wg.Wait()
+
+	allTips := messageTangle.RetrieveAllTips()
+
+	assert.Equal(t, 2, len(allTips))
+
+	messageTangle.Shutdown()
+}
+
+func newTestMessage(payloadString string, parent1, parent2 message.Id) *message.Message {
+	return message.New(parent1, parent2, time.Now(), ed25519.PublicKey{}, 0, payload.NewData([]byte(payloadString)), 0, ed25519.Signature{})
+}

--- a/packages/binary/messagelayer/tipselector/tipselector.go
+++ b/packages/binary/messagelayer/tipselector/tipselector.go
@@ -14,13 +14,26 @@ type TipSelector struct {
 }
 
 // New creates a new tip-selector.
-func New() *TipSelector {
-	return &TipSelector{
+func New(tips ...message.Id) *TipSelector {
+	tipSelector := &TipSelector{
 		tips: datastructure.NewRandomMap(),
 		Events: Events{
 			TipAdded:   events.NewEvent(messageIdEvent),
 			TipRemoved: events.NewEvent(messageIdEvent),
 		},
+	}
+
+	if tips != nil {
+		tipSelector.Set(tips...)
+	}
+
+	return tipSelector
+}
+
+// Set adds the given messageIDs as tips.
+func (tipSelector *TipSelector) Set(tips ...message.Id) {
+	for _, messageID := range tips {
+		tipSelector.tips.Set(messageID, messageID)
 	}
 }
 


### PR DESCRIPTION
This PR enables a beaconer to retrieve the stored tips from the DB before start issuing new sync beacons