### PR TITLE
Mana Research Dashboard (Grafana)

### DIFF
--- a/packages/mana/basevector.go
+++ b/packages/mana/basevector.go
@@ -173,7 +173,7 @@ func (bmv *BaseManaVector) ForEach(callback func(ID identity.ID, bm *BaseMana) b
 	}
 }
 
-//GetManaMap returns mana perception of the node.
+// GetManaMap returns mana perception of the node.
 func (bmv *BaseManaVector) GetManaMap(weight float64) (NodeMap, error) {
 	bmv.Lock()
 	defer bmv.Unlock()

--- a/packages/mana/basevector.go
+++ b/packages/mana/basevector.go
@@ -153,19 +153,12 @@ func (bmv *BaseManaVector) UpdateAll(t time.Time) error {
 	return nil
 }
 
-// GetWeightedMana returns the combination of Effective Base Mana 1 & 2, weighted by weight.
+// GetMana returns combination of Effective Base Mana 1 & 2, weighted by `weight` parameter.
 // mana = EBM1 * weight + EBM2 * ( 1- weight), where weight is in [0,1].
-func (bmv *BaseManaVector) GetWeightedMana(nodeID identity.ID, weight float64) (float64, error) {
+func (bmv *BaseManaVector) GetMana(nodeID identity.ID, weight float64) (float64, error) {
 	bmv.Lock()
 	defer bmv.Unlock()
 	return bmv.getWeightedMana(nodeID, weight)
-}
-
-// GetMana returns the 50 - 50 split combination of Effective Base Mana 1 & 2.
-func (bmv *BaseManaVector) GetMana(nodeID identity.ID) (float64, error) {
-	bmv.Lock()
-	defer bmv.Unlock()
-	return bmv.getMana(nodeID)
 }
 
 // ForEach iterates over the vector and calls the provided callback.
@@ -180,44 +173,54 @@ func (bmv *BaseManaVector) ForEach(callback func(ID identity.ID, bm *BaseMana) b
 	}
 }
 
-//GetManaMap return mana perception of the node.
-func (bmv *BaseManaVector) GetManaMap() NodeMap {
+//GetManaMap returns mana perception of the node.
+func (bmv *BaseManaVector) GetManaMap(weight float64) (NodeMap, error) {
 	bmv.Lock()
 	defer bmv.Unlock()
 	res := make(map[identity.ID]float64)
 	for ID := range bmv.vector {
-		mana, _ := bmv.getMana(ID)
+		mana, err := bmv.getWeightedMana(ID, weight)
+		if err != nil {
+			return nil, err
+		}
 		res[ID] = mana
 	}
-	return res
+	return res, nil
 }
 
 // GetHighestManaNodes return the n highest mana nodes in descending order.
 // It also updates the mana values for each node.
 // If n is zero, it returns all nodes.
-func (bmv *BaseManaVector) GetHighestManaNodes(n uint) []Node {
+func (bmv *BaseManaVector) GetHighestManaNodes(n uint, weight float64) ([]Node, error) {
 	var res []Node
-	func() {
+	err := func() error {
 		// don't lock the vector after this func returns
 		bmv.Lock()
 		defer bmv.Unlock()
 		for ID := range bmv.vector {
-			mana, _ := bmv.getMana(ID)
+			mana, err := bmv.getWeightedMana(ID, weight)
+			if err != nil {
+				return err
+			}
 			res = append(res, Node{
 				ID:   ID,
 				Mana: mana,
 			})
 		}
+		return nil
 	}()
+	if err != nil {
+		return nil, err
+	}
 
 	sort.Slice(res[:], func(i, j int) bool {
 		return res[i].Mana > res[j].Mana
 	})
 
 	if n == 0 || int(n) >= len(res) {
-		return res[:]
+		return res[:], nil
 	}
-	return res[:n]
+	return res[:n], nil
 }
 
 // SetMana sets the base mana for a node.
@@ -312,9 +315,4 @@ func (bmv *BaseManaVector) getWeightedMana(nodeID identity.ID, weight float64) (
 	_ = bmv.update(nodeID, time.Now())
 	baseMana := bmv.vector[nodeID]
 	return baseMana.EffectiveBaseMana1*weight + baseMana.EffectiveBaseMana2*(1-weight), nil
-}
-
-// getMana returns the 50 - 50 split combination of Effective Base Mana 1 & 2. Not concurrency safe.
-func (bmv *BaseManaVector) getMana(nodeID identity.ID) (float64, error) {
-	return bmv.getWeightedMana(nodeID, 0.5)
 }

--- a/packages/mana/basevector_test.go
+++ b/packages/mana/basevector_test.go
@@ -434,47 +434,23 @@ func TestBaseManaVector_UpdateAll(t *testing.T) {
 	assert.Empty(t, updatedNodeIds)
 }
 
-func TestBaseManaVector_GetWeightedMana(t *testing.T) {
-	// let's use an Access Base Mana Vector
-	bmv := NewBaseManaVector(AccessMana)
-	randID := randNodeID()
-	mana, err := bmv.GetWeightedMana(randID, 0.5)
-	assert.Equal(t, 0.0, mana)
-	assert.Error(t, err)
-
-	bmv.SetMana(randID, &BaseMana{})
-	mana, err = bmv.GetWeightedMana(randID, -0.5)
-	assert.Equal(t, 0.0, mana)
-	assert.Error(t, err)
-	assert.Equal(t, ErrInvalidWeightParameter, err)
-	mana, err = bmv.GetWeightedMana(randID, 1.5)
-	assert.Equal(t, 0.0, mana)
-	assert.Error(t, err)
-	assert.Equal(t, ErrInvalidWeightParameter, err)
-
-	bmv.SetMana(randID, &BaseMana{
-		BaseMana1:          10.0,
-		EffectiveBaseMana1: 10.0,
-		BaseMana2:          1.0,
-		EffectiveBaseMana2: 1.0,
-		LastUpdated:        time.Now(),
-	})
-
-	mana, err = bmv.GetWeightedMana(randID, 0.5)
-	assert.NoError(t, err)
-	assert.InDelta(t, 5.5, mana, delta)
-	mana, err = bmv.GetWeightedMana(randID, 1)
-	assert.NoError(t, err)
-	assert.InDelta(t, 10.0, mana, delta)
-	mana, err = bmv.GetWeightedMana(randID, 0)
-	assert.NoError(t, err)
-	assert.InDelta(t, 1.0, mana, delta)
-}
-
 func TestBaseManaVector_GetMana(t *testing.T) {
 	// let's use an Access Base Mana Vector
 	bmv := NewBaseManaVector(AccessMana)
 	randID := randNodeID()
+	mana, err := bmv.GetMana(randID, 0.5)
+	assert.Equal(t, 0.0, mana)
+	assert.Error(t, err)
+
+	bmv.SetMana(randID, &BaseMana{})
+	mana, err = bmv.GetMana(randID, -0.5)
+	assert.Equal(t, 0.0, mana)
+	assert.Error(t, err)
+	assert.Equal(t, ErrInvalidWeightParameter, err)
+	mana, err = bmv.GetMana(randID, 1.5)
+	assert.Equal(t, 0.0, mana)
+	assert.Error(t, err)
+	assert.Equal(t, ErrInvalidWeightParameter, err)
 
 	bmv.SetMana(randID, &BaseMana{
 		BaseMana1:          10.0,
@@ -484,9 +460,15 @@ func TestBaseManaVector_GetMana(t *testing.T) {
 		LastUpdated:        time.Now(),
 	})
 
-	mana, err := bmv.GetMana(randID)
+	mana, err = bmv.GetMana(randID, 0.5)
 	assert.NoError(t, err)
 	assert.InDelta(t, 5.5, mana, delta)
+	mana, err = bmv.GetMana(randID, 1)
+	assert.NoError(t, err)
+	assert.InDelta(t, 10.0, mana, delta)
+	mana, err = bmv.GetMana(randID, 0)
+	assert.NoError(t, err)
+	assert.InDelta(t, 1.0, mana, delta)
 }
 
 func TestBaseManaVector_ForEach(t *testing.T) {
@@ -523,7 +505,8 @@ func TestBaseManaVector_GetManaMap(t *testing.T) {
 	bmv := NewBaseManaVector(AccessMana)
 
 	// empty vector returns empty map
-	manaMap := bmv.GetManaMap()
+	manaMap, err := bmv.GetManaMap(Mixed)
+	assert.NoError(t, err)
 	assert.Empty(t, manaMap)
 
 	now := time.Now()
@@ -541,7 +524,8 @@ func TestBaseManaVector_GetManaMap(t *testing.T) {
 		nodeIDs[id] = 0
 	}
 
-	manaMap = bmv.GetManaMap()
+	manaMap, err = bmv.GetManaMap(Mixed)
+	assert.NoError(t, err)
 	assert.Equal(t, 100, len(manaMap))
 	for nodeID, mana := range manaMap {
 		assert.InDelta(t, 5.5, mana, delta)
@@ -571,13 +555,15 @@ func TestBaseManaVector_GetHighestManaNodes(t *testing.T) {
 	}
 
 	// requesting the top mana holder
-	result := bmv.GetHighestManaNodes(1)
+	result, err := bmv.GetHighestManaNodes(1, Mixed)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, len(result))
 	assert.Equal(t, nodeIDs[9], result[0].ID)
 	assert.InDelta(t, 9.0, result[0].Mana, delta)
 
 	// requesting top 3 mana holders
-	result = bmv.GetHighestManaNodes(3)
+	result, err = bmv.GetHighestManaNodes(3, Mixed)
+	assert.NoError(t, err)
 	assert.Equal(t, 3, len(result))
 	assert.InDelta(t, 9.0, result[0].Mana, delta)
 	for index, value := range result {
@@ -589,7 +575,8 @@ func TestBaseManaVector_GetHighestManaNodes(t *testing.T) {
 	}
 
 	// requesting more, than there currently are in the vector
-	result = bmv.GetHighestManaNodes(20)
+	result, err = bmv.GetHighestManaNodes(20, Mixed)
+	assert.NoError(t, err)
 	assert.Equal(t, 10, len(result))
 	for index, value := range result {
 		assert.Equal(t, nodeIDs[9-index], value.ID)

--- a/packages/mana/parameters.go
+++ b/packages/mana/parameters.go
@@ -2,6 +2,7 @@ package mana
 
 const (
 	// Description: Taking (x * EBM1 + (1-x) * EBM2) into account when getting the mana value.
+
 	// OnlyMana1 takes only EBM1 into account when getting the mana values.
 	OnlyMana1 float64 = 1.0
 	// OnlyMana2 takes only EBM2 into account when getting the mana values.

--- a/packages/mana/parameters.go
+++ b/packages/mana/parameters.go
@@ -1,5 +1,15 @@
 package mana
 
+const (
+	// Description: Taking (x * EBM1 + (1-x) * EBM2) into account when getting the mana value.
+	// OnlyMana1 takes only EBM1 into account when getting the mana values.
+	OnlyMana1 float64 = 1.0
+	// OnlyMana2 takes only EBM2 into account when getting the mana values.
+	OnlyMana2 float64 = 0.0
+	// Mixed takes both EBM1 and EBM2 into account (50-50) when getting the mana values.
+	Mixed float64 = 0.5
+)
+
 var (
 	// default values are for half life of 6 hours, unit is 1/s
 	emaCoeff1 = 0.00003209

--- a/packages/mana/types.go
+++ b/packages/mana/types.go
@@ -21,3 +21,12 @@ func (t Type) String() string {
 		return "Unknown Mana Type"
 	}
 }
+
+const (
+	// OnlyMana1 takes only EBM1 into account when getting the mana values.
+	OnlyMana1 float64 = 0
+	// OnlyMana2 takes only EBM2 into account when getting the mana values.
+	OnlyMana2 float64 = 1.0
+	// Mixed takes both EBM1 and EBM2 into account (50-50) when getting the mana values.
+	Mixed float64 = 0.5
+)

--- a/packages/mana/types.go
+++ b/packages/mana/types.go
@@ -21,12 +21,3 @@ func (t Type) String() string {
 		return "Unknown Mana Type"
 	}
 }
-
-const (
-	// OnlyMana1 takes only EBM1 into account when getting the mana values.
-	OnlyMana1 float64 = 0
-	// OnlyMana2 takes only EBM2 into account when getting the mana values.
-	OnlyMana2 float64 = 1.0
-	// Mixed takes both EBM1 and EBM2 into account (50-50) when getting the mana values.
-	Mixed float64 = 0.5
-)

--- a/plugins/mana/plugin.go
+++ b/plugins/mana/plugin.go
@@ -196,32 +196,32 @@ func pruneStorages() {
 
 // GetHighestManaNodes returns the n highest type mana nodes in descending order.
 // It also updates the mana values for each node.
-func GetHighestManaNodes(manaType mana.Type, n uint) []mana.Node {
+func GetHighestManaNodes(manaType mana.Type, n uint, mode float64) ([]mana.Node, error) {
 	bmv := baseManaVectors[manaType]
-	return bmv.GetHighestManaNodes(n)
+	return bmv.GetHighestManaNodes(n, mode)
 }
 
 // GetManaMap return type mana perception of the node.
-func GetManaMap(manaType mana.Type) mana.NodeMap {
-	return baseManaVectors[manaType].GetManaMap()
+func GetManaMap(manaType mana.Type, mode float64) (mana.NodeMap, error) {
+	return baseManaVectors[manaType].GetManaMap(mode)
 }
 
 // GetAccessMana returns the access mana of the node specified.
-func GetAccessMana(nodeID identity.ID) (float64, error) {
-	return baseManaVectors[mana.AccessMana].GetMana(nodeID)
+func GetAccessMana(nodeID identity.ID, mode float64) (float64, error) {
+	return baseManaVectors[mana.AccessMana].GetMana(nodeID, mode)
 }
 
 // GetConsensusMana returns the consensus mana of the node specified.
-func GetConsensusMana(nodeID identity.ID) (float64, error) {
-	return baseManaVectors[mana.ConsensusMana].GetMana(nodeID)
+func GetConsensusMana(nodeID identity.ID, mode float64) (float64, error) {
+	return baseManaVectors[mana.ConsensusMana].GetMana(nodeID, mode)
 }
 
 // GetNeighborsMana returns the type mana of the nodes neighbors
-func GetNeighborsMana(manaType mana.Type) (mana.NodeMap, error) {
+func GetNeighborsMana(manaType mana.Type, mode float64) (mana.NodeMap, error) {
 	neighbors := gossip.Manager().AllNeighbors()
 	res := make(mana.NodeMap)
 	for _, n := range neighbors {
-		value, err := baseManaVectors[manaType].GetMana(n.ID())
+		value, err := baseManaVectors[manaType].GetMana(n.ID(), mode)
 		if err != nil {
 			return nil, err
 		}
@@ -231,10 +231,10 @@ func GetNeighborsMana(manaType mana.Type) (mana.NodeMap, error) {
 }
 
 // GetAllManaMaps returns the full mana maps for comparison with the perception of other nodes.
-func GetAllManaMaps() map[mana.Type]mana.NodeMap {
+func GetAllManaMaps(mode float64) map[mana.Type]mana.NodeMap {
 	res := make(map[mana.Type]mana.NodeMap)
 	for manaType := range baseManaVectors {
-		res[manaType] = GetManaMap(manaType)
+		res[manaType], _ = GetManaMap(manaType, mode)
 	}
 	return res
 }
@@ -246,9 +246,9 @@ func OverrideMana(manaType mana.Type, nodeID identity.ID, bm *mana.BaseMana) {
 }
 
 //GetWeightedRandomNodes returns a weighted random selection of n nodes.
-func GetWeightedRandomNodes(n uint, manaType mana.Type) mana.NodeMap {
+func GetWeightedRandomNodes(n uint, manaType mana.Type, mode float64) mana.NodeMap {
 	rand.Seed(time.Now().UTC().UnixNano())
-	manaMap := GetManaMap(manaType)
+	manaMap, _ := GetManaMap(manaType, mode)
 	var choices []mana.RandChoice
 	for nodeID, manaValue := range manaMap {
 		choices = append(choices, mana.RandChoice{
@@ -273,7 +273,7 @@ func GetAllowedPledgeNodes(manaType mana.Type) AllowedPledge {
 
 // GetOnlineNodes gets the list of currently known (and verified) peers in the network, and their respective mana values.
 // Sorted in descending order based on mana.
-func GetOnlineNodes(manaType mana.Type) ([]mana.Node, error) {
+func GetOnlineNodes(manaType mana.Type, mode float64) ([]mana.Node, error) {
 	knownPeers := autopeering.Discovery().GetVerifiedPeers()
 	// consider ourselves as a peer in the network too
 	knownPeers = append(knownPeers, local.GetInstance().Peer)
@@ -282,7 +282,7 @@ func GetOnlineNodes(manaType mana.Type) ([]mana.Node, error) {
 		if !baseManaVectors[manaType].Has(peer.ID()) {
 			onlineNodesMana = append(onlineNodesMana, mana.Node{ID: peer.ID(), Mana: 0})
 		} else {
-			peerMana, err := baseManaVectors[manaType].GetMana(peer.ID())
+			peerMana, err := baseManaVectors[manaType].GetMana(peer.ID(), mode)
 			if err != nil {
 				return nil, err
 			}

--- a/plugins/metrics/mana.go
+++ b/plugins/metrics/mana.go
@@ -65,7 +65,7 @@ func ConsensusManaMap() mana.NodeMap {
 }
 
 func measureMana() {
-	tmp := manaPlugin.GetAllManaMaps()
+	tmp := manaPlugin.GetAllManaMaps(mana.Mixed)
 	accessLock.Lock()
 	defer accessLock.Unlock()
 	accessMap = tmp[mana.AccessMana]

--- a/plugins/metrics/mana.go
+++ b/plugins/metrics/mana.go
@@ -184,7 +184,7 @@ func measureMana() {
 	cPer, _ := consensusMap.GetPercentile(local.GetInstance().ID())
 	consensusPercentile.Store(cPer)
 
-	accessMap, _ := manaPlugin.GetNeighborsMana(mana.AccessMana)
+	accessMap, _ := manaPlugin.GetNeighborsMana(mana.AccessMana, mana.Mixed)
 	accessSum, accessAvg := 0.0, 0.0
 	for _, v := range accessMap {
 		accessSum += v
@@ -194,7 +194,7 @@ func measureMana() {
 	}
 	averageNeighborsAccess.Store(accessAvg)
 
-	consensusMap, _ := manaPlugin.GetNeighborsMana(mana.ConsensusMana)
+	consensusMap, _ := manaPlugin.GetNeighborsMana(mana.ConsensusMana, mana.Mixed)
 	consensusSum, consensusAvg := 0.0, 0.0
 	for _, v := range consensusMap {
 		consensusSum += v

--- a/plugins/metrics/manaresearch.go
+++ b/plugins/metrics/manaresearch.go
@@ -1,0 +1,148 @@
+package metrics
+
+import (
+	"sync"
+
+	"github.com/iotaledger/goshimmer/packages/mana"
+	"github.com/iotaledger/goshimmer/plugins/autopeering/local"
+	manaPlugin "github.com/iotaledger/goshimmer/plugins/mana"
+	"go.uber.org/atomic"
+)
+
+var (
+	accessMapBM1           mana.NodeMap
+	accessPercentileBM1    atomic.Float64
+	accessLockBM1          sync.RWMutex
+	consensusMapBM1        mana.NodeMap
+	consensusPercentileBM1 atomic.Float64
+	consensusLockBm1       sync.RWMutex
+)
+
+// AccessPercentileBM1 returns the top percentile the node belongs to in terms of access mana holders.
+func AccessPercentileBM1() float64 {
+	return accessPercentileBM1.Load()
+}
+
+// OwnAccessManaBM1 returns the access mana of the node.
+func OwnAccessManaBM1() float64 {
+	accessLockBM1.RLock()
+	defer accessLockBM1.RUnlock()
+	return accessMapBM1[local.GetInstance().ID()]
+}
+
+// AccessManaMapBM1 returns the access mana of the whole network.
+func AccessManaMapBM1() mana.NodeMap {
+	accessLockBM1.RLock()
+	defer accessLockBM1.RUnlock()
+	result := mana.NodeMap{}
+	for k, v := range accessMapBM1 {
+		result[k] = v
+	}
+	return result
+}
+
+// ConsensusPercentileBM1 returns the top percentile the node belongs to in terms of consensus mana holders.
+func ConsensusPercentileBM1() float64 {
+	return consensusPercentileBM1.Load()
+}
+
+// OwnConsensusManaBM1 returns the consensus mana of the node.
+func OwnConsensusManaBM1() float64 {
+	consensusLockBm1.RLock()
+	defer consensusLockBm1.RUnlock()
+	return consensusMapBM1[local.GetInstance().ID()]
+}
+
+// ConsensusManaMapBM1 returns the consensus mana of the whole network.
+func ConsensusManaMapBM1() mana.NodeMap {
+	consensusLockBm1.RLock()
+	defer consensusLockBm1.RUnlock()
+	result := mana.NodeMap{}
+	for k, v := range consensusMapBM1 {
+		result[k] = v
+	}
+	return result
+}
+
+func measureManaBM1() {
+	tmp := manaPlugin.GetAllManaMaps(mana.OnlyMana1)
+	accessLockBM1.Lock()
+	defer accessLockBM1.Unlock()
+	accessMapBM1 = tmp[mana.AccessMana]
+	aPer, _ := accessMapBM1.GetPercentile(local.GetInstance().ID())
+	accessPercentileBM1.Store(aPer)
+	consensusLockBm1.Lock()
+	defer consensusLockBm1.Unlock()
+	consensusMapBM1 = tmp[mana.ConsensusMana]
+	cPer, _ := consensusMapBM1.GetPercentile(local.GetInstance().ID())
+	consensusPercentileBM1.Store(cPer)
+}
+
+var (
+	accessMapBM2           mana.NodeMap
+	accessPercentileBM2    atomic.Float64
+	accessLockBM2          sync.RWMutex
+	consensusMapBM2        mana.NodeMap
+	consensusPercentileBM2 atomic.Float64
+	consensusLockBM2       sync.RWMutex
+)
+
+// AccessPercentileBM2 returns the top percentile the node belongs to in terms of access mana holders.
+func AccessPercentileBM2() float64 {
+	return accessPercentileBM2.Load()
+}
+
+// OwnAccessManaBM2 returns the access mana of the node.
+func OwnAccessManaBM2() float64 {
+	accessLockBM2.RLock()
+	defer accessLockBM2.RUnlock()
+	return accessMapBM2[local.GetInstance().ID()]
+}
+
+// AccessManaMapBM2 returns the access mana of the whole network.
+func AccessManaMapBM2() mana.NodeMap {
+	accessLockBM2.RLock()
+	defer accessLockBM2.RUnlock()
+	result := mana.NodeMap{}
+	for k, v := range accessMapBM2 {
+		result[k] = v
+	}
+	return result
+}
+
+// ConsensusPercentileBM2 returns the top percentile the node belongs to in terms of consensus mana holders.
+func ConsensusPercentileBM2() float64 {
+	return consensusPercentileBM2.Load()
+}
+
+// OwnConsensusManaBM2 returns the consensus mana of the node.
+func OwnConsensusManaBM2() float64 {
+	consensusLockBM2.RLock()
+	defer consensusLockBM2.RUnlock()
+	return consensusMapBM2[local.GetInstance().ID()]
+}
+
+// ConsensusManaMapBM2 returns the consensus mana of the whole network.
+func ConsensusManaMapBM2() mana.NodeMap {
+	consensusLockBM2.RLock()
+	defer consensusLockBM2.RUnlock()
+	result := mana.NodeMap{}
+	for k, v := range consensusMapBM2 {
+		result[k] = v
+	}
+	return result
+}
+
+func measureManaBM2() {
+	tmp := manaPlugin.GetAllManaMaps(mana.OnlyMana2)
+	accessLockBM2.Lock()
+	defer accessLockBM2.Unlock()
+	accessMapBM2 = tmp[mana.AccessMana]
+	aPer, _ := accessMapBM2.GetPercentile(local.GetInstance().ID())
+	accessPercentileBM2.Store(aPer)
+	consensusLockBM2.Lock()
+	defer consensusLockBM2.Unlock()
+	consensusMapBM2 = tmp[mana.ConsensusMana]
+	cPer, _ := consensusMapBM2.GetPercentile(local.GetInstance().ID())
+	consensusPercentileBM2.Store(cPer)
+}

--- a/plugins/metrics/parameters.go
+++ b/plugins/metrics/parameters.go
@@ -11,10 +11,13 @@ const (
 	CfgMetricsGlobal = "metrics.global"
 	// CfgManaUpdateInterval defines the interval in seconds at which mana metrics are updated.
 	CfgManaUpdateInterval = "metrics.manaUpdateInterval"
+	// CfgMetricsManaResearch defines mana metrics for research.
+	CfgMetricsManaResearch = "metrics.manaResearch"
 )
 
 func init() {
 	flag.Bool(CfgMetricsLocal, true, "include local metrics")
 	flag.Bool(CfgMetricsGlobal, false, "include global metrics")
 	flag.Uint(CfgManaUpdateInterval, 30, "mana metrics update interval")
+	flag.Bool(CfgMetricsManaResearch, false, "include research mana metrics")
 }

--- a/plugins/metrics/plugin.go
+++ b/plugins/metrics/plugin.go
@@ -99,6 +99,21 @@ func run(_ *node.Plugin) {
 	}, shutdown.PriorityMetrics); err != nil {
 		log.Panicf("Failed to start as daemon: %s", err)
 	}
+
+	if config.Node().GetBool(CfgMetricsManaResearch) {
+		// create a background worker that updates the research mana metrics
+		if err := daemon.BackgroundWorker("Metrics Research Mana Updater", func(shutdownSignal <-chan struct{}) {
+			defer log.Infof("Stopping Metrics Research Mana Updater ... done")
+			timeutil.Ticker(func() {
+				measureManaBM1()
+				measureManaBM2()
+			}, time.Second*time.Duration(config.Node().GetUint(CfgManaUpdateInterval)), shutdownSignal)
+
+			log.Infof("Stopping Metrics Research Mana Updater ...")
+		}, shutdown.PriorityMetrics); err != nil {
+			log.Panicf("Failed to start as daemon: %s", err)
+		}
+	}
 }
 
 func registerLocalMetrics() {

--- a/plugins/prometheus/manaresearch.go
+++ b/plugins/prometheus/manaresearch.go
@@ -1,0 +1,79 @@
+package prometheus
+
+import (
+	"github.com/iotaledger/goshimmer/plugins/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	accessManaMapResearch       *prometheus.GaugeVec
+	accessPercentileResearch    *prometheus.GaugeVec
+	consensusManaMapResearch    *prometheus.GaugeVec
+	consensusPercentileResearch *prometheus.GaugeVec
+)
+
+func registerManaResearchMetrics() {
+	accessManaMapResearch = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "mana_research_access",
+			Help: "Access mana map of the network",
+		},
+		[]string{
+			"nodeID",
+			"method",
+		})
+
+	accessPercentileResearch = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "mana_research_access_percentile",
+			Help: "Top percentile node belongs to in terms of access mana.",
+		},
+		[]string{
+			"method",
+		})
+
+	consensusManaMapResearch = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "mana_research_consensus",
+			Help: "Consensus mana map of the network",
+		},
+		[]string{
+			"nodeID",
+			"method",
+		})
+
+	consensusPercentileResearch = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "mana_research_consensus_percentile",
+			Help: "Top percentile node belongs to in terms of consensus mana.",
+		},
+		[]string{
+			"method",
+		})
+
+	registry.MustRegister(accessManaMapResearch)
+	registry.MustRegister(accessPercentileResearch)
+	registry.MustRegister(consensusManaMapResearch)
+	registry.MustRegister(consensusPercentileResearch)
+
+	addCollect(collectManaResearchMetrics)
+}
+
+func collectManaResearchMetrics() {
+	for nodeID, value := range metrics.AccessManaMapBM1() {
+		accessManaMapResearch.WithLabelValues(nodeID.String(), "bm1").Set(value)
+	}
+	for nodeID, value := range metrics.AccessManaMapBM2() {
+		accessManaMapResearch.WithLabelValues(nodeID.String(), "bm2").Set(value)
+	}
+	accessPercentileResearch.WithLabelValues("bm1").Set(metrics.AccessPercentileBM1())
+	accessPercentileResearch.WithLabelValues("bm2").Set(metrics.AccessPercentileBM2())
+	for nodeID, value := range metrics.ConsensusManaMapBM1() {
+		consensusManaMapResearch.WithLabelValues(nodeID.String(), "bm1").Set(value)
+	}
+	for nodeID, value := range metrics.ConsensusManaMapBM2() {
+		consensusManaMapResearch.WithLabelValues(nodeID.String(), "bm2").Set(value)
+	}
+	consensusPercentileResearch.WithLabelValues("bm1").Set(metrics.ConsensusPercentileBM1())
+	consensusPercentileResearch.WithLabelValues("bm2").Set(metrics.ConsensusPercentileBM2())
+}

--- a/plugins/prometheus/plugin.go
+++ b/plugins/prometheus/plugin.go
@@ -56,6 +56,10 @@ func configure(plugin *node.Plugin) {
 	if config.Node().GetBool(metrics.CfgMetricsGlobal) {
 		registerClientsMetrics()
 	}
+
+	if config.Node().GetBool(metrics.CfgMetricsManaResearch) {
+		registerManaResearchMetrics()
+	}
 }
 
 func addCollect(collect func()) {

--- a/plugins/webapi/info/plugin.go
+++ b/plugins/webapi/info/plugin.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	goSync "sync"
 
+	manaPkg "github.com/iotaledger/goshimmer/packages/mana"
 	"github.com/iotaledger/goshimmer/plugins/autopeering"
 	"github.com/iotaledger/goshimmer/plugins/autopeering/local"
 	"github.com/iotaledger/goshimmer/plugins/banner"
@@ -103,8 +104,8 @@ func getInfo(c echo.Context) error {
 		})
 	}
 
-	accessMana, _ := mana.GetAccessMana(local.GetInstance().ID())
-	consensusMana, _ := mana.GetConsensusMana(local.GetInstance().ID())
+	accessMana, _ := mana.GetAccessMana(local.GetInstance().ID(), manaPkg.Mixed)
+	consensusMana, _ := mana.GetConsensusMana(local.GetInstance().ID(), manaPkg.Mixed)
 	nodeMana := Mana{
 		Access:    accessMana,
 		Consensus: consensusMana,

--- a/plugins/webapi/info/plugin.go
+++ b/plugins/webapi/info/plugin.go
@@ -5,11 +5,11 @@ import (
 	"sort"
 	goSync "sync"
 
-	manaPkg "github.com/iotaledger/goshimmer/packages/mana"
+	"github.com/iotaledger/goshimmer/packages/mana"
 	"github.com/iotaledger/goshimmer/plugins/autopeering"
 	"github.com/iotaledger/goshimmer/plugins/autopeering/local"
 	"github.com/iotaledger/goshimmer/plugins/banner"
-	"github.com/iotaledger/goshimmer/plugins/mana"
+	manaPlugin "github.com/iotaledger/goshimmer/plugins/mana"
 	"github.com/iotaledger/goshimmer/plugins/metrics"
 	"github.com/iotaledger/goshimmer/plugins/syncbeaconfollower"
 	"github.com/iotaledger/goshimmer/plugins/webapi"
@@ -104,8 +104,8 @@ func getInfo(c echo.Context) error {
 		})
 	}
 
-	accessMana, _ := mana.GetAccessMana(local.GetInstance().ID(), manaPkg.Mixed)
-	consensusMana, _ := mana.GetConsensusMana(local.GetInstance().ID(), manaPkg.Mixed)
+	accessMana, _ := manaPlugin.GetAccessMana(local.GetInstance().ID(), mana.Mixed)
+	consensusMana, _ := manaPlugin.GetConsensusMana(local.GetInstance().ID(), mana.Mixed)
 	nodeMana := Mana{
 		Access:    accessMana,
 		Consensus: consensusMana,

--- a/plugins/webapi/mana/allmana.go
+++ b/plugins/webapi/mana/allmana.go
@@ -3,20 +3,20 @@ package mana
 import (
 	"net/http"
 
-	manaPkg "github.com/iotaledger/goshimmer/packages/mana"
+	"github.com/iotaledger/goshimmer/packages/mana"
 	manaPlugin "github.com/iotaledger/goshimmer/plugins/mana"
 	"github.com/labstack/echo"
 )
 
 // getAllManaHandler handles the request.
 func getAllManaHandler(c echo.Context) error {
-	access, err := manaPlugin.GetManaMap(manaPkg.AccessMana, manaPkg.Mixed)
+	access, err := manaPlugin.GetManaMap(mana.AccessMana, mana.Mixed)
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, getAllManaResponse{
 			Error: err.Error(),
 		})
 	}
-	consensus, err := manaPlugin.GetManaMap(manaPkg.ConsensusMana, manaPkg.Mixed)
+	consensus, err := manaPlugin.GetManaMap(mana.ConsensusMana, mana.Mixed)
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, getAllManaResponse{
 			Error: err.Error(),
@@ -30,7 +30,7 @@ func getAllManaHandler(c echo.Context) error {
 
 // getAllManaResponse is the request to a getAllManaHandler request.
 type getAllManaResponse struct {
-	Access    []manaPkg.NodeStr `json:"access"`
-	Consensus []manaPkg.NodeStr `json:"consensus"`
-	Error     string            `json:"error,omitempty"`
+	Access    []mana.NodeStr `json:"access"`
+	Consensus []mana.NodeStr `json:"consensus"`
+	Error     string         `json:"error,omitempty"`
 }

--- a/plugins/webapi/mana/allmana.go
+++ b/plugins/webapi/mana/allmana.go
@@ -10,11 +10,21 @@ import (
 
 // getAllManaHandler handles the request.
 func getAllManaHandler(c echo.Context) error {
-	access := manaPlugin.GetManaMap(manaPkg.AccessMana).ToNodeStrList()
-	consensus := manaPlugin.GetManaMap(manaPkg.ConsensusMana).ToNodeStrList()
+	access, err := manaPlugin.GetManaMap(manaPkg.AccessMana, manaPkg.Mixed)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, getAllManaResponse{
+			Error: err.Error(),
+		})
+	}
+	consensus, err := manaPlugin.GetManaMap(manaPkg.ConsensusMana, manaPkg.Mixed)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, getAllManaResponse{
+			Error: err.Error(),
+		})
+	}
 	return c.JSON(http.StatusOK, getAllManaResponse{
-		Access:    access,
-		Consensus: consensus,
+		Access:    access.ToNodeStrList(),
+		Consensus: consensus.ToNodeStrList(),
 	})
 }
 
@@ -22,4 +32,5 @@ func getAllManaHandler(c echo.Context) error {
 type getAllManaResponse struct {
 	Access    []manaPkg.NodeStr `json:"access"`
 	Consensus []manaPkg.NodeStr `json:"consensus"`
+	Error     string            `json:"error,omitempty"`
 }

--- a/plugins/webapi/mana/mana.go
+++ b/plugins/webapi/mana/mana.go
@@ -3,7 +3,7 @@ package mana
 import (
 	"net/http"
 
-	manaPkg "github.com/iotaledger/goshimmer/packages/mana"
+	"github.com/iotaledger/goshimmer/packages/mana"
 	"github.com/iotaledger/goshimmer/plugins/autopeering/local"
 	manaPlugin "github.com/iotaledger/goshimmer/plugins/mana"
 	"github.com/iotaledger/hive.go/identity"
@@ -17,7 +17,7 @@ func getManaHandler(c echo.Context) error {
 	if err := c.Bind(&request); err != nil {
 		return c.JSON(http.StatusBadRequest, GetManaResponse{Error: err.Error()})
 	}
-	ID, err := manaPkg.IDFromStr(request.Node)
+	ID, err := mana.IDFromStr(request.Node)
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, GetManaResponse{Error: err.Error()})
 	}
@@ -25,11 +25,11 @@ func getManaHandler(c echo.Context) error {
 	if ID == emptyID {
 		ID = local.GetInstance().ID()
 	}
-	accessMana, err := manaPlugin.GetAccessMana(ID, manaPkg.Mixed)
+	accessMana, err := manaPlugin.GetAccessMana(ID, mana.Mixed)
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, GetManaResponse{Error: err.Error()})
 	}
-	consensusMana, err := manaPlugin.GetConsensusMana(ID, manaPkg.Mixed)
+	consensusMana, err := manaPlugin.GetConsensusMana(ID, mana.Mixed)
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, GetManaResponse{Error: err.Error()})
 	}

--- a/plugins/webapi/mana/mana.go
+++ b/plugins/webapi/mana/mana.go
@@ -25,11 +25,11 @@ func getManaHandler(c echo.Context) error {
 	if ID == emptyID {
 		ID = local.GetInstance().ID()
 	}
-	accessMana, err := manaPlugin.GetAccessMana(ID)
+	accessMana, err := manaPlugin.GetAccessMana(ID, manaPkg.Mixed)
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, GetManaResponse{Error: err.Error()})
 	}
-	consensusMana, err := manaPlugin.GetConsensusMana(ID)
+	consensusMana, err := manaPlugin.GetConsensusMana(ID, manaPkg.Mixed)
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, GetManaResponse{Error: err.Error()})
 	}

--- a/plugins/webapi/mana/nhighest.go
+++ b/plugins/webapi/mana/nhighest.go
@@ -25,7 +25,10 @@ func nHighestHandler(c echo.Context, manaType manaPkg.Type) error {
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, GetNHighestResponse{Error: err.Error()})
 	}
-	highestNodes := manaPlugin.GetHighestManaNodes(manaType, uint(number))
+	highestNodes, err := manaPlugin.GetHighestManaNodes(manaType, uint(number), manaPkg.Mixed)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, GetNHighestResponse{Error: err.Error()})
+	}
 	var res []manaPkg.NodeStr
 	for _, n := range highestNodes {
 		res = append(res, n.ToNodeStr())

--- a/plugins/webapi/mana/nhighest.go
+++ b/plugins/webapi/mana/nhighest.go
@@ -4,32 +4,32 @@ import (
 	"net/http"
 	"strconv"
 
-	manaPkg "github.com/iotaledger/goshimmer/packages/mana"
+	"github.com/iotaledger/goshimmer/packages/mana"
 	manaPlugin "github.com/iotaledger/goshimmer/plugins/mana"
 	"github.com/labstack/echo"
 )
 
 // getNHighestAccessHandler handles a /mana/access/nhighest request.
 func getNHighestAccessHandler(c echo.Context) error {
-	return nHighestHandler(c, manaPkg.AccessMana)
+	return nHighestHandler(c, mana.AccessMana)
 }
 
 // getNHighestConsensusHandler handles a /mana/consensus/nhighest request.
 func getNHighestConsensusHandler(c echo.Context) error {
-	return nHighestHandler(c, manaPkg.ConsensusMana)
+	return nHighestHandler(c, mana.ConsensusMana)
 }
 
 // nHighestHandler handles the request.
-func nHighestHandler(c echo.Context, manaType manaPkg.Type) error {
+func nHighestHandler(c echo.Context, manaType mana.Type) error {
 	number, err := strconv.ParseUint(c.QueryParam("number"), 10, 32)
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, GetNHighestResponse{Error: err.Error()})
 	}
-	highestNodes, err := manaPlugin.GetHighestManaNodes(manaType, uint(number), manaPkg.Mixed)
+	highestNodes, err := manaPlugin.GetHighestManaNodes(manaType, uint(number), mana.Mixed)
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, GetNHighestResponse{Error: err.Error()})
 	}
-	var res []manaPkg.NodeStr
+	var res []mana.NodeStr
 	for _, n := range highestNodes {
 		res = append(res, n.ToNodeStr())
 	}
@@ -40,6 +40,6 @@ func nHighestHandler(c echo.Context, manaType manaPkg.Type) error {
 
 // GetNHighestResponse holds info about nodes and their mana values.
 type GetNHighestResponse struct {
-	Error string            `json:"error,omitempty"`
-	Nodes []manaPkg.NodeStr `json:"nodes,omitempty"`
+	Error string         `json:"error,omitempty"`
+	Nodes []mana.NodeStr `json:"nodes,omitempty"`
 }

--- a/plugins/webapi/mana/online.go
+++ b/plugins/webapi/mana/online.go
@@ -3,22 +3,22 @@ package mana
 import (
 	"net/http"
 
-	manaPkg "github.com/iotaledger/goshimmer/packages/mana"
+	"github.com/iotaledger/goshimmer/packages/mana"
 	manaPlugin "github.com/iotaledger/goshimmer/plugins/mana"
 	"github.com/labstack/echo"
 )
 
 func getOnlineAccessHandler(c echo.Context) error {
-	return getOnlineHandler(c, manaPkg.AccessMana)
+	return getOnlineHandler(c, mana.AccessMana)
 }
 
 func getOnlineConsensusHandler(c echo.Context) error {
-	return getOnlineHandler(c, manaPkg.ConsensusMana)
+	return getOnlineHandler(c, mana.ConsensusMana)
 }
 
 // getOnlineHandler handles the request.
-func getOnlineHandler(c echo.Context, manaType manaPkg.Type) error {
-	onlinePeersMana, err := manaPlugin.GetOnlineNodes(manaType, manaPkg.Mixed)
+func getOnlineHandler(c echo.Context, manaType mana.Type) error {
+	onlinePeersMana, err := manaPlugin.GetOnlineNodes(manaType, mana.Mixed)
 	if err != nil {
 		return c.JSON(http.StatusNotFound, GetOnlineResponse{Error: err.Error()})
 	}

--- a/plugins/webapi/mana/online.go
+++ b/plugins/webapi/mana/online.go
@@ -18,7 +18,7 @@ func getOnlineConsensusHandler(c echo.Context) error {
 
 // getOnlineHandler handles the request.
 func getOnlineHandler(c echo.Context, manaType manaPkg.Type) error {
-	onlinePeersMana, err := manaPlugin.GetOnlineNodes(manaType)
+	onlinePeersMana, err := manaPlugin.GetOnlineNodes(manaType, manaPkg.Mixed)
 	if err != nil {
 		return c.JSON(http.StatusNotFound, GetOnlineResponse{Error: err.Error()})
 	}

--- a/plugins/webapi/mana/percentile.go
+++ b/plugins/webapi/mana/percentile.go
@@ -3,7 +3,7 @@ package mana
 import (
 	"net/http"
 
-	manaPkg "github.com/iotaledger/goshimmer/packages/mana"
+	"github.com/iotaledger/goshimmer/packages/mana"
 	"github.com/iotaledger/goshimmer/plugins/autopeering/local"
 	manaPlugin "github.com/iotaledger/goshimmer/plugins/mana"
 	"github.com/iotaledger/hive.go/identity"
@@ -17,7 +17,7 @@ func getPercentileHandler(c echo.Context) error {
 	if err := c.Bind(&request); err != nil {
 		return c.JSON(http.StatusBadRequest, GetPercentileResponse{Error: err.Error()})
 	}
-	ID, err := manaPkg.IDFromStr(request.Node)
+	ID, err := mana.IDFromStr(request.Node)
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, GetPercentileResponse{Error: err.Error()})
 	}
@@ -25,7 +25,7 @@ func getPercentileHandler(c echo.Context) error {
 	if ID == emptyID {
 		ID = local.GetInstance().ID()
 	}
-	access, err := manaPlugin.GetManaMap(manaPkg.AccessMana, manaPkg.Mixed)
+	access, err := manaPlugin.GetManaMap(mana.AccessMana, mana.Mixed)
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, GetPercentileResponse{Error: err.Error()})
 	}
@@ -33,7 +33,7 @@ func getPercentileHandler(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, GetPercentileResponse{Error: err.Error()})
 	}
-	consensus, err := manaPlugin.GetManaMap(manaPkg.ConsensusMana, manaPkg.Mixed)
+	consensus, err := manaPlugin.GetManaMap(mana.ConsensusMana, mana.Mixed)
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, GetPercentileResponse{Error: err.Error()})
 	}

--- a/plugins/webapi/mana/percentile.go
+++ b/plugins/webapi/mana/percentile.go
@@ -25,18 +25,26 @@ func getPercentileHandler(c echo.Context) error {
 	if ID == emptyID {
 		ID = local.GetInstance().ID()
 	}
-	access, err := manaPlugin.GetManaMap(manaPkg.AccessMana).GetPercentile(ID)
+	access, err := manaPlugin.GetManaMap(manaPkg.AccessMana, manaPkg.Mixed)
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, GetPercentileResponse{Error: err.Error()})
 	}
-	consensus, err := manaPlugin.GetManaMap(manaPkg.ConsensusMana).GetPercentile(ID)
+	accessPercentile, err := access.GetPercentile(ID)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, GetPercentileResponse{Error: err.Error()})
+	}
+	consensus, err := manaPlugin.GetManaMap(manaPkg.ConsensusMana, manaPkg.Mixed)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, GetPercentileResponse{Error: err.Error()})
+	}
+	consensusPercentile, err := consensus.GetPercentile(ID)
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, GetPercentileResponse{Error: err.Error()})
 	}
 	return c.JSON(http.StatusOK, GetPercentileResponse{
 		Node:      base58.Encode(ID.Bytes()),
-		Access:    access,
-		Consensus: consensus,
+		Access:    accessPercentile,
+		Consensus: consensusPercentile,
 	})
 }
 

--- a/tools/docker-network/docker-compose.yml
+++ b/tools/docker-network/docker-compose.yml
@@ -47,6 +47,7 @@ services:
       --valueLayer.snapshot.file=/tmp/assets/7R1itJx5hVuo9w9hjg5cwKFmek4HMSoBDgJZN8hKGxih.bin
       --syncbeacon.broadcastInterval=5
       --syncbeacon.startSynced=true
+      --metrics.manaResearch=true
     volumes:
       - ./config.docker.json:/tmp/config.json:ro
       - goshimmer-cache:/go

--- a/tools/docker-network/grafana/dashboards/global_dashboard.json
+++ b/tools/docker-network/grafana/dashboards/global_dashboard.json
@@ -898,6 +898,7 @@
   },
   "timepicker": {
     "refresh_intervals": [
+      "5s",
       "10s",
       "30s",
       "1m",

--- a/tools/docker-network/grafana/dashboards/local_dashboard.json
+++ b/tools/docker-network/grafana/dashboards/local_dashboard.json
@@ -4299,6 +4299,7 @@
   },
   "timepicker": {
     "refresh_intervals": [
+      "5s",
       "10s",
       "30s",
       "1m",

--- a/tools/docker-network/grafana/dashboards/mana_research_dashboard.json
+++ b/tools/docker-network/grafana/dashboards/mana_research_dashboard.json
@@ -16,196 +16,451 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 6,
-  "iteration": 1602603298633,
+  "id": 7,
+  "iteration": 1602772272572,
   "links": [],
   "panels": [
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
       "datasource": "Prometheus",
-      "description": "Amount of access mana this node has by taking only EBM1 into account.",
+      "description": "Amount of access mana this node has.",
       "fieldConfig": {
         "defaults": {
           "custom": {},
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
           "unit": "short"
         },
         "overrides": []
       },
+      "fill": 3,
+      "fillGradient": 4,
       "gridPos": {
-        "h": 3,
-        "w": 8,
+        "h": 14,
+        "w": 12,
         "x": 0,
         "y": 0
       },
-      "id": 85,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "value_and_name"
+      "hiddenSeries": false,
+      "id": 83,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": true
       },
+      "lines": true,
+      "linewidth": 2,
+      "nullPointMode": "null",
+      "percentage": false,
       "pluginVersion": "7.1.1",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
       "targets": [
         {
           "expr": "mana_research_access{nodeID=\"$NodeID\",method=\"bm1\"}",
           "interval": "",
-          "legendFormat": "Access",
+          "legendFormat": "Access Mana 1",
           "refId": "A"
         },
-        {
-          "expr": "mana_research_consensus{nodeID=\"$NodeID\",method=\"bm1\"}",
-          "interval": "",
-          "legendFormat": "Consensus",
-          "refId": "B"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Current Mana 1",
-      "type": "stat"
-    },
-    {
-      "datasource": "Prometheus",
-      "description": "Amount of access mana this node has by taking into account 50% EBM1 and 50% EBM2.",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 8,
-        "x": 8,
-        "y": 0
-      },
-      "id": 104,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "value_and_name"
-      },
-      "pluginVersion": "7.1.1",
-      "targets": [
-        {
-          "expr": "mana_access{nodeID=\"$NodeID\"}",
-          "interval": "",
-          "legendFormat": "Access",
-          "refId": "A"
-        },
-        {
-          "expr": "mana_consensus{nodeID=\"$NodeID\"}",
-          "interval": "",
-          "legendFormat": "Consensus",
-          "refId": "B"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Current Mana Mixed",
-      "type": "stat"
-    },
-    {
-      "datasource": "Prometheus",
-      "description": "Amount of access mana this node has by taking only EBM2 into account.",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 8,
-        "x": 16,
-        "y": 0
-      },
-      "id": 125,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "value_and_name"
-      },
-      "pluginVersion": "7.1.1",
-      "targets": [
         {
           "expr": "mana_research_access{nodeID=\"$NodeID\",method=\"bm2\"}",
           "interval": "",
-          "legendFormat": "Access",
+          "legendFormat": "Access Mana 2",
+          "refId": "B"
+        },
+        {
+          "expr": "mana_access{nodeID=\"$NodeID\"}",
+          "interval": "",
+          "legendFormat": "Access Mana Fifty-fifty",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Access Mana $NodeID",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "description": "Amount of consensus mana this node has.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "fill": 3,
+      "fillGradient": 4,
+      "gridPos": {
+        "h": 14,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 84,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "nullPointMode": "null",
+      "percentage": false,
+      "pluginVersion": "7.1.1",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "mana_research_consensus{nodeID=\"$NodeID\",method=\"bm1\"}",
+          "interval": "",
+          "legendFormat": "Consensus Mana 1",
           "refId": "A"
         },
         {
           "expr": "mana_research_consensus{nodeID=\"$NodeID\",method=\"bm2\"}",
           "interval": "",
-          "legendFormat": "Consensus",
+          "legendFormat": "Consensus Mana 2",
           "refId": "B"
+        },
+        {
+          "expr": "mana_consensus{nodeID=\"$NodeID\"}",
+          "interval": "",
+          "legendFormat": "Consensus Mana Fifty-fifty",
+          "refId": "C"
         }
       ],
+      "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
-      "title": "Current Mana 2",
-      "type": "stat"
+      "title": "Consensus Mana $NodeID",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
       "datasource": "Prometheus",
-      "description": "Average mana of a node in the network taking only EBM1 into account.",
+      "description": "Total Access  Mana In the network.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 13,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
+      "hiddenSeries": false,
+      "id": 89,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "show": true,
+        "sort": "current",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "percentage": false,
+      "pluginVersion": "7.1.1",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(mana_access)",
+          "interval": "",
+          "legendFormat": "Total Access Mana Fifty-fifty In Network",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(mana_research_access{method=\"bm1\"})",
+          "interval": "",
+          "legendFormat": "Total Access Mana 1 In Network",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(mana_research_access{method=\"bm2\"})",
+          "interval": "",
+          "legendFormat": "Total Access Mana 2 In Network",
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Total Access Mana In Network",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "description": "Total Consensus  Mana In the network.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 13,
+        "w": 12,
+        "x": 12,
+        "y": 14
+      },
+      "hiddenSeries": false,
+      "id": 129,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "show": true,
+        "sort": "current",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "percentage": false,
+      "pluginVersion": "7.1.1",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(mana_consensus)",
+          "interval": "",
+          "legendFormat": "Total Consensus Mana Fifty-fifty In Network",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(mana_research_consensus{method=\"bm1\"})",
+          "interval": "",
+          "legendFormat": "Total Consensus Mana 1 In Network",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(mana_research_consensus{method=\"bm2\"})",
+          "interval": "",
+          "legendFormat": "Total Consensus Mana 2 In Network",
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Total Consensus Mana In Network",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "description": "Average access mana of a node in the network.",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -223,367 +478,225 @@
         },
         "overrides": []
       },
+      "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
-        "h": 3,
-        "w": 8,
+        "h": 13,
+        "w": 12,
         "x": 0,
-        "y": 3
+        "y": 27
       },
+      "hiddenSeries": false,
       "id": 95,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": true
       },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "percentage": false,
       "pluginVersion": "7.1.1",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
       "targets": [
         {
           "expr": "avg(mana_research_access{method=\"bm1\"})",
           "interval": "",
-          "legendFormat": "Access",
+          "legendFormat": "Access Mana 1",
           "refId": "A"
         },
-        {
-          "expr": "avg(mana_research_consensus{method=\"bm1\"})",
-          "interval": "",
-          "legendFormat": "Consensus",
-          "refId": "B"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Average Mana 1",
-      "type": "stat"
-    },
-    {
-      "datasource": "Prometheus",
-      "description": "Average mana of a node in the network taking into account 50% EBM1 and 50% EBM2.",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 8,
-        "x": 8,
-        "y": 3
-      },
-      "id": 105,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "7.1.1",
-      "targets": [
-        {
-          "expr": "avg(mana_access)",
-          "interval": "",
-          "legendFormat": "Access",
-          "refId": "A"
-        },
-        {
-          "expr": "avg(mana_consensus)",
-          "interval": "",
-          "legendFormat": "Consensus",
-          "refId": "B"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Average Mana Mixed",
-      "type": "stat"
-    },
-    {
-      "datasource": "Prometheus",
-      "description": "Average mana of a node in the network taking only EBM2 into account.",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 8,
-        "x": 16,
-        "y": 3
-      },
-      "id": 126,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "7.1.1",
-      "targets": [
         {
           "expr": "avg(mana_research_access{method=\"bm2\"})",
           "interval": "",
-          "legendFormat": "Access",
-          "refId": "A"
+          "legendFormat": "Access Mana 2",
+          "refId": "E"
+        },
+        {
+          "expr": "avg(mana_access)",
+          "interval": "",
+          "legendFormat": "Access Mana Mixed",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Average Access Mana",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "description": "Average consensus mana of a node in the network.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 13,
+        "w": 12,
+        "x": 12,
+        "y": 27
+      },
+      "hiddenSeries": false,
+      "id": 131,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "percentage": false,
+      "pluginVersion": "7.1.1",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(mana_research_consensus{method=\"bm1\"})",
+          "interval": "",
+          "legendFormat": "Consensus Mana 1",
+          "refId": "B"
         },
         {
           "expr": "avg(mana_research_consensus{method=\"bm2\"})",
           "interval": "",
-          "legendFormat": "Consensus",
-          "refId": "B"
+          "legendFormat": "Consensus Mana 2",
+          "refId": "F"
+        },
+        {
+          "expr": "avg(mana_consensus)",
+          "interval": "",
+          "legendFormat": "Consensus Mana Mixed",
+          "refId": "D"
         }
       ],
+      "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
-      "title": "Average Mana 2",
-      "type": "stat"
-    },
-    {
-      "datasource": "Prometheus",
-      "description": "Percentile of a node in the network by taking only EBM1 values into account.",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "percent"
-        },
-        "overrides": []
+      "title": "Average Consensus Mana",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
       },
-      "gridPos": {
-        "h": 3,
-        "w": 8,
-        "x": 0,
-        "y": 6
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
       },
-      "id": 101,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "7.1.1",
-      "targets": [
+      "yaxes": [
         {
-          "expr": "mana_research_access_percentile{method=\"bm1\"}",
-          "interval": "",
-          "legendFormat": "Access",
-          "refId": "A"
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
         },
         {
-          "expr": "mana_research_consensus_percentile{method=\"bm1\"}",
-          "interval": "",
-          "legendFormat": "Consensus",
-          "refId": "B"
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Mana 1 Percentile",
-      "type": "stat"
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
       "datasource": "Prometheus",
-      "description": "Percentile of a node in the network by taking into account 50% EBM1 and 50% EBM2.",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "percent"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 8,
-        "x": 8,
-        "y": 6
-      },
-      "id": 106,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "7.1.1",
-      "targets": [
-        {
-          "expr": "mana_access_percentile",
-          "interval": "",
-          "legendFormat": "Access",
-          "refId": "A"
-        },
-        {
-          "expr": "mana_consensus_percentile",
-          "interval": "",
-          "legendFormat": "Consensus",
-          "refId": "B"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Mana Mixed Percentile",
-      "type": "stat"
-    },
-    {
-      "datasource": "Prometheus",
-      "description": "Percentile of a node in the network by taking only EBM2 values into account.",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "percent"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 8,
-        "x": 16,
-        "y": 6
-      },
-      "id": 127,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "7.1.1",
-      "targets": [
-        {
-          "expr": "mana_research_access_percentile{method=\"bm2\"}",
-          "interval": "",
-          "legendFormat": "Access",
-          "refId": "A"
-        },
-        {
-          "expr": "mana_research_consensus_percentile{method=\"bm2\"}",
-          "interval": "",
-          "legendFormat": "Consensus",
-          "refId": "B"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Mana 2 Percentile",
-      "type": "stat"
-    },
-    {
-      "datasource": "Prometheus",
-      "description": "Standard deviation of mana of nodes in the network by taking into account only EBM1.",
+      "description": "Standard deviation of access mana of nodes in the network.",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -601,168 +714,215 @@
         },
         "overrides": []
       },
+      "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
-        "h": 3,
-        "w": 8,
+        "h": 13,
+        "w": 12,
         "x": 0,
-        "y": 9
+        "y": 40
       },
+      "hiddenSeries": false,
       "id": 96,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
       },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "percentage": false,
       "pluginVersion": "7.1.1",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
       "targets": [
         {
           "expr": "stddev(mana_research_access{method=\"bm1\"})",
           "interval": "",
-          "legendFormat": "Access",
+          "legendFormat": "Access Mana 1",
           "refId": "A"
         },
-        {
-          "expr": "stddev(mana_research_consensus{method=\"bm1\"})",
-          "interval": "",
-          "legendFormat": "Consensus",
-          "refId": "B"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Standard Deviation of Mana 1",
-      "type": "stat"
-    },
-    {
-      "datasource": "Prometheus",
-      "description": "Standard deviation of mana of nodes in the network by taking into account 50% EBM1 and 50% EBM2.",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 8,
-        "x": 8,
-        "y": 9
-      },
-      "id": 107,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "7.1.1",
-      "targets": [
-        {
-          "expr": "stddev(mana_access)",
-          "interval": "",
-          "legendFormat": "Access",
-          "refId": "A"
-        },
-        {
-          "expr": "stddev(mana_consensus)",
-          "interval": "",
-          "legendFormat": "Consensus",
-          "refId": "B"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Standard Deviation of Mana Mixed",
-      "type": "stat"
-    },
-    {
-      "datasource": "Prometheus",
-      "description": "Standard deviation of mana of nodes in the network by taking into account only EBM2.",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 8,
-        "x": 16,
-        "y": 9
-      },
-      "id": 128,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "7.1.1",
-      "targets": [
         {
           "expr": "stddev(mana_research_access{method=\"bm2\"})",
           "interval": "",
-          "legendFormat": "Access",
+          "legendFormat": "Access Mana 2",
+          "refId": "B"
+        },
+        {
+          "expr": "stddev(mana_access)",
+          "interval": "",
+          "legendFormat": "Access Mana Mixed",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Standard Deviation of Access Mana",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "description": "Standard deviation of consensus mana of nodes in the network.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 13,
+        "w": 12,
+        "x": 12,
+        "y": 40
+      },
+      "hiddenSeries": false,
+      "id": 132,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "percentage": false,
+      "pluginVersion": "7.1.1",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "stddev(mana_research_consensus{method=\"bm1\"})",
+          "interval": "",
+          "legendFormat": "Consensus Mana 1",
           "refId": "A"
         },
         {
           "expr": "stddev(mana_research_consensus{method=\"bm2\"})",
           "interval": "",
-          "legendFormat": "Consensus",
+          "legendFormat": "Consensus Mana 2",
           "refId": "B"
+        },
+        {
+          "expr": "stddev(mana_consensus)",
+          "interval": "",
+          "legendFormat": "Consensus Mana Mixed",
+          "refId": "C"
         }
       ],
+      "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
-      "title": "Standard Deviation of Mana 2",
-      "type": "stat"
+      "title": "Standard Deviation of Consensus Mana",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -784,7 +944,7 @@
         "h": 12,
         "w": 8,
         "x": 0,
-        "y": 12
+        "y": 53
       },
       "hiddenSeries": false,
       "id": 98,
@@ -884,7 +1044,7 @@
         "h": 12,
         "w": 8,
         "x": 8,
-        "y": 12
+        "y": 53
       },
       "hiddenSeries": false,
       "id": 109,
@@ -984,7 +1144,7 @@
         "h": 12,
         "w": 8,
         "x": 16,
-        "y": 12
+        "y": 53
       },
       "hiddenSeries": false,
       "id": 123,
@@ -1084,7 +1244,7 @@
         "h": 12,
         "w": 8,
         "x": 0,
-        "y": 24
+        "y": 65
       },
       "hiddenSeries": false,
       "id": 99,
@@ -1184,7 +1344,7 @@
         "h": 12,
         "w": 8,
         "x": 8,
-        "y": 24
+        "y": 65
       },
       "hiddenSeries": false,
       "id": 110,
@@ -1284,7 +1444,7 @@
         "h": 12,
         "w": 8,
         "x": 16,
-        "y": 24
+        "y": 65
       },
       "hiddenSeries": false,
       "id": 124,
@@ -1381,10 +1541,10 @@
       "fill": 3,
       "fillGradient": 4,
       "gridPos": {
-        "h": 9,
+        "h": 10,
         "w": 8,
         "x": 0,
-        "y": 36
+        "y": 77
       },
       "hiddenSeries": false,
       "id": 90,
@@ -1479,10 +1639,10 @@
       "fill": 3,
       "fillGradient": 4,
       "gridPos": {
-        "h": 9,
+        "h": 10,
         "w": 8,
         "x": 8,
-        "y": 36
+        "y": 77
       },
       "hiddenSeries": false,
       "id": 111,
@@ -1577,10 +1737,10 @@
       "fill": 3,
       "fillGradient": 4,
       "gridPos": {
-        "h": 9,
+        "h": 10,
         "w": 8,
         "x": 16,
-        "y": 36
+        "y": 77
       },
       "hiddenSeries": false,
       "id": 118,
@@ -1681,7 +1841,7 @@
         "h": 9,
         "w": 8,
         "x": 0,
-        "y": 45
+        "y": 87
       },
       "id": 92,
       "interval": null,
@@ -1734,7 +1894,7 @@
         "h": 9,
         "w": 8,
         "x": 8,
-        "y": 45
+        "y": 87
       },
       "id": 112,
       "interval": null,
@@ -1787,7 +1947,7 @@
         "h": 9,
         "w": 8,
         "x": 16,
-        "y": 45
+        "y": 87
       },
       "id": 119,
       "interval": null,
@@ -1834,10 +1994,10 @@
       "fill": 3,
       "fillGradient": 4,
       "gridPos": {
-        "h": 9,
+        "h": 10,
         "w": 8,
         "x": 0,
-        "y": 54
+        "y": 96
       },
       "hiddenSeries": false,
       "id": 91,
@@ -1932,10 +2092,10 @@
       "fill": 3,
       "fillGradient": 4,
       "gridPos": {
-        "h": 9,
+        "h": 10,
         "w": 8,
         "x": 8,
-        "y": 54
+        "y": 96
       },
       "hiddenSeries": false,
       "id": 113,
@@ -2030,10 +2190,10 @@
       "fill": 3,
       "fillGradient": 4,
       "gridPos": {
-        "h": 9,
+        "h": 10,
         "w": 8,
         "x": 16,
-        "y": 54
+        "y": 96
       },
       "hiddenSeries": false,
       "id": 120,
@@ -2134,7 +2294,7 @@
         "h": 9,
         "w": 8,
         "x": 0,
-        "y": 63
+        "y": 106
       },
       "id": 93,
       "interval": null,
@@ -2187,7 +2347,7 @@
         "h": 9,
         "w": 8,
         "x": 8,
-        "y": 63
+        "y": 106
       },
       "id": 114,
       "interval": null,
@@ -2240,7 +2400,7 @@
         "h": 9,
         "w": 8,
         "x": 16,
-        "y": 63
+        "y": 106
       },
       "id": 121,
       "interval": null,
@@ -2276,436 +2436,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "Prometheus",
-      "description": "Amount of access mana this node has.",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "fill": 3,
-      "fillGradient": 4,
-      "gridPos": {
-        "h": 14,
-        "w": 12,
-        "x": 0,
-        "y": 72
-      },
-      "hiddenSeries": false,
-      "id": 83,
-      "legend": {
-        "alignAsTable": true,
-        "avg": false,
-        "current": true,
-        "max": false,
-        "min": false,
-        "rightSide": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 2,
-      "nullPointMode": "null",
-      "percentage": false,
-      "pluginVersion": "7.1.1",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "mana_research_access{nodeID=\"$NodeID\",method=\"bm1\"}",
-          "interval": "",
-          "legendFormat": "Access Mana 1",
-          "refId": "A"
-        },
-        {
-          "expr": "mana_research_access{nodeID=\"$NodeID\",method=\"bm2\"}",
-          "interval": "",
-          "legendFormat": "Access Mana 2",
-          "refId": "B"
-        },
-        {
-          "expr": "mana_access{nodeID=\"$NodeID\"}",
-          "interval": "",
-          "legendFormat": "Access Mana Fifty-fifty",
-          "refId": "C"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Access Mana",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "description": "Amount of consensus mana this node has.",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "fill": 3,
-      "fillGradient": 4,
-      "gridPos": {
-        "h": 14,
-        "w": 12,
-        "x": 12,
-        "y": 72
-      },
-      "hiddenSeries": false,
-      "id": 84,
-      "legend": {
-        "alignAsTable": true,
-        "avg": false,
-        "current": true,
-        "max": false,
-        "min": false,
-        "rightSide": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 2,
-      "nullPointMode": "null",
-      "percentage": false,
-      "pluginVersion": "7.1.1",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "mana_research_consensus{nodeID=\"$NodeID\",method=\"bm1\"}",
-          "interval": "",
-          "legendFormat": "Consensus Mana 1",
-          "refId": "A"
-        },
-        {
-          "expr": "mana_research_consensus{nodeID=\"$NodeID\",method=\"bm2\"}",
-          "interval": "",
-          "legendFormat": "Consensus Mana 2",
-          "refId": "B"
-        },
-        {
-          "expr": "mana_consensus{nodeID=\"$NodeID\"}",
-          "interval": "",
-          "legendFormat": "Consensus Mana Fifty-fifty",
-          "refId": "C"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Consensus Mana",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "description": "Total Access  Mana In the network.",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 13,
-        "w": 12,
-        "x": 0,
-        "y": 86
-      },
-      "hiddenSeries": false,
-      "id": 89,
-      "legend": {
-        "alignAsTable": true,
-        "avg": false,
-        "current": true,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "percentage": false,
-      "pluginVersion": "7.1.1",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "sum(mana_access)",
-          "interval": "",
-          "legendFormat": "Total Access Mana Fifty-fifty In Network",
-          "refId": "A"
-        },
-        {
-          "expr": "sum(mana_research_access{method=\"bm1\"})",
-          "interval": "",
-          "legendFormat": "Total Access Mana 1 In Network",
-          "refId": "C"
-        },
-        {
-          "expr": "sum(mana_research_access{method=\"bm2\"})",
-          "interval": "",
-          "legendFormat": "Total Access Mana 2 In Network",
-          "refId": "D"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Total Access Mana In Network",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "description": "Total Consensus  Mana In the network.",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 13,
-        "w": 12,
-        "x": 12,
-        "y": 86
-      },
-      "hiddenSeries": false,
-      "id": 129,
-      "legend": {
-        "alignAsTable": true,
-        "avg": false,
-        "current": true,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "percentage": false,
-      "pluginVersion": "7.1.1",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "sum(mana_consensus)",
-          "interval": "",
-          "legendFormat": "Total Consensus Mana Fifty-fifty In Network",
-          "refId": "A"
-        },
-        {
-          "expr": "sum(mana_research_consensus{method=\"bm1\"})",
-          "interval": "",
-          "legendFormat": "Total Consensus Mana 1 In Network",
-          "refId": "C"
-        },
-        {
-          "expr": "sum(mana_research_consensus{method=\"bm2\"})",
-          "interval": "",
-          "legendFormat": "Total Consensus Mana 2 In Network",
-          "refId": "D"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Total Consensus Mana In Network",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "custom": {}
@@ -2718,7 +2448,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 99
+        "y": 115
       },
       "hiddenSeries": false,
       "id": 103,
@@ -2769,7 +2499,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Access Mana Percentile Development",
+      "title": "Access Mana Percentile Development $NodeID",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -2824,7 +2554,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 99
+        "y": 115
       },
       "hiddenSeries": false,
       "id": 130,
@@ -2875,7 +2605,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Consensus Mana Percentile Development",
+      "title": "Consensus Mana Percentile Development $NodeID",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -2974,5 +2704,5 @@
   "timezone": "",
   "title": "GoShimmer Mana Research",
   "uid": "kjOQZ2ZMo",
-  "version": 4
+  "version": 8
 }

--- a/tools/docker-network/grafana/dashboards/mana_research_dashboard.json
+++ b/tools/docker-network/grafana/dashboards/mana_research_dashboard.json
@@ -1,0 +1,2977 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Shows mana metrics with different EBM1 & EBM2 weights.",
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 5,
+  "iteration": 1602601061179,
+  "links": [],
+  "panels": [
+    {
+      "datasource": "Prometheus",
+      "description": "Amount of access mana this node has by taking only EBM1 into account.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "id": 85,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "7.1.1",
+      "targets": [
+        {
+          "expr": "mana_research_access{nodeID=\"$NodeID\",method=\"bm1\"}",
+          "interval": "",
+          "legendFormat": "Access",
+          "refId": "A"
+        },
+        {
+          "expr": "mana_research_consensus{nodeID=\"$NodeID\",method=\"bm1\"}",
+          "interval": "",
+          "legendFormat": "Consensus",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Current Mana 1",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Amount of access mana this node has by taking into account 50% EBM1 and 50% EBM2.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "id": 104,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "7.1.1",
+      "targets": [
+        {
+          "expr": "mana_access{nodeID=\"$NodeID\"}",
+          "interval": "",
+          "legendFormat": "Access",
+          "refId": "A"
+        },
+        {
+          "expr": "mana_consensus{nodeID=\"$NodeID\"}",
+          "interval": "",
+          "legendFormat": "Consensus",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Current Mana Mixed",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Amount of access mana this node has by taking only EBM2 into account.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "id": 125,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "7.1.1",
+      "targets": [
+        {
+          "expr": "mana_research_access{nodeID=\"$NodeID\",method=\"bm2\"}",
+          "interval": "",
+          "legendFormat": "Access",
+          "refId": "A"
+        },
+        {
+          "expr": "mana_research_consensus{nodeID=\"$NodeID\",method=\"bm2\"}",
+          "interval": "",
+          "legendFormat": "Consensus",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Current Mana 2",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Average mana of a node in the network taking only EBM1 into account.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 8,
+        "x": 0,
+        "y": 3
+      },
+      "id": 95,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.1.1",
+      "targets": [
+        {
+          "expr": "avg(mana_research_access{method=\"bm1\"})",
+          "interval": "",
+          "legendFormat": "Access",
+          "refId": "A"
+        },
+        {
+          "expr": "avg(mana_research_consensus{method=\"bm1\"})",
+          "interval": "",
+          "legendFormat": "Consensus",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Average Mana 1",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Average mana of a node in the network taking into account 50% EBM1 and 50% EBM2.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 8,
+        "x": 8,
+        "y": 3
+      },
+      "id": 105,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.1.1",
+      "targets": [
+        {
+          "expr": "avg(mana_access)",
+          "interval": "",
+          "legendFormat": "Access",
+          "refId": "A"
+        },
+        {
+          "expr": "avg(mana_consensus)",
+          "interval": "",
+          "legendFormat": "Consensus",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Average Mana Mixed",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Average mana of a node in the network taking only EBM2 into account.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 8,
+        "x": 16,
+        "y": 3
+      },
+      "id": 126,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.1.1",
+      "targets": [
+        {
+          "expr": "avg(mana_research_access{method=\"bm2\"})",
+          "interval": "",
+          "legendFormat": "Access",
+          "refId": "A"
+        },
+        {
+          "expr": "avg(mana_research_consensus{method=\"bm2\"})",
+          "interval": "",
+          "legendFormat": "Consensus",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Average Mana 2",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Percentile of a node in the network by taking only EBM1 values into account.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 8,
+        "x": 0,
+        "y": 6
+      },
+      "id": 101,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.1.1",
+      "targets": [
+        {
+          "expr": "mana_research_access_percentile{method=\"bm1\"}",
+          "interval": "",
+          "legendFormat": "Access",
+          "refId": "A"
+        },
+        {
+          "expr": "mana_research_consensus_percentile{method=\"bm1\"}",
+          "interval": "",
+          "legendFormat": "Consensus",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Mana 1 Percentile",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Percentile of a node in the network by taking into account 50% EBM1 and 50% EBM2.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 8,
+        "x": 8,
+        "y": 6
+      },
+      "id": 106,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.1.1",
+      "targets": [
+        {
+          "expr": "mana_access_percentile",
+          "interval": "",
+          "legendFormat": "Access",
+          "refId": "A"
+        },
+        {
+          "expr": "mana_consensus_percentile",
+          "interval": "",
+          "legendFormat": "Consensus",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Mana Mixed Percentile",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Percentile of a node in the network by taking only EBM2 values into account.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 8,
+        "x": 16,
+        "y": 6
+      },
+      "id": 127,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.1.1",
+      "targets": [
+        {
+          "expr": "mana_research_access_percentile{method=\"bm2\"}",
+          "interval": "",
+          "legendFormat": "Access",
+          "refId": "A"
+        },
+        {
+          "expr": "mana_research_consensus_percentile{method=\"bm2\"}",
+          "interval": "",
+          "legendFormat": "Consensus",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Mana 2 Percentile",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Standard deviation of mana of nodes in the network by taking into account only EBM1.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 8,
+        "x": 0,
+        "y": 9
+      },
+      "id": 96,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.1.1",
+      "targets": [
+        {
+          "expr": "stddev(mana_research_access{method=\"bm1\"})",
+          "interval": "",
+          "legendFormat": "Access",
+          "refId": "A"
+        },
+        {
+          "expr": "stddev(mana_research_consensus{method=\"bm1\"})",
+          "interval": "",
+          "legendFormat": "Consensus",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Standard Deviation of Mana 1",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Standard deviation of mana of nodes in the network by taking into account 50% EBM1 and 50% EBM2.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 8,
+        "x": 8,
+        "y": 9
+      },
+      "id": 107,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.1.1",
+      "targets": [
+        {
+          "expr": "stddev(mana_access)",
+          "interval": "",
+          "legendFormat": "Access",
+          "refId": "A"
+        },
+        {
+          "expr": "stddev(mana_consensus)",
+          "interval": "",
+          "legendFormat": "Consensus",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Standard Deviation of Mana Mixed",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Standard deviation of mana of nodes in the network by taking into account only EBM2.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 8,
+        "x": 16,
+        "y": 9
+      },
+      "id": 128,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.1.1",
+      "targets": [
+        {
+          "expr": "stddev(mana_research_access{method=\"bm2\"})",
+          "interval": "",
+          "legendFormat": "Access",
+          "refId": "A"
+        },
+        {
+          "expr": "stddev(mana_research_consensus{method=\"bm2\"})",
+          "interval": "",
+          "legendFormat": "Consensus",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Standard Deviation of Mana 2",
+      "type": "stat"
+    },
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "description": "Histogram of access mana 1 of nodes by taking only EBM1 into account.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 12,
+        "w": 8,
+        "x": 0,
+        "y": 12
+      },
+      "hiddenSeries": false,
+      "id": 98,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": false,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "percentage": false,
+      "pluginVersion": "7.1.1",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "mana_research_access{method=\"bm1\"}",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Access Mana 1 Distribution In Network",
+      "tooltip": {
+        "shared": false,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "histogram",
+        "name": null,
+        "show": true,
+        "values": [
+          "total"
+        ]
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "none",
+          "label": "Number of Nodes",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "description": "Histogram of access mana 2 of nodes by taking into account 50% EBM1 and 50% EBM2.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 12,
+        "w": 8,
+        "x": 8,
+        "y": 12
+      },
+      "hiddenSeries": false,
+      "id": 109,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": false,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "percentage": false,
+      "pluginVersion": "7.1.1",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "mana_access",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Access Mana Mixed Distribution In Network",
+      "tooltip": {
+        "shared": false,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "histogram",
+        "name": null,
+        "show": true,
+        "values": [
+          "total"
+        ]
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "none",
+          "label": "Number of Nodes",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "description": "Histogram of access mana 2 of nodes by taking only EBM2 into account.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 12,
+        "w": 8,
+        "x": 16,
+        "y": 12
+      },
+      "hiddenSeries": false,
+      "id": 123,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": false,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "percentage": false,
+      "pluginVersion": "7.1.1",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "mana_research_access{method=\"bm2\"}",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Access Mana 2 Distribution In Network",
+      "tooltip": {
+        "shared": false,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "histogram",
+        "name": null,
+        "show": true,
+        "values": [
+          "total"
+        ]
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "none",
+          "label": "Number of Nodes",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "description": "Histogram of consensus mana 1 of nodes by only taking into account EBM1.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 12,
+        "w": 8,
+        "x": 0,
+        "y": 24
+      },
+      "hiddenSeries": false,
+      "id": 99,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": false,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "percentage": false,
+      "pluginVersion": "7.1.1",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "mana_research_consensus{method=\"bm1\"}",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Consensus Mana 1 Distribution in Network",
+      "tooltip": {
+        "shared": false,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "histogram",
+        "name": null,
+        "show": true,
+        "values": [
+          "total"
+        ]
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "none",
+          "label": "Number of Nodes",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "description": "Histogram of consensus mana 2 of nodes by taking into account 50% EBM1 and 50% EBM2.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 12,
+        "w": 8,
+        "x": 8,
+        "y": 24
+      },
+      "hiddenSeries": false,
+      "id": 110,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": false,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "percentage": false,
+      "pluginVersion": "7.1.1",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "mana_consensus",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Consensus Mana Mixed Distribution in Network",
+      "tooltip": {
+        "shared": false,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "histogram",
+        "name": null,
+        "show": true,
+        "values": [
+          "total"
+        ]
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "none",
+          "label": "Number of Nodes",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "description": "Histogram of consensus mana 2 of nodes by only taking into account EBM2.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 12,
+        "w": 8,
+        "x": 16,
+        "y": 24
+      },
+      "hiddenSeries": false,
+      "id": 124,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": false,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "percentage": false,
+      "pluginVersion": "7.1.1",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "mana_research_consensus{method=\"bm2\"}",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Consensus Mana 2 Distribution in Network",
+      "tooltip": {
+        "shared": false,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "histogram",
+        "name": null,
+        "show": true,
+        "values": [
+          "total"
+        ]
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "none",
+          "label": "Number of Nodes",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "description": "Amount of access mana 1 of nodes in the network by taking only EBM1 into account.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "fill": 3,
+      "fillGradient": 4,
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 0,
+        "y": 36
+      },
+      "hiddenSeries": false,
+      "id": 90,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sort": "current",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "nullPointMode": "null",
+      "percentage": false,
+      "pluginVersion": "7.1.1",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "mana_research_access{method=\"bm1\"}",
+          "interval": "",
+          "legendFormat": "{{nodeID}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Network Wide Access Mana 1",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "description": "Amount of access mana 2 of nodes in the network by taking into account 50% EBM1 and 50% EBM2.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "fill": 3,
+      "fillGradient": 4,
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 8,
+        "y": 36
+      },
+      "hiddenSeries": false,
+      "id": 111,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sort": "current",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "nullPointMode": "null",
+      "percentage": false,
+      "pluginVersion": "7.1.1",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "mana_access",
+          "interval": "",
+          "legendFormat": "{{nodeID}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Network Wide Access Mana Mixed",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "description": "Amount of access mana 2 of nodes in the network by taking only EBM2 into account.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "fill": 3,
+      "fillGradient": 4,
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 16,
+        "y": 36
+      },
+      "hiddenSeries": false,
+      "id": 118,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sort": "current",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "nullPointMode": "null",
+      "percentage": false,
+      "pluginVersion": "7.1.1",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "mana_research_access{method=\"bm2\"}",
+          "interval": "",
+          "legendFormat": "{{nodeID}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Network Wide Access Mana 2",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "breakPoint": "50%",
+      "cacheTimeout": null,
+      "combine": {
+        "label": "Others",
+        "threshold": 0
+      },
+      "datasource": "Prometheus",
+      "description": "Allocation of access mana 1 of nodes in the network by taking only EBM1 into account.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "fontSize": "80%",
+      "format": "short",
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 0,
+        "y": 45
+      },
+      "id": 92,
+      "interval": null,
+      "legend": {
+        "show": true,
+        "sort": "current",
+        "sortDesc": true,
+        "values": true
+      },
+      "legendType": "Under graph",
+      "links": [],
+      "nullPointMode": "connected",
+      "pieType": "pie",
+      "pluginVersion": "7.1.1",
+      "strokeWidth": 1,
+      "targets": [
+        {
+          "expr": "mana_research_access{method=\"bm1\"}",
+          "interval": "",
+          "legendFormat": "{{nodeID}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Access Mana 1 Allocation",
+      "type": "grafana-piechart-panel",
+      "valueName": "current"
+    },
+    {
+      "aliasColors": {},
+      "breakPoint": "50%",
+      "cacheTimeout": null,
+      "combine": {
+        "label": "Others",
+        "threshold": 0
+      },
+      "datasource": "Prometheus",
+      "description": "Allocation of access mana 2 of nodes in the network by taking into account 50% EBM1 and 50% EBM2.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "fontSize": "80%",
+      "format": "short",
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 8,
+        "y": 45
+      },
+      "id": 112,
+      "interval": null,
+      "legend": {
+        "show": true,
+        "sort": "current",
+        "sortDesc": true,
+        "values": true
+      },
+      "legendType": "Under graph",
+      "links": [],
+      "nullPointMode": "connected",
+      "pieType": "pie",
+      "pluginVersion": "7.1.1",
+      "strokeWidth": 1,
+      "targets": [
+        {
+          "expr": "mana_access",
+          "interval": "",
+          "legendFormat": "{{nodeID}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Access Mana Mixed Allocation",
+      "type": "grafana-piechart-panel",
+      "valueName": "current"
+    },
+    {
+      "aliasColors": {},
+      "breakPoint": "50%",
+      "cacheTimeout": null,
+      "combine": {
+        "label": "Others",
+        "threshold": 0
+      },
+      "datasource": "Prometheus",
+      "description": "Allocation of access mana 2 of nodes in the network by taking only EBM2 into account.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "fontSize": "80%",
+      "format": "short",
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 16,
+        "y": 45
+      },
+      "id": 119,
+      "interval": null,
+      "legend": {
+        "show": true,
+        "sort": "current",
+        "sortDesc": true,
+        "values": true
+      },
+      "legendType": "Under graph",
+      "links": [],
+      "nullPointMode": "connected",
+      "pieType": "pie",
+      "pluginVersion": "7.1.1",
+      "strokeWidth": 1,
+      "targets": [
+        {
+          "expr": "mana_research_access{method=\"bm2\"}",
+          "interval": "",
+          "legendFormat": "{{nodeID}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Access Mana 2 Allocation",
+      "type": "grafana-piechart-panel",
+      "valueName": "current"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "description": "Amount of consensus mana of nodes in the network by taking only EBM1 into account.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "fill": 3,
+      "fillGradient": 4,
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 0,
+        "y": 54
+      },
+      "hiddenSeries": false,
+      "id": 91,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sort": "current",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "nullPointMode": "null",
+      "percentage": false,
+      "pluginVersion": "7.1.1",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "mana_research_consensus{method=\"bm1\"}",
+          "interval": "",
+          "legendFormat": "{{nodeID}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Network Wide Consensus Mana 1 ",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "description": "Amount of consensus mana of nodes in the network by taking into account 50% EBM1 and 50% EBM2.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "fill": 3,
+      "fillGradient": 4,
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 8,
+        "y": 54
+      },
+      "hiddenSeries": false,
+      "id": 113,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sort": "current",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "nullPointMode": "null",
+      "percentage": false,
+      "pluginVersion": "7.1.1",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "mana_consensus",
+          "interval": "",
+          "legendFormat": "{{nodeID}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Network Wide Consensus Mana Mixed",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "description": "Amount of consensus mana of nodes in the network by taking only EBM2 into account.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "fill": 3,
+      "fillGradient": 4,
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 16,
+        "y": 54
+      },
+      "hiddenSeries": false,
+      "id": 120,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sort": "current",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "nullPointMode": "null",
+      "percentage": false,
+      "pluginVersion": "7.1.1",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "mana_research_consensus{method=\"bm2\"}",
+          "interval": "",
+          "legendFormat": "{{nodeID}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Network Wide Consensus Mana 2",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "breakPoint": "50%",
+      "cacheTimeout": null,
+      "combine": {
+        "label": "Others",
+        "threshold": 0
+      },
+      "datasource": "Prometheus",
+      "description": "Allocation of consensus mana of nodes in the network by taking into account only EBM1.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "fontSize": "80%",
+      "format": "short",
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 0,
+        "y": 63
+      },
+      "id": 93,
+      "interval": null,
+      "legend": {
+        "show": true,
+        "sort": "current",
+        "sortDesc": true,
+        "values": true
+      },
+      "legendType": "Under graph",
+      "links": [],
+      "nullPointMode": "connected",
+      "pieType": "pie",
+      "pluginVersion": "7.1.1",
+      "strokeWidth": 1,
+      "targets": [
+        {
+          "expr": "mana_research_consensus{method=\"bm1\"}",
+          "interval": "",
+          "legendFormat": "{{nodeID}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Consensus Mana 1 Allocation",
+      "type": "grafana-piechart-panel",
+      "valueName": "current"
+    },
+    {
+      "aliasColors": {},
+      "breakPoint": "50%",
+      "cacheTimeout": null,
+      "combine": {
+        "label": "Others",
+        "threshold": 0
+      },
+      "datasource": "Prometheus",
+      "description": "Allocation of consensus mana of nodes in the network by taking into account only EBM2.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "fontSize": "80%",
+      "format": "short",
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 8,
+        "y": 63
+      },
+      "id": 114,
+      "interval": null,
+      "legend": {
+        "show": true,
+        "sort": "current",
+        "sortDesc": true,
+        "values": true
+      },
+      "legendType": "Under graph",
+      "links": [],
+      "nullPointMode": "connected",
+      "pieType": "pie",
+      "pluginVersion": "7.1.1",
+      "strokeWidth": 1,
+      "targets": [
+        {
+          "expr": "mana_research_consensus{method=\"bm2\"}",
+          "interval": "",
+          "legendFormat": "{{nodeID}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Consensus Mana 2 Allocation",
+      "type": "grafana-piechart-panel",
+      "valueName": "current"
+    },
+    {
+      "aliasColors": {},
+      "breakPoint": "50%",
+      "cacheTimeout": null,
+      "combine": {
+        "label": "Others",
+        "threshold": 0
+      },
+      "datasource": "Prometheus",
+      "description": "Allocation of consensus mana of nodes in the network by taking into account only EBM2.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "fontSize": "80%",
+      "format": "short",
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 16,
+        "y": 63
+      },
+      "id": 121,
+      "interval": null,
+      "legend": {
+        "show": true,
+        "sort": "current",
+        "sortDesc": true,
+        "values": true
+      },
+      "legendType": "Under graph",
+      "links": [],
+      "nullPointMode": "connected",
+      "pieType": "pie",
+      "pluginVersion": "7.1.1",
+      "strokeWidth": 1,
+      "targets": [
+        {
+          "expr": "mana_research_consensus{method=\"bm2\"}",
+          "interval": "",
+          "legendFormat": "{{nodeID}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Consensus Mana 2 Allocation",
+      "type": "grafana-piechart-panel",
+      "valueName": "current"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "description": "Amount of access mana this node has.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "fill": 3,
+      "fillGradient": 4,
+      "gridPos": {
+        "h": 14,
+        "w": 12,
+        "x": 0,
+        "y": 72
+      },
+      "hiddenSeries": false,
+      "id": 83,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "nullPointMode": "null",
+      "percentage": false,
+      "pluginVersion": "7.1.1",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "mana_research_access{nodeID=\"$NodeID\",method=\"bm1\"}",
+          "interval": "",
+          "legendFormat": "Access Mana 1",
+          "refId": "A"
+        },
+        {
+          "expr": "mana_research_access{nodeID=\"$NodeID\",method=\"bm2\"}",
+          "interval": "",
+          "legendFormat": "Access Mana 2",
+          "refId": "B"
+        },
+        {
+          "expr": "mana_access{nodeID=\"$NodeID\"}",
+          "interval": "",
+          "legendFormat": "Access Mana Fifty-fifty",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Access Mana",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "description": "Amount of consensus mana this node has.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "fill": 3,
+      "fillGradient": 4,
+      "gridPos": {
+        "h": 14,
+        "w": 12,
+        "x": 12,
+        "y": 72
+      },
+      "hiddenSeries": false,
+      "id": 84,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "nullPointMode": "null",
+      "percentage": false,
+      "pluginVersion": "7.1.1",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "mana_research_consensus{nodeID=\"$NodeID\",method=\"bm1\"}",
+          "interval": "",
+          "legendFormat": "Consensus Mana 1",
+          "refId": "A"
+        },
+        {
+          "expr": "mana_research_consensus{nodeID=\"$NodeID\",method=\"bm2\"}",
+          "interval": "",
+          "legendFormat": "Consensus Mana 2",
+          "refId": "B"
+        },
+        {
+          "expr": "mana_consensus{nodeID=\"$NodeID\"}",
+          "interval": "",
+          "legendFormat": "Consensus Mana Fifty-fifty",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Consensus Mana",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "description": "Total Access  Mana In the network.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 13,
+        "w": 12,
+        "x": 0,
+        "y": 86
+      },
+      "hiddenSeries": false,
+      "id": 89,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "percentage": false,
+      "pluginVersion": "7.1.1",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(mana_access)",
+          "interval": "",
+          "legendFormat": "Total Access Mana Fifty-fifty In Network",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(mana_research_access{method=\"bm1\"})",
+          "interval": "",
+          "legendFormat": "Total Access Mana 1 In Network",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(mana_research_access{method=\"bm2\"})",
+          "interval": "",
+          "legendFormat": "Total Access Mana 2 In Network",
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Total Access Mana In Network",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "description": "Total Consensus  Mana In the network.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 13,
+        "w": 12,
+        "x": 12,
+        "y": 86
+      },
+      "hiddenSeries": false,
+      "id": 129,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "percentage": false,
+      "pluginVersion": "7.1.1",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(mana_consensus)",
+          "interval": "",
+          "legendFormat": "Total Consensus Mana Fifty-fifty In Network",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(mana_research_consensus{method=\"bm1\"})",
+          "interval": "",
+          "legendFormat": "Total Consensus Mana 1 In Network",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(mana_research_consensus{method=\"bm2\"})",
+          "interval": "",
+          "legendFormat": "Total Consensus Mana 2 In Network",
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Total Consensus Mana In Network",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 99
+      },
+      "hiddenSeries": false,
+      "id": 103,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "percentage": false,
+      "pluginVersion": "7.1.1",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "mana_access_percentile",
+          "interval": "",
+          "legendFormat": "Access Percentile Fifty-fifty",
+          "refId": "A"
+        },
+        {
+          "expr": "mana_research_access_percentile{method=\"bm1\"}",
+          "interval": "",
+          "legendFormat": "Access Percentile 1",
+          "refId": "B"
+        },
+        {
+          "expr": "mana_research_access_percentile{method=\"bm2\"}",
+          "interval": "",
+          "legendFormat": "Access Percentile 2",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Access Mana Percentile Development",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "percent",
+          "label": null,
+          "logBase": 1,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 99
+      },
+      "hiddenSeries": false,
+      "id": 130,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "percentage": false,
+      "pluginVersion": "7.1.1",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "mana_consensus_percentile",
+          "interval": "",
+          "legendFormat": "Consensus Percentile Fifty-fifty",
+          "refId": "D"
+        },
+        {
+          "expr": "mana_research_consensus_percentile{method=\"bm1\"}",
+          "interval": "",
+          "legendFormat": "Consensus Percentile 1",
+          "refId": "E"
+        },
+        {
+          "expr": "mana_research_consensus_percentile{method=\"bm2\"}",
+          "interval": "",
+          "legendFormat": "Consensus Percentile 2",
+          "refId": "F"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Consensus Mana Percentile Development",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "percent",
+          "label": null,
+          "logBase": 1,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 26,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "selected": true,
+          "text": "4AeXyZ26e4G",
+          "value": "4AeXyZ26e4G"
+        },
+        "datasource": "Prometheus",
+        "definition": "label_values(iota_info_app, nodeID)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Node Identity",
+        "multi": false,
+        "name": "NodeID",
+        "options": [
+          {
+            "selected": true,
+            "text": "4AeXyZ26e4G",
+            "value": "4AeXyZ26e4G"
+          }
+        ],
+        "query": "label_values(iota_info_app, nodeID)",
+        "refresh": 0,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "",
+  "title": "GoShimmer Mana Research",
+  "uid": "kjOQZ2ZMo",
+  "version": 8
+}

--- a/tools/docker-network/grafana/dashboards/mana_research_dashboard.json
+++ b/tools/docker-network/grafana/dashboards/mana_research_dashboard.json
@@ -16,8 +16,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 5,
-  "iteration": 1602601061179,
+  "id": 6,
+  "iteration": 1602603298633,
   "links": [],
   "panels": [
     {
@@ -2173,7 +2173,7 @@
         "threshold": 0
       },
       "datasource": "Prometheus",
-      "description": "Allocation of consensus mana of nodes in the network by taking into account only EBM2.",
+      "description": "Allocation of consensus mana of nodes in the network by taking into account 50% EBM1 and 50% EBM2.",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -2205,7 +2205,7 @@
       "strokeWidth": 1,
       "targets": [
         {
-          "expr": "mana_research_consensus{method=\"bm2\"}",
+          "expr": "mana_consensus",
           "interval": "",
           "legendFormat": "{{nodeID}}",
           "refId": "A"
@@ -2213,7 +2213,7 @@
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Consensus Mana 2 Allocation",
+      "title": "Consensus Mana Mixed Allocation",
       "type": "grafana-piechart-panel",
       "valueName": "current"
     },
@@ -2973,5 +2973,5 @@
   "timezone": "",
   "title": "GoShimmer Mana Research",
   "uid": "kjOQZ2ZMo",
-  "version": 8
+  "version": 4
 }

--- a/tools/docker-network/grafana/dashboards/mana_research_dashboard.json
+++ b/tools/docker-network/grafana/dashboards/mana_research_dashboard.json
@@ -2959,6 +2959,7 @@
   },
   "timepicker": {
     "refresh_intervals": [
+      "5s",
       "10s",
       "30s",
       "1m",


### PR DESCRIPTION
Fixes #770 

- Refactor `baseManaVector` methods to accept mana calculation weights instead of using hardcoded weight of `0.5`.
- Introduce constants for weights: `OnlyMana1`, `OnlyMana2` and `Mixed` (50-50).
- Collect mana research metrics for all three "modes" of mana calculation. (metrics pkg)
- Export mana research metrics for all three "modes" of mana calculation. (prometheus)
- Compare mana research metrics on `Mana Research Dashboard` in Grafana.
- Mana research metrics collection (and export) is disabled by default, can be enabled via config:

```json
  "metrics": {
    "manaResearch": true,
  },
```
- Mana webapi endpoints return `Mixed` mode values.

![image](https://user-images.githubusercontent.com/32927267/96122285-8bc85000-0ef1-11eb-9d4b-c7142ad487ba.png)

