### PR TITLE
 Add value tips debug API

### DIFF
--- a/dapps/valuetransfers/packages/tipmanager/tipmanager.go
+++ b/dapps/valuetransfers/packages/tipmanager/tipmanager.go
@@ -77,6 +77,15 @@ func (t *TipManager) Tips() (parent1ObjectID, parent2ObjectID payload.ID) {
 	return
 }
 
+// AllTips returns all the tips.
+func (t *TipManager) AllTips() (tips []payload.ID) {
+	tips = make([]payload.ID, t.Size())
+	for i, tip := range t.tips.Keys() {
+		tips[i] = tip.(payload.ID)
+	}
+	return
+}
+
 // Size returns the total liked tips.
 func (t *TipManager) Size() int {
 	return t.tips.Size()

--- a/packages/binary/datastructure/random_map.go
+++ b/packages/binary/datastructure/random_map.go
@@ -135,3 +135,17 @@ func (rmap *RandomMap) RandomEntry() (result interface{}) {
 
 	return
 }
+
+// Keys returns the list of keys stored in the RandomMap.
+func (rmap *RandomMap) Keys() (result []interface{}) {
+	rmap.mutex.RLock()
+	defer rmap.mutex.RUnlock()
+
+	result = make([]interface{}, rmap.size)
+
+	for i, item := range rmap.keys {
+		result[i] = item
+	}
+
+	return
+}

--- a/plugins/webapi/value/plugin.go
+++ b/plugins/webapi/value/plugin.go
@@ -9,6 +9,7 @@ import (
 	"github.com/iotaledger/goshimmer/plugins/webapi/value/sendtransaction"
 	"github.com/iotaledger/goshimmer/plugins/webapi/value/sendtransactionbyjson"
 	"github.com/iotaledger/goshimmer/plugins/webapi/value/testsendtxn"
+	"github.com/iotaledger/goshimmer/plugins/webapi/value/tips"
 	"github.com/iotaledger/goshimmer/plugins/webapi/value/unspentoutputs"
 	"github.com/iotaledger/hive.go/node"
 )
@@ -37,4 +38,5 @@ func configure(_ *node.Plugin) {
 	webapi.Server().POST("value/sendTransactionByJson", sendtransactionbyjson.Handler)
 	webapi.Server().POST("value/testSendTxn", testsendtxn.Handler)
 	webapi.Server().GET("value/transactionByID", gettransactionbyid.Handler)
+	webapi.Server().GET("value/tips", tips.Handler)
 }

--- a/plugins/webapi/value/tips/handler.go
+++ b/plugins/webapi/value/tips/handler.go
@@ -1,0 +1,43 @@
+package tips
+
+import (
+	"net/http"
+
+	"github.com/iotaledger/goshimmer/dapps/valuetransfers"
+	"github.com/iotaledger/goshimmer/dapps/valuetransfers/packages/tangle"
+	"github.com/labstack/echo"
+)
+
+// Handler gets the value object info from the tips.
+func Handler(c echo.Context) error {
+	result := make([]ValueObject, valuetransfers.TipManager().Size())
+	for i, valueID := range valuetransfers.TipManager().AllTips() {
+		var obj ValueObject
+		valuetransfers.Tangle().PayloadMetadata(valueID).Consume(func(payloadMetadata *tangle.PayloadMetadata) {
+			obj.ID = payloadMetadata.PayloadID().String()
+			obj.Solid = payloadMetadata.IsSolid()
+			obj.Liked = payloadMetadata.Liked()
+			obj.Confirmed = payloadMetadata.Confirmed()
+			obj.Rejected = payloadMetadata.Rejected()
+			obj.BranchID = payloadMetadata.BranchID().String()
+		})
+		result[i] = obj
+	}
+	return c.JSON(http.StatusOK, Response{ValueObjects: result})
+}
+
+// Response is the HTTP response from retrieving value objects.
+type Response struct {
+	ValueObjects []ValueObject `json:"value_objects,omitempty"`
+	Error        string        `json:"error,omitempty"`
+}
+
+// ValueObject holds the info of a ValueObject
+type ValueObject struct {
+	ID        string `json:"id"`
+	Solid     bool   `json:"solid"`
+	Liked     bool   `json:"liked"`
+	Confirmed bool   `json:"confirmed"`
+	Rejected  bool   `json:"rejected"`
+	BranchID  string `json:"branch_id"`
+}

--- a/plugins/webapi/value/tips/handler.go
+++ b/plugins/webapi/value/tips/handler.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/iotaledger/goshimmer/dapps/valuetransfers"
+	"github.com/iotaledger/goshimmer/dapps/valuetransfers/packages/payload"
 	"github.com/iotaledger/goshimmer/dapps/valuetransfers/packages/tangle"
 	"github.com/labstack/echo"
 )
@@ -21,6 +22,11 @@ func Handler(c echo.Context) error {
 			obj.Rejected = payloadMetadata.Rejected()
 			obj.BranchID = payloadMetadata.BranchID().String()
 		})
+
+		valuetransfers.Tangle().Payload(valueID).Consume(func(p *payload.Payload) {
+			obj.TransactionID = p.Transaction().ID().String()
+		})
+
 		result[i] = obj
 	}
 	return c.JSON(http.StatusOK, Response{ValueObjects: result})
@@ -34,10 +40,11 @@ type Response struct {
 
 // ValueObject holds the info of a ValueObject
 type ValueObject struct {
-	ID        string `json:"id"`
-	Solid     bool   `json:"solid"`
-	Liked     bool   `json:"liked"`
-	Confirmed bool   `json:"confirmed"`
-	Rejected  bool   `json:"rejected"`
-	BranchID  string `json:"branch_id"`
+	ID            string `json:"id"`
+	Solid         bool   `json:"solid"`
+	Liked         bool   `json:"liked"`
+	Confirmed     bool   `json:"confirmed"`
+	Rejected      bool   `json:"rejected"`
+	BranchID      string `json:"branch_id"`
+	TransactionID string `json:"transaction_id"`
 }

--- a/tools/integration-tests/tester/framework/framework.go
+++ b/tools/integration-tests/tester/framework/framework.go
@@ -258,7 +258,7 @@ func (f *Framework) CreateDRNGNetwork(name string, members, peers, minimumNeighb
 	}
 
 	config := GoShimmerConfig{
-		DRNGInstance:       1,
+		DRNGInstance:       111,
 		DRNGThreshold:      3,
 		DRNGDistKey:        hex.EncodeToString(drng.distKey),
 		DRNGCommittee:      drngCommittee,


### PR DESCRIPTION
This PR adds a new API endpoint for retrieving metadata info about the current tips

For example:

```
{"value_objects":[
{"id":"6VLLfKeoo6vhJLCaeyCgz98eNGR5FoPCQh9356cz72A8","solid":true,"liked":true,"confirmed":true,"rejected":false,"branch_id":"4uQeVj5tqViQh7yWWGStvkEG1Zmhx6uasJtWCJziofM"},
{"id":"HYBcXEs8WLnuQEQcqxKhGyaRrGH95Knq8VNBChu5n5U","solid":true,"liked":true,"confirmed":true,"rejected":false,"branch_id":"4uQeVj5tqViQh7yWWGStvkEG1Zmhx6uasJtWCJziofM"}
]}
```