### PR TITLE
Add rand-seed tool

### DIFF
--- a/tools/rand-seed/main.go
+++ b/tools/rand-seed/main.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/mr-tron/base58"
+)
+
+func main() {
+	b := make([]byte, 32)
+	_, err := rand.Read(b)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	fmt.Printf("base64:%s\n", base64.StdEncoding.EncodeToString(b))
+	fmt.Printf("base58:%s\n", base58.Encode(b))
+}


### PR DESCRIPTION
This PR adds a `rand-seed` under the tool folder. It produces a similar output:

```
base64:N/LWxpXBYVE0zfs1VJLoNRk3scJgTkhTcXI3vRVP85w=
base58:4mQC6qfXtPati8eJude4tan9wV4kud9oHJ4fk1Bk7EVH
```