### PR TITLE
Several Grafana Dashboard Related Updates

### DIFF
--- a/plugins/prometheus/info.go
+++ b/plugins/prometheus/info.go
@@ -1,6 +1,7 @@
 package prometheus
 
 import (
+	"github.com/iotaledger/goshimmer/plugins/autopeering/local"
 	"github.com/iotaledger/goshimmer/plugins/banner"
 	"github.com/iotaledger/goshimmer/plugins/metrics"
 	"github.com/prometheus/client_golang/prometheus"
@@ -9,6 +10,7 @@ import (
 var (
 	infoApp *prometheus.GaugeVec
 	sync    prometheus.Gauge
+	nodeID  string
 )
 
 func registerInfoMetrics() {
@@ -17,9 +19,12 @@ func registerInfoMetrics() {
 			Name: "iota_info_app",
 			Help: "Node software name and version.",
 		},
-		[]string{"name", "version"},
+		[]string{"name", "version", "nodeID"},
 	)
-	infoApp.WithLabelValues(banner.AppName, banner.AppVersion).Set(1)
+	if local.GetInstance() != nil {
+		nodeID = local.GetInstance().ID().String()
+	}
+	infoApp.WithLabelValues(banner.AppName, banner.AppVersion, nodeID).Set(1)
 
 	sync = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "sync",

--- a/plugins/prometheus/parameters.go
+++ b/plugins/prometheus/parameters.go
@@ -20,7 +20,7 @@ const (
 func init() {
 	flag.String(CfgPrometheusBindAddress, "0.0.0.0:9311", "the bind address on which the Prometheus exporter listens on")
 	flag.Bool(CfgPrometheusGoMetrics, false, "include go metrics")
-	flag.Bool(CfgPrometheusProcessMetrics, false, "include process metrics")
+	flag.Bool(CfgPrometheusProcessMetrics, true, "include process metrics")
 	flag.Bool(CfgPrometheusPromhttpMetrics, false, "include promhttp metrics")
 	flag.Bool(CfgPrometheusWorkerpoolMetrics, false, "include workerpool metrics")
 }

--- a/tools/docker-network/docker-compose.yml
+++ b/tools/docker-network/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       --metrics.local=false
       --metrics.global=true
       --prometheus.bindAddress=0.0.0.0:9312
+      --prometheus.processMetrics=false
       --node.enablePlugins=analysis-server,analysis-dashboard,prometheus
       --node.disablePlugins=portcheck,dashboard,analysis-client,gossip,drng,issuer,syncbeaconfollower,messagelayer,pow,valuetransfers,webapi,webapibroadcastdataendpoint,webapifindtransactionhashesendpoint,webapigetneighborsendpoint,webapigettransactionobjectsbyhashendpoint,webapigettransactiontrytesbyhashendpoint
     volumes:

--- a/tools/docker-network/grafana/dashboards/local_dashboard.json
+++ b/tools/docker-network/grafana/dashboards/local_dashboard.json
@@ -74,7 +74,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "expr": "iota_info_app",
@@ -153,7 +153,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "expr": "sync",
@@ -212,7 +212,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "expr": "irate(tangle_message_total_count[5m])",
@@ -270,7 +270,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "expr": "process_cpu_usage",
@@ -324,7 +324,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "expr": "process_mem_usage_bytes/1024/1024",
@@ -382,7 +382,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "expr": "db_size_bytes/1024/1024",
@@ -496,10 +496,16 @@
           "refId": "D"
         },
         {
-          "expr": "irate(tangle_messages_per_type_count{message_type=\"netowrkdelay\"}[5m])",
+          "expr": "irate(tangle_messages_per_type_count{message_type=\"networkdelay\"}[5m])",
           "interval": "",
           "legendFormat": "Network Delay Messages Per Second",
           "refId": "E"
+        },
+        {
+          "expr": "irate(tangle_messages_per_type_count{message_type=\"syncbeacon\"}[5m])",
+          "interval": "",
+          "legendFormat": "Sync Beacons Per Second",
+          "refId": "F"
         }
       ],
       "thresholds": [],
@@ -693,7 +699,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "expr": "autopeering_neighbor_connections_count - autopeering_neighbor_drop_count",
@@ -747,7 +753,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "expr": "autopeering_avg_neighbor_connection_lifetime",
@@ -804,7 +810,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "expr": "autopeering_neighbor_connections_count",
@@ -861,7 +867,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "expr": "autopeering_neighbor_drop_count",
@@ -1750,7 +1756,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "expr": "traffic_gossip_outbound_bytes",
@@ -1803,7 +1809,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "expr": "traffic_gossip_inbound_bytes",
@@ -1856,7 +1862,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "expr": "traffic_autopeering_outbound_bytes",
@@ -1909,7 +1915,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "expr": "traffic_autopeering_inbound_bytes",
@@ -1962,7 +1968,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "expr": "traffic_fpc_inbound_bytes",
@@ -2015,7 +2021,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "expr": "traffic_fpc_outbound_bytes",
@@ -2068,7 +2074,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "expr": "traffic_analysis_outbound_bytes",
@@ -2233,7 +2239,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "expr": "fpc_avg_rounds_to_finalize",
@@ -2290,7 +2296,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "expr": "fpc_finalized_conflicts",
@@ -2347,7 +2353,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "expr": "fpc_failed_conflicts",
@@ -2770,5 +2776,5 @@
   "timezone": "",
   "title": "GoShimmer Local Metrics",
   "uid": "kjOQZ2ZMk",
-  "version": 6
+  "version": 3
 }

--- a/tools/docker-network/grafana/dashboards/local_dashboard.json
+++ b/tools/docker-network/grafana/dashboards/local_dashboard.json
@@ -16,7 +16,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 1,
+  "id": 2,
   "links": [],
   "panels": [
     {
@@ -72,9 +72,10 @@
           ],
           "fields": "/^version$/",
           "values": false
-        }
+        },
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.5",
+      "pluginVersion": "7.1.1",
       "targets": [
         {
           "expr": "iota_info_app",
@@ -92,6 +93,121 @@
           "options": {}
         }
       ],
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Shortened version of the public key of the node.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 2,
+        "y": 1
+      },
+      "id": 81,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^nodeID$/",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.1.1",
+      "targets": [
+        {
+          "expr": "iota_info_app",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Node Identity",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {}
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Shows the time elapsed since the start of the node.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 4,
+        "y": 1
+      },
+      "id": 79,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "pluginVersion": "7.1.1",
+      "targets": [
+        {
+          "expr": "time() - process_start_time_seconds",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Uptime",
       "type": "stat"
     },
     {
@@ -136,7 +252,7 @@
       "gridPos": {
         "h": 2,
         "w": 2,
-        "x": 2,
+        "x": 6,
         "y": 1
       },
       "id": 22,
@@ -151,9 +267,10 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.5",
+      "pluginVersion": "7.1.1",
       "targets": [
         {
           "expr": "sync",
@@ -195,7 +312,7 @@
       "gridPos": {
         "h": 2,
         "w": 2,
-        "x": 4,
+        "x": 8,
         "y": 1
       },
       "id": 30,
@@ -210,9 +327,10 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.5",
+      "pluginVersion": "7.1.1",
       "targets": [
         {
           "expr": "irate(tangle_message_total_count[5m])",
@@ -253,7 +371,7 @@
       "gridPos": {
         "h": 2,
         "w": 2,
-        "x": 6,
+        "x": 10,
         "y": 1
       },
       "id": 53,
@@ -268,9 +386,10 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.5",
+      "pluginVersion": "7.1.1",
       "targets": [
         {
           "expr": "process_cpu_usage",
@@ -307,7 +426,7 @@
       "gridPos": {
         "h": 2,
         "w": 2,
-        "x": 8,
+        "x": 12,
         "y": 1
       },
       "id": 20,
@@ -322,9 +441,10 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.5",
+      "pluginVersion": "7.1.1",
       "targets": [
         {
           "expr": "process_mem_usage_bytes/1024/1024",
@@ -365,7 +485,7 @@
       "gridPos": {
         "h": 2,
         "w": 2,
-        "x": 10,
+        "x": 14,
         "y": 1
       },
       "id": 58,
@@ -380,9 +500,10 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.5",
+      "pluginVersion": "7.1.1",
       "targets": [
         {
           "expr": "db_size_bytes/1024/1024",
@@ -419,20 +540,7 @@
       "fieldConfig": {
         "defaults": {
           "custom": {},
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
+          "links": []
         },
         "overrides": []
       },
@@ -458,11 +566,8 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
       "percentage": false,
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -557,7 +662,8 @@
       "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "custom": {},
+          "links": []
         },
         "overrides": []
       },
@@ -583,10 +689,8 @@
       "lines": false,
       "linewidth": 1,
       "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
       "percentage": false,
+      "pluginVersion": "7.1.1",
       "pointradius": 0.5,
       "points": true,
       "renderer": "flot",
@@ -697,9 +801,10 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.5",
+      "pluginVersion": "7.1.1",
       "targets": [
         {
           "expr": "autopeering_neighbor_connections_count - autopeering_neighbor_drop_count",
@@ -751,9 +856,10 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.5",
+      "pluginVersion": "7.1.1",
       "targets": [
         {
           "expr": "autopeering_avg_neighbor_connection_lifetime",
@@ -808,9 +914,10 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.5",
+      "pluginVersion": "7.1.1",
       "targets": [
         {
           "expr": "autopeering_neighbor_connections_count",
@@ -865,9 +972,10 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.5",
+      "pluginVersion": "7.1.1",
       "targets": [
         {
           "expr": "autopeering_neighbor_drop_count",
@@ -890,7 +998,8 @@
       "description": "Shows tips in message and value layer.",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "custom": {},
+          "links": []
         },
         "overrides": []
       },
@@ -916,10 +1025,8 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
       "percentage": false,
+      "pluginVersion": "7.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -990,7 +1097,8 @@
       "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "custom": {},
+          "links": []
         },
         "overrides": []
       },
@@ -1016,10 +1124,8 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
       "percentage": false,
+      "pluginVersion": "7.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1084,7 +1190,8 @@
       "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "custom": {},
+          "links": []
         },
         "overrides": []
       },
@@ -1110,10 +1217,8 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
       "percentage": false,
+      "pluginVersion": "7.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1179,7 +1284,8 @@
       "description": "Number of messages in missingMessageStore. These are the message the node knows it doesn't have and tries to requests them.",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "custom": {},
+          "links": []
         },
         "overrides": []
       },
@@ -1205,10 +1311,8 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
       "percentage": false,
+      "pluginVersion": "7.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1274,7 +1378,8 @@
       "description": "Describes the amount of total, solid and not solid messages in the node's database.",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "custom": {},
+          "links": []
         },
         "overrides": []
       },
@@ -1302,10 +1407,8 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
       "percentage": false,
+      "pluginVersion": "7.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1383,7 +1486,8 @@
       "description": "Number of messages currently requested by the message tangle.",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "custom": {},
+          "links": []
         },
         "overrides": []
       },
@@ -1409,10 +1513,8 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
       "percentage": false,
+      "pluginVersion": "7.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1477,7 +1579,8 @@
       "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "custom": {},
+          "links": []
         },
         "overrides": []
       },
@@ -1503,10 +1606,8 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
       "percentage": false,
+      "pluginVersion": "7.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1608,7 +1709,8 @@
       "description": "Average time it takes to solidify messages.",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "custom": {},
+          "links": []
         },
         "overrides": []
       },
@@ -1634,10 +1736,8 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
       "percentage": false,
+      "pluginVersion": "7.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1712,6 +1812,11 @@
       },
       "id": 61,
       "mode": "markdown",
+      "options": {
+        "content": "\n# Total Network Traffic\n\n\nSince the start of the node.\n",
+        "mode": "markdown"
+      },
+      "pluginVersion": "7.1.0",
       "timeFrom": null,
       "timeShift": null,
       "title": "",
@@ -1754,9 +1859,10 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.5",
+      "pluginVersion": "7.1.1",
       "targets": [
         {
           "expr": "traffic_gossip_outbound_bytes",
@@ -1807,9 +1913,10 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.5",
+      "pluginVersion": "7.1.1",
       "targets": [
         {
           "expr": "traffic_gossip_inbound_bytes",
@@ -1860,9 +1967,10 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.5",
+      "pluginVersion": "7.1.1",
       "targets": [
         {
           "expr": "traffic_autopeering_outbound_bytes",
@@ -1913,9 +2021,10 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.5",
+      "pluginVersion": "7.1.1",
       "targets": [
         {
           "expr": "traffic_autopeering_inbound_bytes",
@@ -1966,9 +2075,10 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.5",
+      "pluginVersion": "7.1.1",
       "targets": [
         {
           "expr": "traffic_fpc_inbound_bytes",
@@ -2019,9 +2129,10 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.5",
+      "pluginVersion": "7.1.1",
       "targets": [
         {
           "expr": "traffic_fpc_outbound_bytes",
@@ -2072,9 +2183,10 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.5",
+      "pluginVersion": "7.1.1",
       "targets": [
         {
           "expr": "traffic_analysis_outbound_bytes",
@@ -2110,7 +2222,8 @@
       "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "custom": {},
+          "links": []
         },
         "overrides": []
       },
@@ -2136,10 +2249,8 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
       "percentage": false,
+      "pluginVersion": "7.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2237,9 +2348,10 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.5",
+      "pluginVersion": "7.1.1",
       "targets": [
         {
           "expr": "fpc_avg_rounds_to_finalize",
@@ -2294,9 +2406,10 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.5",
+      "pluginVersion": "7.1.1",
       "targets": [
         {
           "expr": "fpc_finalized_conflicts",
@@ -2351,9 +2464,10 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.5",
+      "pluginVersion": "7.1.1",
       "targets": [
         {
           "expr": "fpc_failed_conflicts",
@@ -2376,7 +2490,8 @@
       "description": "Describes how many FPC query requests the node has received.",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "custom": {},
+          "links": []
         },
         "overrides": []
       },
@@ -2402,10 +2517,8 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
       "percentage": false,
+      "pluginVersion": "7.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2470,7 +2583,8 @@
       "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "custom": {},
+          "links": []
         },
         "overrides": []
       },
@@ -2496,10 +2610,8 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
       "percentage": false,
+      "pluginVersion": "7.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2565,7 +2677,8 @@
       "description": "Describes how many FPC opinions were requested from the node.",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "custom": {},
+          "links": []
         },
         "overrides": []
       },
@@ -2591,10 +2704,8 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
       "percentage": false,
+      "pluginVersion": "7.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2659,7 +2770,8 @@
       "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "custom": {},
+          "links": []
         },
         "overrides": []
       },
@@ -2685,10 +2797,8 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
       "percentage": false,
+      "pluginVersion": "7.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2750,7 +2860,7 @@
     }
   ],
   "refresh": "5s",
-  "schemaVersion": 25,
+  "schemaVersion": 26,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -2776,5 +2886,5 @@
   "timezone": "",
   "title": "GoShimmer Local Metrics",
   "uid": "kjOQZ2ZMk",
-  "version": 3
+  "version": 17
 }

--- a/tools/monitoring/grafana/dashboards/local_dashboard.json
+++ b/tools/monitoring/grafana/dashboards/local_dashboard.json
@@ -74,7 +74,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "expr": "iota_info_app",
@@ -153,7 +153,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "expr": "sync",
@@ -212,7 +212,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "expr": "irate(tangle_message_total_count[5m])",
@@ -270,7 +270,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "expr": "process_cpu_usage",
@@ -324,7 +324,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "expr": "process_mem_usage_bytes/1024/1024",
@@ -382,7 +382,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "expr": "db_size_bytes/1024/1024",
@@ -496,10 +496,16 @@
           "refId": "D"
         },
         {
-          "expr": "irate(tangle_messages_per_type_count{message_type=\"netowrkdelay\"}[5m])",
+          "expr": "irate(tangle_messages_per_type_count{message_type=\"networkdelay\"}[5m])",
           "interval": "",
           "legendFormat": "Network Delay Messages Per Second",
           "refId": "E"
+        },
+        {
+          "expr": "irate(tangle_messages_per_type_count{message_type=\"syncbeacon\"}[5m])",
+          "interval": "",
+          "legendFormat": "Sync Beacons Per Second",
+          "refId": "F"
         }
       ],
       "thresholds": [],
@@ -693,7 +699,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "expr": "autopeering_neighbor_connections_count - autopeering_neighbor_drop_count",
@@ -747,7 +753,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "expr": "autopeering_avg_neighbor_connection_lifetime",
@@ -804,7 +810,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "expr": "autopeering_neighbor_connections_count",
@@ -861,7 +867,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "expr": "autopeering_neighbor_drop_count",
@@ -1750,7 +1756,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "expr": "traffic_gossip_outbound_bytes",
@@ -1803,7 +1809,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "expr": "traffic_gossip_inbound_bytes",
@@ -1856,7 +1862,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "expr": "traffic_autopeering_outbound_bytes",
@@ -1909,7 +1915,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "expr": "traffic_autopeering_inbound_bytes",
@@ -1962,7 +1968,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "expr": "traffic_fpc_inbound_bytes",
@@ -2015,7 +2021,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "expr": "traffic_fpc_outbound_bytes",
@@ -2068,7 +2074,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "expr": "traffic_analysis_outbound_bytes",
@@ -2233,7 +2239,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "expr": "fpc_avg_rounds_to_finalize",
@@ -2290,7 +2296,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "expr": "fpc_finalized_conflicts",
@@ -2347,7 +2353,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "expr": "fpc_failed_conflicts",
@@ -2770,5 +2776,5 @@
   "timezone": "",
   "title": "GoShimmer Local Metrics",
   "uid": "kjOQZ2ZMk",
-  "version": 6
+  "version": 3
 }

--- a/tools/monitoring/grafana/dashboards/local_dashboard.json
+++ b/tools/monitoring/grafana/dashboards/local_dashboard.json
@@ -16,7 +16,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 1,
+  "id": 2,
   "links": [],
   "panels": [
     {
@@ -72,9 +72,10 @@
           ],
           "fields": "/^version$/",
           "values": false
-        }
+        },
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.5",
+      "pluginVersion": "7.1.1",
       "targets": [
         {
           "expr": "iota_info_app",
@@ -92,6 +93,121 @@
           "options": {}
         }
       ],
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Shortened version of the public key of the node.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 2,
+        "y": 1
+      },
+      "id": 81,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^nodeID$/",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.1.1",
+      "targets": [
+        {
+          "expr": "iota_info_app",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Node Identity",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {}
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Shows the time elapsed since the start of the node.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 4,
+        "y": 1
+      },
+      "id": 79,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "pluginVersion": "7.1.1",
+      "targets": [
+        {
+          "expr": "time() - process_start_time_seconds",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Uptime",
       "type": "stat"
     },
     {
@@ -136,7 +252,7 @@
       "gridPos": {
         "h": 2,
         "w": 2,
-        "x": 2,
+        "x": 6,
         "y": 1
       },
       "id": 22,
@@ -151,9 +267,10 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.5",
+      "pluginVersion": "7.1.1",
       "targets": [
         {
           "expr": "sync",
@@ -195,7 +312,7 @@
       "gridPos": {
         "h": 2,
         "w": 2,
-        "x": 4,
+        "x": 8,
         "y": 1
       },
       "id": 30,
@@ -210,9 +327,10 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.5",
+      "pluginVersion": "7.1.1",
       "targets": [
         {
           "expr": "irate(tangle_message_total_count[5m])",
@@ -253,7 +371,7 @@
       "gridPos": {
         "h": 2,
         "w": 2,
-        "x": 6,
+        "x": 10,
         "y": 1
       },
       "id": 53,
@@ -268,9 +386,10 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.5",
+      "pluginVersion": "7.1.1",
       "targets": [
         {
           "expr": "process_cpu_usage",
@@ -307,7 +426,7 @@
       "gridPos": {
         "h": 2,
         "w": 2,
-        "x": 8,
+        "x": 12,
         "y": 1
       },
       "id": 20,
@@ -322,9 +441,10 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.5",
+      "pluginVersion": "7.1.1",
       "targets": [
         {
           "expr": "process_mem_usage_bytes/1024/1024",
@@ -365,7 +485,7 @@
       "gridPos": {
         "h": 2,
         "w": 2,
-        "x": 10,
+        "x": 14,
         "y": 1
       },
       "id": 58,
@@ -380,9 +500,10 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.5",
+      "pluginVersion": "7.1.1",
       "targets": [
         {
           "expr": "db_size_bytes/1024/1024",
@@ -419,20 +540,7 @@
       "fieldConfig": {
         "defaults": {
           "custom": {},
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
+          "links": []
         },
         "overrides": []
       },
@@ -458,11 +566,8 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
       "percentage": false,
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -557,7 +662,8 @@
       "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "custom": {},
+          "links": []
         },
         "overrides": []
       },
@@ -583,10 +689,8 @@
       "lines": false,
       "linewidth": 1,
       "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
       "percentage": false,
+      "pluginVersion": "7.1.1",
       "pointradius": 0.5,
       "points": true,
       "renderer": "flot",
@@ -697,9 +801,10 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.5",
+      "pluginVersion": "7.1.1",
       "targets": [
         {
           "expr": "autopeering_neighbor_connections_count - autopeering_neighbor_drop_count",
@@ -751,9 +856,10 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.5",
+      "pluginVersion": "7.1.1",
       "targets": [
         {
           "expr": "autopeering_avg_neighbor_connection_lifetime",
@@ -808,9 +914,10 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.5",
+      "pluginVersion": "7.1.1",
       "targets": [
         {
           "expr": "autopeering_neighbor_connections_count",
@@ -865,9 +972,10 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.5",
+      "pluginVersion": "7.1.1",
       "targets": [
         {
           "expr": "autopeering_neighbor_drop_count",
@@ -890,7 +998,8 @@
       "description": "Shows tips in message and value layer.",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "custom": {},
+          "links": []
         },
         "overrides": []
       },
@@ -916,10 +1025,8 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
       "percentage": false,
+      "pluginVersion": "7.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -990,7 +1097,8 @@
       "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "custom": {},
+          "links": []
         },
         "overrides": []
       },
@@ -1016,10 +1124,8 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
       "percentage": false,
+      "pluginVersion": "7.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1084,7 +1190,8 @@
       "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "custom": {},
+          "links": []
         },
         "overrides": []
       },
@@ -1110,10 +1217,8 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
       "percentage": false,
+      "pluginVersion": "7.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1179,7 +1284,8 @@
       "description": "Number of messages in missingMessageStore. These are the message the node knows it doesn't have and tries to requests them.",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "custom": {},
+          "links": []
         },
         "overrides": []
       },
@@ -1205,10 +1311,8 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
       "percentage": false,
+      "pluginVersion": "7.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1274,7 +1378,8 @@
       "description": "Describes the amount of total, solid and not solid messages in the node's database.",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "custom": {},
+          "links": []
         },
         "overrides": []
       },
@@ -1302,10 +1407,8 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
       "percentage": false,
+      "pluginVersion": "7.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1383,7 +1486,8 @@
       "description": "Number of messages currently requested by the message tangle.",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "custom": {},
+          "links": []
         },
         "overrides": []
       },
@@ -1409,10 +1513,8 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
       "percentage": false,
+      "pluginVersion": "7.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1477,7 +1579,8 @@
       "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "custom": {},
+          "links": []
         },
         "overrides": []
       },
@@ -1503,10 +1606,8 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
       "percentage": false,
+      "pluginVersion": "7.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1608,7 +1709,8 @@
       "description": "Average time it takes to solidify messages.",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "custom": {},
+          "links": []
         },
         "overrides": []
       },
@@ -1634,10 +1736,8 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
       "percentage": false,
+      "pluginVersion": "7.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1712,6 +1812,11 @@
       },
       "id": 61,
       "mode": "markdown",
+      "options": {
+        "content": "\n# Total Network Traffic\n\n\nSince the start of the node.\n",
+        "mode": "markdown"
+      },
+      "pluginVersion": "7.1.0",
       "timeFrom": null,
       "timeShift": null,
       "title": "",
@@ -1754,9 +1859,10 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.5",
+      "pluginVersion": "7.1.1",
       "targets": [
         {
           "expr": "traffic_gossip_outbound_bytes",
@@ -1807,9 +1913,10 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.5",
+      "pluginVersion": "7.1.1",
       "targets": [
         {
           "expr": "traffic_gossip_inbound_bytes",
@@ -1860,9 +1967,10 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.5",
+      "pluginVersion": "7.1.1",
       "targets": [
         {
           "expr": "traffic_autopeering_outbound_bytes",
@@ -1913,9 +2021,10 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.5",
+      "pluginVersion": "7.1.1",
       "targets": [
         {
           "expr": "traffic_autopeering_inbound_bytes",
@@ -1966,9 +2075,10 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.5",
+      "pluginVersion": "7.1.1",
       "targets": [
         {
           "expr": "traffic_fpc_inbound_bytes",
@@ -2019,9 +2129,10 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.5",
+      "pluginVersion": "7.1.1",
       "targets": [
         {
           "expr": "traffic_fpc_outbound_bytes",
@@ -2072,9 +2183,10 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.5",
+      "pluginVersion": "7.1.1",
       "targets": [
         {
           "expr": "traffic_analysis_outbound_bytes",
@@ -2110,7 +2222,8 @@
       "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "custom": {},
+          "links": []
         },
         "overrides": []
       },
@@ -2136,10 +2249,8 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
       "percentage": false,
+      "pluginVersion": "7.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2237,9 +2348,10 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.5",
+      "pluginVersion": "7.1.1",
       "targets": [
         {
           "expr": "fpc_avg_rounds_to_finalize",
@@ -2294,9 +2406,10 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.5",
+      "pluginVersion": "7.1.1",
       "targets": [
         {
           "expr": "fpc_finalized_conflicts",
@@ -2351,9 +2464,10 @@
           ],
           "fields": "",
           "values": false
-        }
+        },
+        "textMode": "auto"
       },
-      "pluginVersion": "7.0.5",
+      "pluginVersion": "7.1.1",
       "targets": [
         {
           "expr": "fpc_failed_conflicts",
@@ -2376,7 +2490,8 @@
       "description": "Describes how many FPC query requests the node has received.",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "custom": {},
+          "links": []
         },
         "overrides": []
       },
@@ -2402,10 +2517,8 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
       "percentage": false,
+      "pluginVersion": "7.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2470,7 +2583,8 @@
       "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "custom": {},
+          "links": []
         },
         "overrides": []
       },
@@ -2496,10 +2610,8 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
       "percentage": false,
+      "pluginVersion": "7.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2565,7 +2677,8 @@
       "description": "Describes how many FPC opinions were requested from the node.",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "custom": {},
+          "links": []
         },
         "overrides": []
       },
@@ -2591,10 +2704,8 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
       "percentage": false,
+      "pluginVersion": "7.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2659,7 +2770,8 @@
       "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
-          "custom": {}
+          "custom": {},
+          "links": []
         },
         "overrides": []
       },
@@ -2685,10 +2797,8 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
       "percentage": false,
+      "pluginVersion": "7.1.1",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2750,7 +2860,7 @@
     }
   ],
   "refresh": "5s",
-  "schemaVersion": 25,
+  "schemaVersion": 26,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -2776,5 +2886,5 @@
   "timezone": "",
   "title": "GoShimmer Local Metrics",
   "uid": "kjOQZ2ZMk",
-  "version": 3
+  "version": 17
 }


### PR DESCRIPTION
Fixes #679

* Fix MPS Per Payload Graph on Grafana Dashboard 
   - typo in networkdelay payload type
   - add syncbeacon payload type
* Display Uptime
   - enable prometheus process metrics by default
   - add panel of uptime to dashboard
* Display nodeID
  - export nodeID through `iota_info_app` prometheus metric
  - add panel of nodeID to dashboard

![image](https://user-images.githubusercontent.com/32927267/88650210-cd9ee280-d0c8-11ea-9dad-fa238c78833a.png)
