### PR TITLE
Make syncPercentage configurable

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -21,7 +21,8 @@
     "followNodes": [
       "Gm7W191NDnqyF7KJycZqK7V6ENLwqxTwoKQN4SmpkB24",
       "9DB3j9cWYSuEEtkvanrzqkzCQMdH1FGv3TawJdVbDxkd"
-    ]
+    ],
+    "syncPercentage": 0.5
   },
   "dashboard": {
     "bindAddress": "127.0.0.1:8081",

--- a/plugins/syncbeaconfollower/plugin.go
+++ b/plugins/syncbeaconfollower/plugin.go
@@ -128,6 +128,8 @@ func OverwriteSyncedState(syncedOverwrite bool) {
 
 // configure plugin
 func configure(_ *node.Plugin) {
+	log = logger.NewLogger(PluginName)
+
 	pubKeys := config.Node().GetStringSlice(CfgSyncBeaconFollowNodes)
 	beaconMaxTimeOfflineSec = float64(config.Node().GetInt(CfgSyncBeaconMaxTimeOfflineSec))
 	beaconMaxTimeWindowSec = float64(config.Node().GetInt(CfgSyncBeaconMaxTimeWindowSec))
@@ -138,8 +140,6 @@ func configure(_ *node.Plugin) {
 		log.Warnf("setting syncPercentage to default value of 0.5")
 		syncPercentage = 0.5
 	}
-
-	log = logger.NewLogger(PluginName)
 
 	currentBeacons = make(map[ed25519.PublicKey]*Status)
 	currentBeaconPubKeys = make(map[ed25519.PublicKey]string)

--- a/plugins/syncbeaconfollower/plugin.go
+++ b/plugins/syncbeaconfollower/plugin.go
@@ -37,8 +37,8 @@ const (
 	// CfgSyncBeaconCleanupInterval defines the interval that old beacon status are cleaned up.
 	CfgSyncBeaconCleanupInterval = "syncbeaconfollower.cleanupInterval"
 
-	// syncPercentage defines the percentage of following nodes that have to be synced.
-	syncPercentage = 0.5
+	// CfgSyncBeaconSyncPercentage defines the percentage of following nodes that have to be synced.
+	CfgSyncBeaconSyncPercentage = "syncbeaconfollower.syncPercentage"
 )
 
 // Status represents the status of a beacon node consisting of latest messageID, sentTime and sync status.
@@ -54,6 +54,7 @@ func init() {
 	flag.Int(CfgSyncBeaconMaxTimeWindowSec, 10, "the maximum time window for which a sync payload would be considerable")
 	flag.Int(CfgSyncBeaconMaxTimeOfflineSec, 70, "the maximum time the node should stay synced without receiving updates")
 	flag.Int(CfgSyncBeaconCleanupInterval, 10, "the interval at which cleanups are done")
+	flag.Float64(CfgSyncBeaconSyncPercentage, 0.5, "percentage of nodes being followed that need to be synced in order to consider the node synced")
 }
 
 var (
@@ -66,6 +67,7 @@ var (
 	mutex                   sync.RWMutex
 	beaconMaxTimeOfflineSec float64
 	beaconMaxTimeWindowSec  float64
+	syncPercentage          float64
 	// tells whether the node is synced or not.
 	synced atomic.Bool
 
@@ -129,6 +131,14 @@ func configure(_ *node.Plugin) {
 	pubKeys := config.Node().GetStringSlice(CfgSyncBeaconFollowNodes)
 	beaconMaxTimeOfflineSec = float64(config.Node().GetInt(CfgSyncBeaconMaxTimeOfflineSec))
 	beaconMaxTimeWindowSec = float64(config.Node().GetInt(CfgSyncBeaconMaxTimeWindowSec))
+	syncPercentage = config.Node().GetFloat64(CfgSyncBeaconSyncPercentage)
+	if syncPercentage < 0.5 || syncPercentage > 1.0 {
+		log.Warnf("invalid syncPercentage: %f, syncPercentage has to be in [0.5, 1.0] interval", syncPercentage)
+		// set it to default
+		log.Warnf("setting syncPercentage to default value of 0.5")
+		syncPercentage = 0.5
+	}
+
 	log = logger.NewLogger(PluginName)
 
 	currentBeacons = make(map[ed25519.PublicKey]*Status)


### PR DESCRIPTION
 - Use `syncbeaconfollower.syncPercentage` in config.json to specify the desired percentage of nodes (being followed) that we need to be synced compared to in order to consider the node synced.
 - syncPercentage has to be in [0.5, 1.0] interval.
 - Use default value of 0.5 in case of invalid config.