### PR TITLE
Static peering support

### DIFF
--- a/pluginmgr/webapi/plugins.go
+++ b/pluginmgr/webapi/plugins.go
@@ -10,6 +10,7 @@ import (
 	"github.com/iotaledger/goshimmer/plugins/webapi/info"
 	"github.com/iotaledger/goshimmer/plugins/webapi/message"
 	"github.com/iotaledger/goshimmer/plugins/webapi/spammer"
+	"github.com/iotaledger/goshimmer/plugins/webapi/staticpeering"
 	"github.com/iotaledger/goshimmer/plugins/webapi/tools"
 	"github.com/iotaledger/goshimmer/plugins/webapi/value"
 	"github.com/iotaledger/goshimmer/plugins/webauth"
@@ -30,4 +31,5 @@ var PLUGINS = node.Plugins(
 	info.Plugin(),
 	value.Plugin(),
 	tools.Plugin(),
+	staticpeering.Plugin(),
 )

--- a/plugins/webapi/staticpeering/addpeers/handler.go
+++ b/plugins/webapi/staticpeering/addpeers/handler.go
@@ -1,0 +1,94 @@
+package addpeers
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+
+	"github.com/labstack/gommon/log"
+
+	"github.com/iotaledger/goshimmer/plugins/gossip"
+	"github.com/iotaledger/hive.go/autopeering/peer"
+	"github.com/iotaledger/hive.go/autopeering/peer/service"
+	"github.com/iotaledger/hive.go/crypto/ed25519"
+	"github.com/iotaledger/hive.go/identity"
+	"github.com/labstack/echo"
+	"github.com/mr-tron/base58"
+)
+
+var (
+	// ErrParsingNode is returned when the node cannot be parsed.
+	ErrParsingNode = errors.New("cannot parse node")
+)
+
+// Handler adds peers statically
+func Handler(c echo.Context) error {
+	var request Request
+	if err := c.Bind(&request); err != nil {
+		log.Info(err.Error())
+		return c.JSON(http.StatusBadRequest, Response{Error: err.Error()})
+	}
+
+	peers, err := parsePeers(request.Peers)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, Response{Error: err.Error()})
+	}
+
+	var added = 0
+	for _, p := range peers {
+		err := gossip.Manager().AddOutbound(p)
+		if err != nil {
+			log.Errorf("%w", err)
+		} else {
+			log.Infof("peered successfully: %s", p)
+			added++
+		}
+	}
+	return c.JSON(http.StatusCreated, Response{Added: added})
+}
+
+func parsePeers(peers []string) (result []*peer.Peer, err error) {
+	for _, p := range peers {
+		if p == "" {
+			continue
+		}
+
+		parts := strings.Split(p, "@")
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("%w: master node parts must be 2, is %d", ErrParsingNode, len(parts))
+		}
+		pubKey, err := base58.Decode(parts[0])
+		if err != nil {
+			return nil, fmt.Errorf("%w: invalid public key: %s", ErrParsingNode, err)
+		}
+		addr, err := net.ResolveUDPAddr("udp", parts[1])
+		if err != nil {
+			return nil, fmt.Errorf("%w: host cannot be resolved: %s", ErrParsingNode, err)
+		}
+		publicKey, _, err := ed25519.PublicKeyFromBytes(pubKey)
+		if err != nil {
+			return nil, err
+		}
+
+		services := service.New()
+		services.Update(service.PeeringKey, addr.Network(), addr.Port)
+		services.Update(service.GossipKey, addr.Network(), addr.Port)
+
+		result = append(result, peer.NewPeer(identity.New(publicKey), addr.IP, services))
+	}
+
+	return result, nil
+}
+
+// Response represents the addPeers api response.
+type Response struct {
+	Added int    `json:"added"`
+	Error string `json:"error,omitempty"`
+}
+
+// Request represents the addPeers api request body.
+type Request struct {
+	Peers []string `json:"peers"`
+}

--- a/plugins/webapi/staticpeering/plugin.go
+++ b/plugins/webapi/staticpeering/plugin.go
@@ -1,0 +1,33 @@
+package staticpeering
+
+import (
+	"sync"
+
+	"github.com/iotaledger/goshimmer/plugins/webapi/staticpeering/removepeers"
+
+	"github.com/iotaledger/goshimmer/plugins/webapi"
+	"github.com/iotaledger/goshimmer/plugins/webapi/staticpeering/addpeers"
+	"github.com/iotaledger/hive.go/node"
+)
+
+// PluginName is the name of the web API staticpeering endpoint plugin.
+const PluginName = "WebAPI staticpeering Endpoint"
+
+var (
+	// plugin is the plugin instance of the web API staticpeering endpoint plugin.
+	plugin *node.Plugin
+	once   sync.Once
+)
+
+func configure(plugin *node.Plugin) {
+	webapi.Server().GET("staticpeering/addPeers", addpeers.Handler)
+	webapi.Server().GET("staticpeering/removePeers", removepeers.Handler)
+}
+
+// Plugin gets the plugin instance.
+func Plugin() *node.Plugin {
+	once.Do(func() {
+		plugin = node.NewPlugin(PluginName, node.Enabled, configure)
+	})
+	return plugin
+}

--- a/plugins/webapi/staticpeering/removepeers/handler.go
+++ b/plugins/webapi/staticpeering/removepeers/handler.go
@@ -1,0 +1,60 @@
+package removepeers
+
+import (
+	"net/http"
+
+	"github.com/iotaledger/hive.go/crypto/ed25519"
+	"github.com/mr-tron/base58"
+
+	"github.com/iotaledger/hive.go/identity"
+
+	"github.com/iotaledger/goshimmer/plugins/gossip"
+	"github.com/labstack/echo"
+	"github.com/labstack/gommon/log"
+)
+
+// Handler removes peers
+func Handler(c echo.Context) error {
+	var request Request
+	if err := c.Bind(&request); err != nil {
+		log.Info(err.Error())
+		return c.JSON(http.StatusBadRequest, Response{Error: err.Error()})
+	}
+
+	var peerIDs []identity.ID
+	for _, peerIDStr := range request.Peers {
+		bytes, err := base58.Decode(peerIDStr)
+		if err != nil {
+			return c.JSON(http.StatusBadRequest, Response{Error: err.Error()})
+		}
+		pubKey, _, err := ed25519.PublicKeyFromBytes(bytes)
+		peerID := identity.NewID(pubKey)
+		if err != nil {
+			return c.JSON(http.StatusBadRequest, Response{Error: err.Error()})
+		}
+		peerIDs = append(peerIDs, peerID)
+	}
+
+	var removed = 0
+	for _, peerID := range peerIDs {
+		err := gossip.Manager().DropNeighbor(peerID)
+		if err != nil {
+			log.Errorf("%w: error dropping peer: %s", err)
+		} else {
+			log.Infof("successfully removed peer %s", peerID)
+			removed++
+		}
+	}
+	return c.JSON(http.StatusOK, Response{Removed: removed})
+}
+
+// Response represents the removePeers api response.
+type Response struct {
+	Removed int    `json:"removed"`
+	Error   string `json:"error,omitempty"`
+}
+
+// Request represents the removePeers api request body.
+type Request struct {
+	Peers []string `json:"peers"`
+}


### PR DESCRIPTION
Adds static peering support via API
 - `addPeers`: Accepts a list of nodes to peer with. Returns the number of nodes added.
 - `removePeers`: Accepts a list of nodes to disconnect. Returns the number of nodes removed.

Fixes #547 
