### PR TITLE
Make autopeering.NetworkVersion configurable

### DIFF
--- a/plugins/autopeering/autopeering.go
+++ b/plugins/autopeering/autopeering.go
@@ -195,6 +195,7 @@ func parseEntryNodes() (result []*peer.Peer, err error) {
 	return result, nil
 }
 
+// NetworkVersion returns the network version of the autopeering.
 func NetworkVersion() uint32 {
 	return networkVersion
 }

--- a/plugins/autopeering/autopeering.go
+++ b/plugins/autopeering/autopeering.go
@@ -24,7 +24,6 @@ import (
 // autopeering constants
 const (
 	ProtocolVersion = 0 // update on protocol changes
-	NetworkVersion  = 6 // update on network changes
 )
 
 var (
@@ -92,7 +91,7 @@ func createPeerDisc() {
 	}
 	log.Debugf("Master peers: %v", masterPeers)
 
-	peerDisc = discover.New(local.GetInstance(), ProtocolVersion, NetworkVersion,
+	peerDisc = discover.New(local.GetInstance(), ProtocolVersion, config.Node().GetUint32(CfgNetworkVersion),
 		discover.Logger(log),
 		discover.MasterPeers(masterPeers),
 	)

--- a/plugins/autopeering/autopeering.go
+++ b/plugins/autopeering/autopeering.go
@@ -48,6 +48,8 @@ var (
 		once sync.Once
 		c    chan *server.Server
 	}{c: make(chan *server.Server, 1)}
+
+	networkVersion uint32
 )
 
 // Discovery returns the peer discovery instance.
@@ -91,7 +93,7 @@ func createPeerDisc() {
 	}
 	log.Debugf("Master peers: %v", masterPeers)
 
-	peerDisc = discover.New(local.GetInstance(), ProtocolVersion, config.Node().GetUint32(CfgNetworkVersion),
+	peerDisc = discover.New(local.GetInstance(), ProtocolVersion, NetworkVersion(),
 		discover.Logger(log),
 		discover.MasterPeers(masterPeers),
 	)
@@ -191,4 +193,8 @@ func parseEntryNodes() (result []*peer.Peer, err error) {
 	}
 
 	return result, nil
+}
+
+func NetworkVersion() uint32 {
+	return networkVersion
 }

--- a/plugins/autopeering/parameters.go
+++ b/plugins/autopeering/parameters.go
@@ -7,8 +7,11 @@ import (
 const (
 	// CfgEntryNodes defines the config flag of the entry nodes.
 	CfgEntryNodes = "autopeering.entryNodes"
+	// CfgNetworkVersion defines the config flag of the netowrk version.
+	CfgNetworkVersion = "autopeering.networkVersion"
 )
 
 func init() {
 	flag.StringSlice(CfgEntryNodes, []string{"2PV5487xMw5rasGBXXWeqSi4hLz7r19YBt8Y1TGAsQbj@ressims.iota.cafe:15626"}, "list of trusted entry nodes for auto peering")
+	flag.Uint32(CfgNetworkVersion, 6, "autopeering netowrk version")
 }

--- a/plugins/autopeering/parameters.go
+++ b/plugins/autopeering/parameters.go
@@ -7,11 +7,11 @@ import (
 const (
 	// CfgEntryNodes defines the config flag of the entry nodes.
 	CfgEntryNodes = "autopeering.entryNodes"
-	// CfgNetworkVersion defines the config flag of the netowrk version.
+	// CfgNetworkVersion defines the config flag of the network version.
 	CfgNetworkVersion = "autopeering.networkVersion"
 )
 
 func init() {
 	flag.StringSlice(CfgEntryNodes, []string{"2PV5487xMw5rasGBXXWeqSi4hLz7r19YBt8Y1TGAsQbj@ressims.iota.cafe:15626"}, "list of trusted entry nodes for auto peering")
-	flag.Uint32(CfgNetworkVersion, 6, "autopeering netowrk version")
+	flag.Uint32(CfgNetworkVersion, 6, "autopeering network version")
 }

--- a/plugins/autopeering/plugin.go
+++ b/plugins/autopeering/plugin.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/iotaledger/goshimmer/packages/shutdown"
+	"github.com/iotaledger/goshimmer/plugins/config"
 	"github.com/iotaledger/hive.go/autopeering/discover"
 	"github.com/iotaledger/hive.go/autopeering/selection"
 	"github.com/iotaledger/hive.go/daemon"
@@ -34,6 +35,7 @@ func Plugin() *node.Plugin {
 
 func configure(*node.Plugin) {
 	log = logger.NewLogger(PluginName)
+	networkVersion = config.Node().GetUint32(CfgNetworkVersion)
 
 	configureEvents()
 }

--- a/plugins/portcheck/plugin.go
+++ b/plugins/portcheck/plugin.go
@@ -7,7 +7,6 @@ import (
 	"github.com/iotaledger/goshimmer/plugins/autopeering"
 	"github.com/iotaledger/goshimmer/plugins/autopeering/local"
 	"github.com/iotaledger/goshimmer/plugins/banner"
-	"github.com/iotaledger/goshimmer/plugins/config"
 	"github.com/iotaledger/hive.go/autopeering/discover"
 	"github.com/iotaledger/hive.go/autopeering/peer/service"
 	"github.com/iotaledger/hive.go/autopeering/server"
@@ -60,7 +59,7 @@ func checkAutopeeringConnection() {
 	defer conn.Close()
 
 	// create a new discovery server for the port check
-	disc := discover.New(local.GetInstance(), autopeering.ProtocolVersion, config.Node().GetUint32(autopeering.CfgNetworkVersion), discover.Logger(log))
+	disc := discover.New(local.GetInstance(), autopeering.ProtocolVersion, autopeering.NetworkVersion(), discover.Logger(log))
 	srv := server.Serve(local.GetInstance(), conn, log, disc)
 	defer srv.Close()
 

--- a/plugins/portcheck/plugin.go
+++ b/plugins/portcheck/plugin.go
@@ -7,6 +7,7 @@ import (
 	"github.com/iotaledger/goshimmer/plugins/autopeering"
 	"github.com/iotaledger/goshimmer/plugins/autopeering/local"
 	"github.com/iotaledger/goshimmer/plugins/banner"
+	"github.com/iotaledger/goshimmer/plugins/config"
 	"github.com/iotaledger/hive.go/autopeering/discover"
 	"github.com/iotaledger/hive.go/autopeering/peer/service"
 	"github.com/iotaledger/hive.go/autopeering/server"
@@ -59,7 +60,7 @@ func checkAutopeeringConnection() {
 	defer conn.Close()
 
 	// create a new discovery server for the port check
-	disc := discover.New(local.GetInstance(), autopeering.ProtocolVersion, autopeering.NetworkVersion, discover.Logger(log))
+	disc := discover.New(local.GetInstance(), autopeering.ProtocolVersion, config.Node().GetUint32(autopeering.CfgNetworkVersion), discover.Logger(log))
 	srv := server.Serve(local.GetInstance(), conn, log, disc)
 	defer srv.Close()
 

--- a/plugins/webapi/info/plugin.go
+++ b/plugins/webapi/info/plugin.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	goSync "sync"
 
+	"github.com/iotaledger/goshimmer/plugins/autopeering"
 	"github.com/iotaledger/goshimmer/plugins/autopeering/local"
 	"github.com/iotaledger/goshimmer/plugins/banner"
 	"github.com/iotaledger/goshimmer/plugins/metrics"
@@ -103,6 +104,7 @@ func getInfo(c echo.Context) error {
 
 	return c.JSON(http.StatusOK, Response{
 		Version:                 banner.AppVersion,
+		NetworkVersion:          autopeering.NetworkVersion(),
 		Synced:                  synced,
 		Beacons:                 beaconsStatus,
 		IdentityID:              local.GetInstance().Identity.ID().String(),
@@ -119,6 +121,8 @@ func getInfo(c echo.Context) error {
 type Response struct {
 	// version of GoShimmer
 	Version string `json:"version,omitempty"`
+	// Network Version of the autopeering
+	NetworkVersion uint32 `json:"networkVersion,omitempty"`
 	// whether the node is synchronized
 	Synced bool `json:"synced"`
 	// sync beacons status


### PR DESCRIPTION
Makes autopeering network version configurable and adds the network version to the output of the API info