### PR TITLE
Use clock in network delay

### DIFF
--- a/plugins/networkdelay/plugin.go
+++ b/plugins/networkdelay/plugin.go
@@ -112,12 +112,7 @@ func onReceiveMessageFromMessageLayer(cachedMessageEvent *tangle.CachedMessageEv
 		return
 	}
 
-	var now int64
-	if clockEnabled {
-		now = clock.SyncedTime().UnixNano()
-	} else {
-		now = time.Now().UnixNano()
-	}
+	now := clock.SyncedTime().UnixNano()
 
 	// abort if message was sent more than 1min ago
 	// this should only happen due to a node resyncing

--- a/plugins/networkdelay/webapi.go
+++ b/plugins/networkdelay/webapi.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/iotaledger/goshimmer/packages/clock"
 	"github.com/iotaledger/goshimmer/plugins/issuer"
 	"github.com/iotaledger/goshimmer/plugins/webapi"
 	"github.com/labstack/echo"
@@ -24,7 +25,14 @@ func broadcastNetworkDelayObject(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, Response{Error: err.Error()})
 	}
 
-	msg, err := issuer.IssuePayload(NewObject(id, time.Now().UnixNano()))
+	var now int64
+	if clockEnabled {
+		now = clock.SyncedTime().UnixNano()
+	} else {
+		now = time.Now().UnixNano()
+	}
+
+	msg, err := issuer.IssuePayload(NewObject(id, now))
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, Response{Error: err.Error()})
 	}

--- a/plugins/networkdelay/webapi.go
+++ b/plugins/networkdelay/webapi.go
@@ -25,12 +25,7 @@ func broadcastNetworkDelayObject(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, Response{Error: err.Error()})
 	}
 
-	var now int64
-	if clockEnabled {
-		now = clock.SyncedTime().UnixNano()
-	} else {
-		now = time.Now().UnixNano()
-	}
+	now := clock.SyncedTime().UnixNano()
 
 	msg, err := issuer.IssuePayload(NewObject(id, now))
 	if err != nil {


### PR DESCRIPTION
This PR adds the use of the `SyncedTime()` (if enabled) in the network delay app. It also adds two new fields in the `networkDelay` struct: 

- Clock: whether the clock plugin is enabled
- Sync: whether the node is in sync 