### PR TITLE
Added mana related endpoints

### DIFF
--- a/packages/mana/base_test.go
+++ b/packages/mana/base_test.go
@@ -345,3 +345,15 @@ func TestPledgeAndUpdatePastOldFunds(t *testing.T) {
 	// valid EBM2 at t=6 hours, after pledging 10 BM2 at t=0
 	assert.True(t, within(3.465731, bm.EffectiveBaseMana2))
 }
+
+func TestNodeMap_GetPercentile(t *testing.T) {
+	nodes := make(NodeMap)
+	nodes[identity.GenerateIdentity().ID()] = 1
+	nodes[identity.GenerateIdentity().ID()] = 2
+	nodes[identity.GenerateIdentity().ID()] = 3
+	checkID := identity.GenerateIdentity().ID()
+	nodes[checkID] = 4
+	percentile, err := nodes.GetPercentile(checkID)
+	assert.NoError(t, err)
+	assert.Equal(t, 75.0, percentile)
+}

--- a/packages/mana/base_test.go
+++ b/packages/mana/base_test.go
@@ -377,15 +377,3 @@ func TestPledgeAndUpdatePastOldFunds(t *testing.T) {
 	// valid EBM2 at t=6 hours, after pledging 10 BM2 at t=0
 	assert.InDelta(t, 3.465731, bm.EffectiveBaseMana2, delta)
 }
-
-func TestNodeMap_GetPercentile(t *testing.T) {
-	nodes := make(NodeMap)
-	nodes[identity.GenerateIdentity().ID()] = 1
-	nodes[identity.GenerateIdentity().ID()] = 2
-	nodes[identity.GenerateIdentity().ID()] = 3
-	checkID := identity.GenerateIdentity().ID()
-	nodes[checkID] = 4
-	percentile, err := nodes.GetPercentile(checkID)
-	assert.NoError(t, err)
-	assert.Equal(t, 75.0, percentile)
-}

--- a/packages/mana/basevector.go
+++ b/packages/mana/basevector.go
@@ -162,6 +162,7 @@ func (bmv *BaseManaVector) GetManaMap() NodeMap {
 
 // GetHighestManaNodes return the n highest mana nodes in descending order.
 // It also updates the mana values for each node.
+// If n is zero, it returns all nodes.
 func (bmv *BaseManaVector) GetHighestManaNodes(n uint) []Node {
 	var res []Node
 	func() {
@@ -181,10 +182,10 @@ func (bmv *BaseManaVector) GetHighestManaNodes(n uint) []Node {
 		return res[i].Mana > res[j].Mana
 	})
 
-	if int(n) <= len(res) {
-		return res[:n]
+	if n == 0 || int(n) >= len(res) {
+		return res[:]
 	}
-	return res[:]
+	return res[:n]
 }
 
 // SetMana sets the base mana for a node.
@@ -200,8 +201,38 @@ type Node struct {
 	Mana float64
 }
 
+// NodeStr defines a node and its mana value.
+// The node ID is stringified.
+type NodeStr struct {
+	ID   string
+	Mana float64
+}
+
+// ToNodeStr converts a Node to a Nodestr
+func (n Node) ToNodeStr() NodeStr {
+	return NodeStr{
+		ID:   n.ID.String(),
+		Mana: n.Mana,
+	}
+}
+
 // NodeMap is a map of nodeID and mana value.
 type NodeMap map[identity.ID]float64
+
+// NodeMapStr is a NodeMap but with string id.
+type NodeMapStr map[string]float64
+
+// ToNodeStrList converts a NodeMap to list of NodeStr.
+func (n NodeMap) ToNodeStrList() []NodeStr {
+	var list []NodeStr
+	for ID, val := range n {
+		list = append(list, NodeStr{
+			ID:   ID.String(),
+			Mana: val,
+		})
+	}
+	return list
+}
 
 //// Region Internal methods ////
 

--- a/packages/mana/basevector.go
+++ b/packages/mana/basevector.go
@@ -234,6 +234,25 @@ func (n NodeMap) ToNodeStrList() []NodeStr {
 	return list
 }
 
+// GetPercentile returns the top percentile the node belongs to relative to the network in terms of mana.
+func (n NodeMap) GetPercentile(node identity.ID) (float64, error) {
+	if len(n) == 0 {
+		return 0, nil
+	}
+	value, ok := n[node]
+	if !ok {
+		return 0, ErrNodeNotFoundInBaseManaVector
+	}
+	nBelow := 0.0
+	for _, val := range n {
+		if val < value {
+			nBelow++
+		}
+	}
+
+	return (nBelow / float64(len(n))) * 100, nil
+}
+
 //// Region Internal methods ////
 
 // update updates the mana entries for a particular node wrt time. Not concurrency safe.

--- a/packages/mana/basevector_test.go
+++ b/packages/mana/basevector_test.go
@@ -570,12 +570,8 @@ func TestBaseManaVector_GetHighestManaNodes(t *testing.T) {
 		})
 	}
 
-	// requesting zero highest mana nodes
-	result := bmv.GetHighestManaNodes(0)
-	assert.Empty(t, result)
-
 	// requesting the top mana holder
-	result = bmv.GetHighestManaNodes(1)
+	result := bmv.GetHighestManaNodes(1)
 	assert.Equal(t, 1, len(result))
 	assert.Equal(t, nodeIDs[9], result[0].ID)
 	assert.InDelta(t, 9.0, result[0].Mana, delta)

--- a/packages/mana/basevector_test.go
+++ b/packages/mana/basevector_test.go
@@ -620,3 +620,15 @@ func TestBaseManaVector_SetMana(t *testing.T) {
 		}, *bmv.vector[nodeIDs[i]])
 	}
 }
+
+func TestNodeMap_GetPercentile(t *testing.T) {
+	nodes := make(NodeMap)
+	nodes[identity.GenerateIdentity().ID()] = 1
+	nodes[identity.GenerateIdentity().ID()] = 2
+	nodes[identity.GenerateIdentity().ID()] = 3
+	checkID := identity.GenerateIdentity().ID()
+	nodes[checkID] = 4
+	percentile, err := nodes.GetPercentile(checkID)
+	assert.NoError(t, err)
+	assert.Equal(t, 75.0, percentile)
+}

--- a/packages/mana/identity.go
+++ b/packages/mana/identity.go
@@ -3,6 +3,8 @@ package mana
 import (
 	"fmt"
 
+	"github.com/iotaledger/hive.go/marshalutil"
+
 	"github.com/iotaledger/hive.go/identity"
 	"github.com/mr-tron/base58"
 )
@@ -15,9 +17,30 @@ func IDFromStr(idStr string) (ID identity.ID, err error) {
 	}
 	bytes, err := base58.Decode(idStr)
 	if err != nil {
-		err = fmt.Errorf("could not parse public key: %s, as base58: %w", idStr, err)
+		err = fmt.Errorf("could not decode ID: %s, from base58: %w", idStr, err)
 		return
 	}
 	copy(ID[:], bytes)
+	return
+}
+
+// IDFromPubKey returns the ID from the given public key.
+func IDFromPubKey(pubKey string) (ID identity.ID, err error) {
+	ID = identity.ID{}
+	if pubKey == "" {
+		return
+	}
+	bytes, err := base58.Decode(pubKey)
+	if err != nil {
+		err = fmt.Errorf("could not decode public key: %s, from base58: %w", pubKey, err)
+		return
+	}
+	_identity, err := identity.Parse(marshalutil.New(bytes))
+	if err != nil {
+		err = fmt.Errorf("could not parse public key: %s, %w", pubKey, err)
+		return
+	}
+
+	copy(ID[:], _identity.ID().Bytes())
 	return
 }

--- a/packages/mana/identity.go
+++ b/packages/mana/identity.go
@@ -1,0 +1,23 @@
+package mana
+
+import (
+	"fmt"
+
+	"github.com/iotaledger/hive.go/identity"
+	"github.com/mr-tron/base58"
+)
+
+// IDFromPubKey returns the identity of a node from its public key in base58.
+func IDFromPubKey(pubKey string) (ID identity.ID, err error) {
+	ID = identity.ID{}
+	if pubKey == "" {
+		return
+	}
+	bytes, err := base58.Decode(pubKey)
+	if err != nil {
+		err = fmt.Errorf("could not parse public key: %s, as base58: %w", pubKey, err)
+		return
+	}
+	copy(ID[:], bytes)
+	return
+}

--- a/packages/mana/identity.go
+++ b/packages/mana/identity.go
@@ -7,15 +7,15 @@ import (
 	"github.com/mr-tron/base58"
 )
 
-// IDFromPubKey returns the identity of a node from its public key in base58.
-func IDFromPubKey(pubKey string) (ID identity.ID, err error) {
+// IDFromStr decodes and returns an ID from base58.
+func IDFromStr(idStr string) (ID identity.ID, err error) {
 	ID = identity.ID{}
-	if pubKey == "" {
+	if idStr == "" {
 		return
 	}
-	bytes, err := base58.Decode(pubKey)
+	bytes, err := base58.Decode(idStr)
 	if err != nil {
-		err = fmt.Errorf("could not parse public key: %s, as base58: %w", pubKey, err)
+		err = fmt.Errorf("could not parse public key: %s, as base58: %w", idStr, err)
 		return
 	}
 	copy(ID[:], bytes)

--- a/packages/mana/identity_test.go
+++ b/packages/mana/identity_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestIDFromPubKey(t *testing.T) {
+func TestIDFromStr(t *testing.T) {
 	_identity := identity.GenerateIdentity()
 	ID, err := IDFromStr(base58.Encode(_identity.ID().Bytes()))
 	assert.NoError(t, err)

--- a/packages/mana/identity_test.go
+++ b/packages/mana/identity_test.go
@@ -1,0 +1,17 @@
+package mana
+
+import (
+	"testing"
+
+	"github.com/mr-tron/base58"
+
+	"github.com/iotaledger/hive.go/identity"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIDFromPubKey(t *testing.T) {
+	_identity := identity.GenerateIdentity()
+	ID, err := IDFromStr(base58.Encode(_identity.ID().Bytes()))
+	assert.NoError(t, err)
+	assert.Equal(t, _identity.ID(), ID)
+}

--- a/packages/mana/identity_test.go
+++ b/packages/mana/identity_test.go
@@ -15,3 +15,10 @@ func TestIDFromStr(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, _identity.ID(), ID)
 }
+
+func TestIDFromPubKey(t *testing.T) {
+	_identity := identity.GenerateIdentity()
+	ID, err := IDFromPubKey(_identity.PublicKey().String())
+	assert.NoError(t, err)
+	assert.Equal(t, _identity.ID(), ID)
+}

--- a/pluginmgr/webapi/plugins.go
+++ b/pluginmgr/webapi/plugins.go
@@ -8,6 +8,7 @@ import (
 	"github.com/iotaledger/goshimmer/plugins/webapi/faucet"
 	"github.com/iotaledger/goshimmer/plugins/webapi/healthz"
 	"github.com/iotaledger/goshimmer/plugins/webapi/info"
+	"github.com/iotaledger/goshimmer/plugins/webapi/mana"
 	"github.com/iotaledger/goshimmer/plugins/webapi/message"
 	"github.com/iotaledger/goshimmer/plugins/webapi/spammer"
 	"github.com/iotaledger/goshimmer/plugins/webapi/tools"
@@ -30,4 +31,5 @@ var PLUGINS = node.Plugins(
 	info.Plugin(),
 	value.Plugin(),
 	tools.Plugin(),
+	mana.Plugin(),
 )

--- a/plugins/mana/plugin.go
+++ b/plugins/mana/plugin.go
@@ -1,7 +1,6 @@
 package mana
 
 import (
-	"fmt"
 	"math/rand"
 	"sync"
 	"time"
@@ -19,10 +18,8 @@ import (
 	"github.com/iotaledger/hive.go/events"
 	"github.com/iotaledger/hive.go/identity"
 	"github.com/iotaledger/hive.go/logger"
-	"github.com/iotaledger/hive.go/marshalutil"
 	"github.com/iotaledger/hive.go/node"
 	"github.com/iotaledger/hive.go/objectstorage"
-	"github.com/mr-tron/base58"
 	flag "github.com/spf13/pflag"
 )
 
@@ -304,23 +301,6 @@ func GetAllowedAccessPledgeNodes(manaType mana.Type) AllowedPledge {
 
 // TODO: Obtaining a list of currently known peers + their mana, sorted. Useful for knowing which high mana nodes are online.
 
-func idFromPubKey(pubKey string) (ID identity.ID, err error) {
-	ID = identity.ID{}
-	bytes, err := base58.Decode(pubKey)
-	if err != nil {
-		err = fmt.Errorf("could not parse %s config entry as base58: %w", pubKey, err)
-		return
-	}
-	marshalUtil := marshalutil.New(bytes)
-	_identity, err := identity.Parse(marshalUtil)
-	if err != nil {
-		err = fmt.Errorf("could not parse %s config entry as identity. %w", pubKey, err)
-		return
-	}
-	ID = _identity.ID()
-	return
-}
-
 func verifyPledgeNodes() error {
 	access := AllowedPledge{
 		IsFilterEnabled: config.Node().GetBool(CfgAllowedAccessFilterEnabled),
@@ -332,7 +312,7 @@ func verifyPledgeNodes() error {
 	if access.IsFilterEnabled {
 		nodes := make(map[identity.ID]interface{})
 		for _, pubKey := range config.Node().GetStringSlice(CfgAllowedAccessPledge) {
-			ID, err := idFromPubKey(pubKey)
+			ID, err := mana.IDFromPubKey(pubKey)
 			if err != nil {
 				return err
 			}
@@ -344,7 +324,7 @@ func verifyPledgeNodes() error {
 	if consensus.IsFilterEnabled {
 		nodes := make(map[identity.ID]interface{})
 		for _, pubKey := range config.Node().GetStringSlice(CfgAllowedConsensusPledge) {
-			ID, err := idFromPubKey(pubKey)
+			ID, err := mana.IDFromPubKey(pubKey)
 			if err != nil {
 				return err
 			}

--- a/plugins/mana/plugin.go
+++ b/plugins/mana/plugin.go
@@ -15,6 +15,7 @@ import (
 	"github.com/iotaledger/goshimmer/plugins/database"
 	"github.com/iotaledger/goshimmer/plugins/gossip"
 	"github.com/iotaledger/hive.go/daemon"
+	"github.com/iotaledger/hive.go/datastructure/set"
 	"github.com/iotaledger/hive.go/events"
 	"github.com/iotaledger/hive.go/identity"
 	"github.com/iotaledger/hive.go/logger"
@@ -294,8 +295,8 @@ func GetWeightedRandomNodes(n uint, manaType mana.Type) mana.NodeMap {
 	return res
 }
 
-// GetAllowedAccessPledgeNodes returns the list of nodes that type mana is allowed to be pledged to.
-func GetAllowedAccessPledgeNodes(manaType mana.Type) AllowedPledge {
+// GetAllowedPledgeNodes returns the list of nodes that type mana is allowed to be pledged to.
+func GetAllowedPledgeNodes(manaType mana.Type) AllowedPledge {
 	return allowedPledgeNodes[manaType]
 }
 
@@ -310,25 +311,25 @@ func verifyPledgeNodes() error {
 	}
 
 	if access.IsFilterEnabled {
-		nodes := make(map[identity.ID]interface{})
+		nodes := set.New(false)
 		for _, pubKey := range config.Node().GetStringSlice(CfgAllowedAccessPledge) {
-			ID, err := mana.IDFromPubKey(pubKey)
+			ID, err := mana.IDFromStr(pubKey)
 			if err != nil {
 				return err
 			}
-			nodes[ID] = nil // don't care
+			nodes.Add(ID)
 		}
 		access.Allowed = nodes
 	}
 
 	if consensus.IsFilterEnabled {
-		nodes := make(map[identity.ID]interface{})
+		nodes := set.New(false)
 		for _, pubKey := range config.Node().GetStringSlice(CfgAllowedConsensusPledge) {
-			ID, err := mana.IDFromPubKey(pubKey)
+			ID, err := mana.IDFromStr(pubKey)
 			if err != nil {
 				return err
 			}
-			nodes[ID] = nil // don't care
+			nodes.Add(ID)
 		}
 		consensus.Allowed = nodes
 	}
@@ -341,5 +342,5 @@ func verifyPledgeNodes() error {
 // AllowedPledge represents the nodes that mana is allowed to be pledged to.
 type AllowedPledge struct {
 	IsFilterEnabled bool
-	Allowed         map[identity.ID]interface{}
+	Allowed         set.Set
 }

--- a/plugins/webapi/info/plugin.go
+++ b/plugins/webapi/info/plugin.go
@@ -8,6 +8,7 @@ import (
 	"github.com/iotaledger/goshimmer/plugins/autopeering"
 	"github.com/iotaledger/goshimmer/plugins/autopeering/local"
 	"github.com/iotaledger/goshimmer/plugins/banner"
+	"github.com/iotaledger/goshimmer/plugins/mana"
 	"github.com/iotaledger/goshimmer/plugins/metrics"
 	"github.com/iotaledger/goshimmer/plugins/syncbeaconfollower"
 	"github.com/iotaledger/goshimmer/plugins/webapi"
@@ -102,6 +103,13 @@ func getInfo(c echo.Context) error {
 		})
 	}
 
+	accessMana, _ := mana.GetAccessMana(local.GetInstance().ID())
+	consensusMana, _ := mana.GetConsensusMana(local.GetInstance().ID())
+	nodeMana := Mana{
+		Access:    accessMana,
+		Consensus: consensusMana,
+	}
+
 	return c.JSON(http.StatusOK, Response{
 		Version:                 banner.AppVersion,
 		NetworkVersion:          autopeering.NetworkVersion(),
@@ -114,6 +122,7 @@ func getInfo(c echo.Context) error {
 		TotalMessageCount:       int(metrics.MessageTotalCountDB()),
 		EnabledPlugins:          enabledPlugins,
 		DisabledPlugins:         disabledPlugins,
+		Mana:                    nodeMana,
 	})
 }
 
@@ -141,6 +150,8 @@ type Response struct {
 	EnabledPlugins []string `json:"enabledPlugins,omitempty"`
 	// list if disabled plugins
 	DisabledPlugins []string `json:"disabledPlugins,omitempty"`
+	// Mana values
+	Mana Mana `json:"mana,omitempty"`
 	// error of the response
 	Error string `json:"error,omitempty"`
 }
@@ -151,4 +162,10 @@ type Beacon struct {
 	MsgID     string `json:"msg_id"`
 	SentTime  int64  `json:"sent_time"`
 	Synced    bool   `json:"synced"`
+}
+
+// Mana contains the different mana values of the node.
+type Mana struct {
+	Access    float64 `json:"access"`
+	Consensus float64 `json:"consensus"`
 }

--- a/plugins/webapi/mana/all/handler.go
+++ b/plugins/webapi/mana/all/handler.go
@@ -10,29 +10,16 @@ import (
 
 // Handler handles the request.
 func Handler(c echo.Context) error {
-	access := nodeMapToList(manaPlugin.GetManaMap(mana.AccessMana))
-	consensus := nodeMapToList(manaPlugin.GetManaMap(mana.ConsensusMana))
+	access := manaPlugin.GetManaMap(mana.AccessMana).ToNodeStrList()
+	consensus := manaPlugin.GetManaMap(mana.ConsensusMana).ToNodeStrList()
 	return c.JSON(http.StatusOK, Response{
 		Access:    access,
 		Consensus: consensus,
 	})
 }
 
-func nodeMapToList(nodeMap mana.NodeMap) []NodeMap {
-	var list []NodeMap
-	for ID, val := range nodeMap {
-		m := make(NodeMap)
-		m[ID.String()] = val
-		list = append(list, m)
-	}
-	return list
-}
-
 // Response is the request response.
 type Response struct {
-	Access    []NodeMap `json:"access"`
-	Consensus []NodeMap `json:"consensus"`
+	Access    []mana.NodeStr `json:"access"`
+	Consensus []mana.NodeStr `json:"consensus"`
 }
-
-// NodeMap is a the mana of a node.
-type NodeMap map[string]float64

--- a/plugins/webapi/mana/all/handler.go
+++ b/plugins/webapi/mana/all/handler.go
@@ -1,0 +1,38 @@
+package all
+
+import (
+	"net/http"
+
+	"github.com/iotaledger/goshimmer/packages/mana"
+	manaPlugin "github.com/iotaledger/goshimmer/plugins/mana"
+	"github.com/labstack/echo"
+)
+
+// Handler handles the request.
+func Handler(c echo.Context) error {
+	access := nodeMapToList(manaPlugin.GetManaMap(mana.AccessMana))
+	consensus := nodeMapToList(manaPlugin.GetManaMap(mana.ConsensusMana))
+	return c.JSON(http.StatusOK, Response{
+		Access:    access,
+		Consensus: consensus,
+	})
+}
+
+func nodeMapToList(nodeMap mana.NodeMap) []NodeMap {
+	var list []NodeMap
+	for ID, val := range nodeMap {
+		m := make(NodeMap)
+		m[ID.String()] = val
+		list = append(list, m)
+	}
+	return list
+}
+
+// Response is the request response.
+type Response struct {
+	Access    []NodeMap `json:"access"`
+	Consensus []NodeMap `json:"consensus"`
+}
+
+// NodeMap is a the mana of a node.
+type NodeMap map[string]float64

--- a/plugins/webapi/mana/nhighest/accesshandler.go
+++ b/plugins/webapi/mana/nhighest/accesshandler.go
@@ -1,0 +1,11 @@
+package nhighest
+
+import (
+	"github.com/iotaledger/goshimmer/packages/mana"
+	"github.com/labstack/echo"
+)
+
+// AccessHandler handles the request.
+func AccessHandler(c echo.Context) error {
+	return Handler(c, mana.AccessMana)
+}

--- a/plugins/webapi/mana/nhighest/consensushandler.go
+++ b/plugins/webapi/mana/nhighest/consensushandler.go
@@ -1,0 +1,11 @@
+package nhighest
+
+import (
+	"github.com/iotaledger/goshimmer/packages/mana"
+	"github.com/labstack/echo"
+)
+
+// ConsensusHandler handles the request.
+func ConsensusHandler(c echo.Context) error {
+	return Handler(c, mana.ConsensusMana)
+}

--- a/plugins/webapi/mana/nhighest/handler.go
+++ b/plugins/webapi/mana/nhighest/handler.go
@@ -1,0 +1,32 @@
+package nhighest
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/iotaledger/goshimmer/packages/mana"
+	manaPlugin "github.com/iotaledger/goshimmer/plugins/mana"
+	"github.com/labstack/echo"
+)
+
+// Handler handles the request.
+func Handler(c echo.Context, manaType mana.Type) error {
+	number, err := strconv.ParseUint(c.QueryParam("number"), 10, 32)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, Response{Error: err.Error()})
+	}
+	highestNodes := manaPlugin.GetHighestManaNodes(manaType, uint(number))
+	var res []mana.NodeStr
+	for _, n := range highestNodes {
+		res = append(res, n.ToNodeStr())
+	}
+	return c.JSON(http.StatusOK, Response{
+		Nodes: res,
+	})
+}
+
+// Response is the response.
+type Response struct {
+	Error string `json:"error,omitempty"`
+	Nodes []mana.NodeStr
+}

--- a/plugins/webapi/mana/nhighest/handler.go
+++ b/plugins/webapi/mana/nhighest/handler.go
@@ -27,6 +27,6 @@ func Handler(c echo.Context, manaType mana.Type) error {
 
 // Response is the response.
 type Response struct {
-	Error string `json:"error,omitempty"`
-	Nodes []mana.NodeStr
+	Error string         `json:"error,omitempty"`
+	Nodes []mana.NodeStr `json:"nodes,omitempty"`
 }

--- a/plugins/webapi/mana/percentile/handler.go
+++ b/plugins/webapi/mana/percentile/handler.go
@@ -3,12 +3,12 @@ package percentile
 import (
 	"net/http"
 
-	"github.com/iotaledger/goshimmer/plugins/autopeering/local"
-	"github.com/iotaledger/hive.go/identity"
-
 	"github.com/iotaledger/goshimmer/packages/mana"
+	"github.com/iotaledger/goshimmer/plugins/autopeering/local"
 	manaPlugin "github.com/iotaledger/goshimmer/plugins/mana"
+	"github.com/iotaledger/hive.go/identity"
 	"github.com/labstack/echo"
+	"github.com/mr-tron/base58"
 )
 
 // Handler handles the request.

--- a/plugins/webapi/mana/percentile/handler.go
+++ b/plugins/webapi/mana/percentile/handler.go
@@ -34,7 +34,7 @@ func Handler(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, Response{Error: err.Error()})
 	}
 	return c.JSON(http.StatusOK, Response{
-		Node:      request.Node,
+		Node:      base58.Encode(ID.Bytes()),
 		Access:    access,
 		Consensus: consensus,
 	})

--- a/plugins/webapi/mana/percentile/handler.go
+++ b/plugins/webapi/mana/percentile/handler.go
@@ -1,0 +1,47 @@
+package percentile
+
+import (
+	"net/http"
+
+	"github.com/iotaledger/goshimmer/packages/mana"
+	"github.com/iotaledger/goshimmer/plugins/autopeering/local"
+	manaPlugin "github.com/iotaledger/goshimmer/plugins/mana"
+	"github.com/labstack/echo"
+)
+
+// Handler handles the request.
+func Handler(c echo.Context) error {
+	accessNodes := manaPlugin.GetManaMap(mana.AccessMana)
+	access := getPercentile(accessNodes)
+	consensusNodes := manaPlugin.GetManaMap(mana.ConsensusMana)
+	consensus := getPercentile(consensusNodes)
+	return c.JSON(http.StatusOK, Response{
+		Access:    access,
+		Consensus: consensus,
+	})
+}
+
+func getPercentile(nodes mana.NodeMap) float64 {
+	if len(nodes) == 0 {
+		return 0
+	}
+	mine, ok := nodes[local.GetInstance().ID()]
+	if !ok {
+		return 0
+	}
+	nBelow := 0.0
+	for _, val := range nodes {
+		if val < mine {
+			nBelow++
+		}
+	}
+
+	return (nBelow / float64(len(nodes))) * 100
+}
+
+// Response is the response.
+type Response struct {
+	Error     string  `json:"error,omitempty"`
+	Access    float64 `json:"access"`
+	Consensus float64 `json:"consensus"`
+}

--- a/plugins/webapi/mana/plugin.go
+++ b/plugins/webapi/mana/plugin.go
@@ -1,0 +1,49 @@
+package mana
+
+import (
+	"net/http"
+	goSync "sync"
+
+	"github.com/iotaledger/goshimmer/plugins/autopeering/local"
+	"github.com/iotaledger/goshimmer/plugins/mana"
+	"github.com/iotaledger/goshimmer/plugins/webapi"
+	"github.com/iotaledger/hive.go/node"
+	"github.com/labstack/echo"
+)
+
+// PluginName is the name of the web API mana endpoint plugin.
+const PluginName = "WebAPI mana Endpoint"
+
+var (
+	// plugin is the plugin instance of the web API mana endpoint plugin.
+	plugin *node.Plugin
+	once   goSync.Once
+)
+
+// Plugin gets the plugin instance.
+func Plugin() *node.Plugin {
+	once.Do(func() {
+		plugin = node.NewPlugin(PluginName, node.Enabled, configure)
+	})
+	return plugin
+}
+
+func configure(_ *node.Plugin) {
+	webapi.Server().GET("mana", getMana)
+}
+
+func getMana(c echo.Context) error {
+	accessMana, _ := mana.GetAccessMana(local.GetInstance().ID())
+	consensusMana, _ := mana.GetConsensusMana(local.GetInstance().ID())
+
+	return c.JSON(http.StatusOK, Response{
+		Access:    accessMana,
+		Consensus: consensusMana,
+	})
+}
+
+// Response defines the response for get mana.
+type Response struct {
+	Access    float64 `json:"access"`
+	Consensus float64 `json:"consensus"`
+}

--- a/plugins/webapi/mana/plugin.go
+++ b/plugins/webapi/mana/plugin.go
@@ -65,7 +65,7 @@ func getMana(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, Response{
-		Node:      request.Node,
+		Node:      base58.Encode(ID.Bytes()),
 		Access:    accessMana,
 		Consensus: consensusMana,
 	})

--- a/plugins/webapi/mana/plugin.go
+++ b/plugins/webapi/mana/plugin.go
@@ -9,6 +9,7 @@ import (
 	"github.com/iotaledger/goshimmer/plugins/webapi"
 	"github.com/iotaledger/goshimmer/plugins/webapi/mana/all"
 	"github.com/iotaledger/goshimmer/plugins/webapi/mana/nhighest"
+	"github.com/iotaledger/goshimmer/plugins/webapi/mana/percentile"
 	"github.com/iotaledger/hive.go/node"
 	"github.com/labstack/echo"
 )
@@ -35,6 +36,7 @@ func configure(_ *node.Plugin) {
 	webapi.Server().GET("mana/all", all.Handler)
 	webapi.Server().GET("/mana/access/nhighest", nhighest.AccessHandler)
 	webapi.Server().GET("/mana/consensus/nhighest", nhighest.ConsensusHandler)
+	webapi.Server().GET("/mana/percentile", percentile.Handler)
 }
 
 func getMana(c echo.Context) error {

--- a/plugins/webapi/mana/plugin.go
+++ b/plugins/webapi/mana/plugin.go
@@ -5,16 +5,16 @@ import (
 	"sync"
 
 	manaPkg "github.com/iotaledger/goshimmer/packages/mana"
-	"github.com/iotaledger/hive.go/identity"
-
 	"github.com/iotaledger/goshimmer/plugins/autopeering/local"
 	"github.com/iotaledger/goshimmer/plugins/mana"
 	"github.com/iotaledger/goshimmer/plugins/webapi"
 	"github.com/iotaledger/goshimmer/plugins/webapi/mana/all"
 	"github.com/iotaledger/goshimmer/plugins/webapi/mana/nhighest"
 	"github.com/iotaledger/goshimmer/plugins/webapi/mana/percentile"
+	"github.com/iotaledger/hive.go/identity"
 	"github.com/iotaledger/hive.go/node"
 	"github.com/labstack/echo"
+	"github.com/mr-tron/base58"
 )
 
 // PluginName is the name of the web API mana endpoint plugin.

--- a/plugins/webapi/mana/plugin.go
+++ b/plugins/webapi/mana/plugin.go
@@ -7,6 +7,7 @@ import (
 	"github.com/iotaledger/goshimmer/plugins/autopeering/local"
 	"github.com/iotaledger/goshimmer/plugins/mana"
 	"github.com/iotaledger/goshimmer/plugins/webapi"
+	"github.com/iotaledger/goshimmer/plugins/webapi/mana/all"
 	"github.com/iotaledger/hive.go/node"
 	"github.com/labstack/echo"
 )
@@ -30,6 +31,7 @@ func Plugin() *node.Plugin {
 
 func configure(_ *node.Plugin) {
 	webapi.Server().GET("mana", getMana)
+	webapi.Server().GET("mana/all", all.Handler)
 }
 
 func getMana(c echo.Context) error {

--- a/plugins/webapi/mana/plugin.go
+++ b/plugins/webapi/mana/plugin.go
@@ -8,6 +8,7 @@ import (
 	"github.com/iotaledger/goshimmer/plugins/mana"
 	"github.com/iotaledger/goshimmer/plugins/webapi"
 	"github.com/iotaledger/goshimmer/plugins/webapi/mana/all"
+	"github.com/iotaledger/goshimmer/plugins/webapi/mana/nhighest"
 	"github.com/iotaledger/hive.go/node"
 	"github.com/labstack/echo"
 )
@@ -32,6 +33,8 @@ func Plugin() *node.Plugin {
 func configure(_ *node.Plugin) {
 	webapi.Server().GET("mana", getMana)
 	webapi.Server().GET("mana/all", all.Handler)
+	webapi.Server().GET("/mana/access/nhighest", nhighest.AccessHandler)
+	webapi.Server().GET("/mana/consensus/nhighest", nhighest.ConsensusHandler)
 }
 
 func getMana(c echo.Context) error {

--- a/plugins/webapi/value/allowedmanapledge/handler.go
+++ b/plugins/webapi/value/allowedmanapledge/handler.go
@@ -1,0 +1,46 @@
+package allowedmanapledge
+
+import (
+	"net/http"
+
+	"github.com/iotaledger/goshimmer/packages/mana"
+	manaPlugin "github.com/iotaledger/goshimmer/plugins/mana"
+	"github.com/labstack/echo"
+)
+
+// Handler handles the request.
+func Handler(c echo.Context) error {
+	access := manaPlugin.GetAllowedAccessPledgeNodes(mana.AccessMana)
+	var accessNodes []string
+	for ID := range access.Allowed {
+		accessNodes = append(accessNodes, ID.String())
+	}
+	consensus := manaPlugin.GetAllowedAccessPledgeNodes(mana.ConsensusMana)
+	var consensusNodes []string
+	for ID := range consensus.Allowed {
+		consensusNodes = append(consensusNodes, ID.String())
+	}
+	return c.JSON(http.StatusOK, Response{
+		Access: AllowedPledge{
+			IsFilterEnabled: access.IsFilterEnabled,
+			Allowed:         accessNodes,
+		},
+		Consensus: AllowedPledge{
+			IsFilterEnabled: consensus.IsFilterEnabled,
+			Allowed:         consensusNodes,
+		},
+	})
+}
+
+// Response is the http response.
+type Response struct {
+	Access    AllowedPledge `json:"accessMana"`
+	Consensus AllowedPledge `json:"consensusMana"`
+	Error     string        `json:"error,omitempty"`
+}
+
+// AllowedPledge represents the nodes that mana is allowed to be pledged to.
+type AllowedPledge struct {
+	IsFilterEnabled bool     `json:"isFilterEnabled"`
+	Allowed         []string `json:"allowed,omitempty"`
+}

--- a/plugins/webapi/value/allowedmanapledge/handler.go
+++ b/plugins/webapi/value/allowedmanapledge/handler.go
@@ -5,21 +5,23 @@ import (
 
 	"github.com/iotaledger/goshimmer/packages/mana"
 	manaPlugin "github.com/iotaledger/goshimmer/plugins/mana"
+	"github.com/iotaledger/hive.go/identity"
 	"github.com/labstack/echo"
+	"github.com/mr-tron/base58"
 )
 
 // Handler handles the request.
 func Handler(c echo.Context) error {
-	access := manaPlugin.GetAllowedAccessPledgeNodes(mana.AccessMana)
+	access := manaPlugin.GetAllowedPledgeNodes(mana.AccessMana)
 	var accessNodes []string
-	for ID := range access.Allowed {
-		accessNodes = append(accessNodes, ID.String())
-	}
-	consensus := manaPlugin.GetAllowedAccessPledgeNodes(mana.ConsensusMana)
+	access.Allowed.ForEach(func(element interface{}) {
+		accessNodes = append(accessNodes, base58.Encode(element.(identity.ID).Bytes()))
+	})
+	consensus := manaPlugin.GetAllowedPledgeNodes(mana.ConsensusMana)
 	var consensusNodes []string
-	for ID := range consensus.Allowed {
-		consensusNodes = append(consensusNodes, ID.String())
-	}
+	consensus.Allowed.ForEach(func(element interface{}) {
+		consensusNodes = append(consensusNodes, base58.Encode(element.(identity.ID).Bytes()))
+	})
 	return c.JSON(http.StatusOK, Response{
 		Access: AllowedPledge{
 			IsFilterEnabled: access.IsFilterEnabled,

--- a/plugins/webapi/value/plugin.go
+++ b/plugins/webapi/value/plugin.go
@@ -3,6 +3,8 @@ package value
 import (
 	"sync"
 
+	"github.com/iotaledger/goshimmer/plugins/webapi/value/allowedmanapledge"
+
 	"github.com/iotaledger/goshimmer/plugins/webapi"
 	"github.com/iotaledger/goshimmer/plugins/webapi/value/attachments"
 	"github.com/iotaledger/goshimmer/plugins/webapi/value/gettransactionbyid"
@@ -37,4 +39,5 @@ func configure(_ *node.Plugin) {
 	webapi.Server().POST("value/sendTransactionByJson", sendtransactionbyjson.Handler)
 	webapi.Server().POST("value/testSendTxn", testsendtxn.Handler)
 	webapi.Server().GET("value/transactionByID", gettransactionbyid.Handler)
+	webapi.Server().GET("value/allowedManaPledge", allowedmanapledge.Handler)
 }

--- a/plugins/webapi/value/sendtransactionbyjson/handler.go
+++ b/plugins/webapi/value/sendtransactionbyjson/handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/iotaledger/goshimmer/dapps/valuetransfers/packages/address/signaturescheme"
 	"github.com/iotaledger/goshimmer/dapps/valuetransfers/packages/balance"
 	"github.com/iotaledger/goshimmer/dapps/valuetransfers/packages/transaction"
+	"github.com/iotaledger/goshimmer/packages/mana"
 	"github.com/iotaledger/goshimmer/plugins/issuer"
 	"github.com/iotaledger/goshimmer/plugins/webapi/value/utils"
 	"github.com/iotaledger/hive.go/crypto/ed25519"
@@ -121,6 +122,17 @@ func NewTransactionFromJSON(request Request) (*transaction.Transaction, error) {
 
 	// prepare transaction
 	tx := transaction.New(transaction.NewInputs(inputs...), transaction.NewOutputs(outputs))
+	accessMana, err := mana.IDFromPubKey(request.AccessMana)
+	if err != nil {
+		return nil, err
+	}
+	tx.SetAccessManaNodeID(accessMana)
+	consensusMana, err := mana.IDFromPubKey(request.ConsensusMana)
+	if err != nil {
+		return nil, err
+	}
+	tx.SetConsensusManaNodeID(consensusMana)
+	tx.SetTimestamp(time.Unix(0, request.Timestamp))
 
 	// add data payload
 	if request.Data != nil {
@@ -208,10 +220,13 @@ func NewTransactionFromJSON(request Request) (*transaction.Transaction, error) {
 // 	   }[]
 //  }
 type Request struct {
-	Inputs     []string    `json:"inputs"`
-	Outputs    []Output    `json:"outputs"`
-	Data       []byte      `json:"data,omitempty"`
-	Signatures []Signature `json:"signatures"`
+	Inputs        []string    `json:"inputs"`
+	Outputs       []Output    `json:"outputs"`
+	Data          []byte      `json:"data,omitempty"`
+	Signatures    []Signature `json:"signatures"`
+	AccessMana    string      `json:"accessMana"`
+	ConsensusMana string      `json:"consensusMana"`
+	Timestamp     int64       `json:"timestamp"`
 }
 
 // Output defines the struct of an output.

--- a/plugins/webapi/value/sendtransactionbyjson/handler.go
+++ b/plugins/webapi/value/sendtransactionbyjson/handler.go
@@ -12,9 +12,12 @@ import (
 	"github.com/iotaledger/goshimmer/dapps/valuetransfers/packages/balance"
 	"github.com/iotaledger/goshimmer/dapps/valuetransfers/packages/transaction"
 	"github.com/iotaledger/goshimmer/packages/mana"
+	"github.com/iotaledger/goshimmer/plugins/autopeering/local"
 	"github.com/iotaledger/goshimmer/plugins/issuer"
+	manaPlugin "github.com/iotaledger/goshimmer/plugins/mana"
 	"github.com/iotaledger/goshimmer/plugins/webapi/value/utils"
 	"github.com/iotaledger/hive.go/crypto/ed25519"
+	"github.com/iotaledger/hive.go/identity"
 	"github.com/iotaledger/hive.go/marshalutil"
 	"github.com/labstack/echo"
 	"github.com/mr-tron/base58/base58"
@@ -40,6 +43,8 @@ var (
 	ErrWrongSignature = fmt.Errorf("wrong signature")
 	// ErrSignatureVersion defines a unsupported signature version error.
 	ErrSignatureVersion = fmt.Errorf("unsupported signature version")
+	// ErrNotAllowedToPledgeManaToNode defines an unsupported node to pledge mana to.
+	ErrNotAllowedToPledgeManaToNode = fmt.Errorf("not allowed to pledge mana to node")
 )
 
 // Handler sends a transaction.
@@ -122,16 +127,37 @@ func NewTransactionFromJSON(request Request) (*transaction.Transaction, error) {
 
 	// prepare transaction
 	tx := transaction.New(transaction.NewInputs(inputs...), transaction.NewOutputs(outputs))
-	accessMana, err := mana.IDFromPubKey(request.AccessMana)
+	emptyID := identity.ID{}
+
+	pledgeAccessManaNode, err := mana.IDFromStr(request.AccessMana)
 	if err != nil {
 		return nil, err
 	}
-	tx.SetAccessManaNodeID(accessMana)
-	consensusMana, err := mana.IDFromPubKey(request.ConsensusMana)
+	if pledgeAccessManaNode == emptyID {
+		pledgeAccessManaNode = local.GetInstance().ID()
+	}
+	allowedAccessMana := manaPlugin.GetAllowedPledgeNodes(mana.AccessMana)
+	if allowedAccessMana.IsFilterEnabled {
+		if !allowedAccessMana.Allowed.Has(pledgeAccessManaNode) {
+			return nil, fmt.Errorf("not allowed to pledge access mana to %s: %w", request.AccessMana, ErrNotAllowedToPledgeManaToNode)
+		}
+	}
+	tx.SetAccessManaNodeID(pledgeAccessManaNode)
+
+	pledgeConsensusManaNode, err := mana.IDFromStr(request.ConsensusMana)
 	if err != nil {
 		return nil, err
 	}
-	tx.SetConsensusManaNodeID(consensusMana)
+	if pledgeConsensusManaNode == emptyID {
+		pledgeConsensusManaNode = local.GetInstance().ID()
+	}
+	allowedConsensusMana := manaPlugin.GetAllowedPledgeNodes(mana.ConsensusMana)
+	if allowedConsensusMana.IsFilterEnabled {
+		if !allowedConsensusMana.Allowed.Has(pledgeConsensusManaNode) {
+			return nil, fmt.Errorf("not allowed to pledge consensus mana to %s: %w", request.ConsensusMana, ErrNotAllowedToPledgeManaToNode)
+		}
+	}
+	tx.SetConsensusManaNodeID(pledgeConsensusManaNode)
 	tx.SetTimestamp(time.Unix(0, request.Timestamp))
 
 	// add data payload


### PR DESCRIPTION
- Added mana to `/info` api
- Added `value/allowedManaPledge` api that returns the list of pledgeable nodes
- Updaes `value/sendTransactionByJson` to accept newly added mana transaction fields. `timestamp`, `accessMana`, `consensusMana`

Mana endpoints
- `/mana` returns mana of node
- `/mana/all` returns mana of all nodes
- `/mana/access/nhighest?number=n` returns the n highest access mana nodes 
- `/mana/consensus/nhighest?number=n`returns n highest consensus mana nodes
- `/mana/percentile`returns the access and consensus mana percentile of the node in the network