### PR TITLE
Flatten plugins, remove pluginmgr

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,18 +3,15 @@ package main
 import (
 	_ "net/http/pprof"
 
-	"github.com/iotaledger/goshimmer/pluginmgr/core"
-	"github.com/iotaledger/goshimmer/pluginmgr/research"
-	"github.com/iotaledger/goshimmer/pluginmgr/ui"
-	"github.com/iotaledger/goshimmer/pluginmgr/webapi"
+	"github.com/iotaledger/goshimmer/plugins"
 	"github.com/iotaledger/hive.go/node"
 )
 
 func main() {
 	node.Run(
-		core.PLUGINS,
-		research.PLUGINS,
-		ui.PLUGINS,
-		webapi.PLUGINS,
+		plugins.Core,
+		plugins.Research,
+		plugins.Ui,
+		plugins.WebApi,
 	)
 }

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ func main() {
 	node.Run(
 		plugins.Core,
 		plugins.Research,
-		plugins.Ui,
-		plugins.WebApi,
+		plugins.UI,
+		plugins.WebAPI,
 	)
 }

--- a/plugins/core.go
+++ b/plugins/core.go
@@ -1,4 +1,4 @@
-package core
+package plugins
 
 import (
 	"github.com/iotaledger/goshimmer/dapps/faucet"
@@ -22,12 +22,11 @@ import (
 	"github.com/iotaledger/goshimmer/plugins/spammer"
 	"github.com/iotaledger/goshimmer/plugins/syncbeacon"
 	"github.com/iotaledger/goshimmer/plugins/syncbeaconfollower"
-
 	"github.com/iotaledger/hive.go/node"
 )
 
-// PLUGINS is the list of core plugins.
-var PLUGINS = node.Plugins(
+// Core contains the core plugins of a GoShimmer node.
+var Core = node.Plugins(
 	banner.Plugin(),
 	config.Plugin(),
 	logger.Plugin(),

--- a/plugins/research.go
+++ b/plugins/research.go
@@ -1,4 +1,4 @@
-package research
+package plugins
 
 import (
 	"github.com/iotaledger/goshimmer/dapps/networkdelay"
@@ -10,8 +10,8 @@ import (
 	"github.com/iotaledger/hive.go/node"
 )
 
-// PLUGINS is the list of research plugins.
-var PLUGINS = node.Plugins(
+// Research contains research plugins of a GoShimmer node.
+var Research = node.Plugins(
 	remotelog.Plugin(),
 	analysisserver.Plugin(),
 	analysisclient.Plugin(),

--- a/plugins/ui.go
+++ b/plugins/ui.go
@@ -5,7 +5,7 @@ import (
 	"github.com/iotaledger/hive.go/node"
 )
 
-// Ui contains the user interface plugins of a GoShimmer node.
-var Ui = node.Plugins(
+// UI contains the user interface plugins of a GoShimmer node.
+var UI = node.Plugins(
 	dashboard.Plugin(),
 )

--- a/plugins/ui.go
+++ b/plugins/ui.go
@@ -1,11 +1,11 @@
-package ui
+package plugins
 
 import (
 	"github.com/iotaledger/goshimmer/plugins/dashboard"
 	"github.com/iotaledger/hive.go/node"
 )
 
-// PLUGINS is the list of ui plugins.
-var PLUGINS = node.Plugins(
+// Ui contains the user interface plugins of a GoShimmer node.
+var Ui = node.Plugins(
 	dashboard.Plugin(),
 )

--- a/plugins/webapi.go
+++ b/plugins/webapi.go
@@ -1,4 +1,4 @@
-package webapi
+package plugins
 
 import (
 	"github.com/iotaledger/goshimmer/plugins/webapi"
@@ -15,8 +15,8 @@ import (
 	"github.com/iotaledger/hive.go/node"
 )
 
-// PLUGINS is the list of webapi plugins.
-var PLUGINS = node.Plugins(
+// WebApi contains the webapi endpoint plugins of a GoShimmer node.
+var WebApi = node.Plugins(
 	webapi.Plugin(),
 	webauth.Plugin(),
 	data.Plugin(),

--- a/plugins/webapi.go
+++ b/plugins/webapi.go
@@ -15,8 +15,8 @@ import (
 	"github.com/iotaledger/hive.go/node"
 )
 
-// WebApi contains the webapi endpoint plugins of a GoShimmer node.
-var WebApi = node.Plugins(
+// WebAPI contains the webapi endpoint plugins of a GoShimmer node.
+var WebAPI = node.Plugins(
 	webapi.Plugin(),
 	webauth.Plugin(),
 	data.Plugin(),


### PR DESCRIPTION
- Get rid of `pluginmgr`.
- Add plugin definitions directly under `plugins/`.
- Modify `main.go`.

Part of #341