### PR TITLE
feat: Add commit tag to version

### DIFF
--- a/plugins/analysis/client/fpc_heartbeato.go
+++ b/plugins/analysis/client/fpc_heartbeato.go
@@ -39,7 +39,7 @@ func onRoundExecuted(roundStats *vote.RoundStats) {
 		}
 
 		hb := &packet.FPCHeartbeat{
-			Version:    banner.AppVersion,
+			Version:    banner.SimplifiedAppVersion,
 			OwnID:      nodeID,
 			RoundStats: rs,
 		}

--- a/plugins/analysis/client/heartbeat.go
+++ b/plugins/analysis/client/heartbeat.go
@@ -75,5 +75,5 @@ func createHeartbeat() *packet.Heartbeat {
 		copy(inboundIDs[i], neighbor.ID().Bytes())
 	}
 
-	return &packet.Heartbeat{NetworkID: []byte(banner.AppVersion), OwnID: nodeID, OutboundIDs: outboundIDs, InboundIDs: inboundIDs}
+	return &packet.Heartbeat{NetworkID: []byte(banner.SimplifiedAppVersion), OwnID: nodeID, OutboundIDs: outboundIDs, InboundIDs: inboundIDs}
 }

--- a/plugins/analysis/client/metric_heartbeat.go
+++ b/plugins/analysis/client/metric_heartbeat.go
@@ -35,7 +35,7 @@ func createMetricHeartbeat() *packet.MetricHeartbeat {
 	}
 
 	return &packet.MetricHeartbeat{
-		Version: banner.AppVersion,
+		Version: banner.SimplifiedAppVersion,
 		OwnID:   nodeID,
 		OS:      runtime.GOOS,
 		Arch:    runtime.GOARCH,

--- a/plugins/analysis/packet/fpc_heartbeat.go
+++ b/plugins/analysis/packet/fpc_heartbeat.go
@@ -62,7 +62,7 @@ func ParseFPCHeartbeat(data []byte) (*FPCHeartbeat, error) {
 		return nil, err
 	}
 
-	if hb.Version != banner.AppVersion {
+	if hb.Version != banner.SimplifiedAppVersion {
 		return nil, ErrInvalidFPCHeartbeatVersion
 	}
 

--- a/plugins/analysis/packet/fpc_heartbeat_test.go
+++ b/plugins/analysis/packet/fpc_heartbeat_test.go
@@ -46,7 +46,7 @@ func TestFPCHeartbeat(t *testing.T) {
 	_, err = ParseFPCHeartbeat(packet)
 	require.Error(t, err)
 
-	hb.Version = banner.AppVersion
+	hb.Version = banner.SimplifiedAppVersion
 	packet, err = hb.Bytes()
 	require.NoError(t, err)
 

--- a/plugins/analysis/packet/metric_heartbeat.go
+++ b/plugins/analysis/packet/metric_heartbeat.go
@@ -60,7 +60,7 @@ func ParseMetricHeartbeat(data []byte) (*MetricHeartbeat, error) {
 		return nil, err
 	}
 
-	if hb.Version != banner.AppVersion {
+	if hb.Version != banner.SimplifiedAppVersion {
 		return nil, ErrInvalidMetricHeartbeatVersion
 	}
 

--- a/plugins/analysis/packet/metric_heartbeat_test.go
+++ b/plugins/analysis/packet/metric_heartbeat_test.go
@@ -45,7 +45,7 @@ func TestMetricHeartbeat(t *testing.T) {
 	_, err = ParseMetricHeartbeat(packet)
 	require.Error(t, err)
 
-	hb.Version = banner.AppVersion
+	hb.Version = banner.SimplifiedAppVersion
 	packet, err = hb.Bytes()
 	require.NoError(t, err)
 

--- a/plugins/analysis/server/plugin.go
+++ b/plugins/analysis/server/plugin.go
@@ -148,7 +148,7 @@ func processHeartbeatPacket(data []byte) {
 }
 
 // processHeartbeatPacket parses the serialized data into a FPC Heartbeat packet and triggers its event.
-// Note that the processFPCHeartbeatPacket function will return an error if the hb version field is different than banner.AppVersion,
+// Note that the processFPCHeartbeatPacket function will return an error if the hb version field is different than banner.SimplifiedAppVersion,
 // thus the hb will be discarded.
 func processFPCHeartbeatPacket(data []byte) {
 	hb, err := packet.ParseFPCHeartbeat(data)
@@ -162,7 +162,7 @@ func processFPCHeartbeatPacket(data []byte) {
 }
 
 // processMetricHeartbeatPacket parses the serialized data into a Metric Heartbeat packet and triggers its event.
-// Note that the ParseMetricHeartbeat function will return an error if the hb version field is different than banner.AppVersion,
+// Note that the ParseMetricHeartbeat function will return an error if the hb version field is different than banner.SimplifiedAppVersion,
 // thus the hb will be discarded.
 func processMetricHeartbeatPacket(data []byte) {
 	hb, err := packet.ParseMetricHeartbeat(data)

--- a/plugins/banner/plugin.go
+++ b/plugins/banner/plugin.go
@@ -2,6 +2,7 @@ package banner
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/iotaledger/hive.go/node"
@@ -14,12 +15,14 @@ var (
 	// plugin is the plugin instance of the banner plugin.
 	plugin *node.Plugin
 	once   sync.Once
+
+	// AppVersion version number
+	AppVersion = "v0.3.0"
+	// SimplifiedAppVersion is the version number without commit hash
+	SimplifiedAppVersion string
 )
 
 const (
-	// AppVersion version number
-	AppVersion = "v0.3.0"
-
 	// AppName app code name
 	AppName = "GoShimmer"
 )
@@ -44,8 +47,23 @@ func configure(ctx *node.Plugin) {
 `, AppVersion)
 	fmt.Println()
 
+	SimplifiedAppVersion = simplifiedVersion(AppVersion)
+
 	ctx.Node.Logger.Infof("GoShimmer version %s ...", AppVersion)
 	ctx.Node.Logger.Info("Loading plugins ...")
 }
 
 func run(ctx *node.Plugin) {}
+
+func simplifiedVersion(version string) string {
+	// ignore commit hash
+	ver := version
+	if strings.Contains(ver, "-") {
+		ver = strings.Split(ver, "-")[0]
+	}
+	// attach a "v" at front
+	if !strings.Contains(ver, "v") {
+		ver = "v" + ver
+	}
+	return ver
+}

--- a/plugins/banner/plugin.go
+++ b/plugins/banner/plugin.go
@@ -19,7 +19,7 @@ var (
 	// AppVersion version number
 	AppVersion = "v0.3.0"
 	// SimplifiedAppVersion is the version number without commit hash
-	SimplifiedAppVersion string
+	SimplifiedAppVersion = simplifiedVersion(AppVersion)
 )
 
 const (
@@ -46,8 +46,6 @@ func configure(ctx *node.Plugin) {
                              %s                                     
 `, AppVersion)
 	fmt.Println()
-
-	SimplifiedAppVersion = simplifiedVersion(AppVersion)
 
 	ctx.Node.Logger.Infof("GoShimmer version %s ...", AppVersion)
 	ctx.Node.Logger.Info("Loading plugins ...")

--- a/plugins/metrics/global_metrics.go
+++ b/plugins/metrics/global_metrics.go
@@ -58,8 +58,8 @@ func NodesMetrics() map[string]NodeInfo {
 func calculateNetworkDiameter() {
 	diameter := 0
 	// TODO: send data for all available networkIDs, not just current
-	if analysisserver.Networks[banner.AppVersion] != nil {
-		g := analysisserver.Networks[banner.AppVersion].NetworkGraph()
+	if analysisserver.Networks[banner.SimplifiedAppVersion] != nil {
+		g := analysisserver.Networks[banner.SimplifiedAppVersion].NetworkGraph()
 		diameter = g.Diameter()
 	}
 	networkDiameter.Store(int32(diameter))

--- a/plugins/prometheus/global_metrics.go
+++ b/plugins/prometheus/global_metrics.go
@@ -182,8 +182,8 @@ func collectNodesInfo() {
 	}
 
 	// TODO: send data for all available networkIDs, not just current
-	if analysisserver.Networks[banner.AppVersion] != nil {
-		for nodeID, neighborCount := range analysisserver.Networks[banner.AppVersion].NumOfNeighbors() {
+	if analysisserver.Networks[banner.SimplifiedAppVersion] != nil {
+		for nodeID, neighborCount := range analysisserver.Networks[banner.SimplifiedAppVersion].NumOfNeighbors() {
 			nodesNeighborCount.WithLabelValues(nodeID, "in").Set(float64(neighborCount.Inbound))
 			nodesNeighborCount.WithLabelValues(nodeID, "out").Set(float64(neighborCount.Outbound))
 		}

--- a/plugins/remotelog/plugin.go
+++ b/plugins/remotelog/plugin.go
@@ -105,7 +105,7 @@ func run(plugin *node.Plugin) {
 
 func sendLogMsg(level logger.Level, name string, msg string) {
 	m := logMessage{
-		banner.AppVersion,
+		banner.SimplifiedAppVersion,
 		myGitHead,
 		myGitBranch,
 		myID,

--- a/plugins/remotelog/plugin.go
+++ b/plugins/remotelog/plugin.go
@@ -105,7 +105,7 @@ func run(plugin *node.Plugin) {
 
 func sendLogMsg(level logger.Level, name string, msg string) {
 	m := logMessage{
-		banner.SimplifiedAppVersion,
+		banner.AppVersion,
 		myGitHead,
 		myGitBranch,
 		myID,

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# Builds GoShimmer with the latest git tag and commit hash (short)
+# E.g.: ./goshimmer -v --> GoShimmer 0.3.0-f3b76ae4
+
+latest_tag=$(git describe --tags $(git rev-list --tags --max-count=1))
+commit_hash=$(git rev-parse --short HEAD)
+
+go build -ldflags="-s -w -X github.com/iotaledger/goshimmer/plugins/banner.AppVersion=${latest_tag:1}-$commit_hash"


### PR DESCRIPTION
# Description of change
- Enable users to build with specific version and commit hash.
- Add `SimplifiedAppVersion` which contains `vXX.XX.XX` only, for use by other plugins, e.g. `analysis`, `remotelog` to send the consistent packets.

Fix #494 

## Type of change
- Enhancement 

## How the change has been tested
Build with
`go build -ldflags="-s -w -X github.com/iotaledger/goshimmer/plugins/banner.AppVersion=<tag>-<commit_hash>`

and run the executed file

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
