### PR TITLE
pending mana predictor

### DIFF
--- a/client/mana.go
+++ b/client/mana.go
@@ -15,6 +15,7 @@ const (
 	routeGetOnlineConsensusMana   = "mana/consensus/online"
 	routeGetNHighestAccessMana    = "mana/access/nhighest"
 	routeGetNHighestConsensusMana = "mana/consensus/nhighest"
+	routePending                  = "mana/pending"
 )
 
 // GetOwnMana returns the access and consensus mana of the node this api client is communicating with.
@@ -120,6 +121,16 @@ func (api *GoShimmerAPI) GetNHighestConsensusMana(n int) (*webapi_mana.GetNHighe
 	if err := api.do(http.MethodGet, func() string {
 		return fmt.Sprintf("%s?number=%d", routeGetNHighestConsensusMana, n)
 	}(), nil, res); err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+// GetPending returns the mana (bm2) that will be pledged by spending the output specified.
+func (api *GoShimmerAPI) GetPending(outputID string) (*webapi_mana.PendingResponse, error) {
+	res := &webapi_mana.PendingResponse{}
+	if err := api.do(http.MethodGet, routePending,
+		&webapi_mana.PendingRequest{OutputID: outputID}, res); err != nil {
 		return nil, err
 	}
 	return res, nil

--- a/client/wallet/output.go
+++ b/client/wallet/output.go
@@ -29,5 +29,6 @@ type InclusionState struct {
 
 // OutputMetadata is metadata about the output.
 type OutputMetadata struct {
+	// Timestamp is the timestamp of the tx that created the output.
 	Timestamp time.Time
 }

--- a/client/wallet/output.go
+++ b/client/wallet/output.go
@@ -1,6 +1,8 @@
 package wallet
 
 import (
+	"time"
+
 	"github.com/iotaledger/goshimmer/dapps/valuetransfers/packages/address"
 	"github.com/iotaledger/goshimmer/dapps/valuetransfers/packages/balance"
 	"github.com/iotaledger/goshimmer/dapps/valuetransfers/packages/transaction"
@@ -8,10 +10,12 @@ import (
 
 // Output is a wallet specific representation of an output in the IOTA network.
 type Output struct {
+	ID             transaction.OutputID
 	Address        address.Address
 	TransactionID  transaction.ID
 	Balances       map[balance.Color]uint64
 	InclusionState InclusionState
+	Metadata       OutputMetadata
 }
 
 // InclusionState is a container for the different flags of an output that define if it was accepted in the network.
@@ -21,4 +25,9 @@ type InclusionState struct {
 	Rejected    bool
 	Conflicting bool
 	Spent       bool
+}
+
+// OutputMetadata is metadata about the output.
+type OutputMetadata struct {
+	Timestamp time.Time
 }

--- a/client/wallet/serverstatus.go
+++ b/client/wallet/serverstatus.go
@@ -2,7 +2,8 @@ package wallet
 
 // ServerStatus defines the information of connected server
 type ServerStatus struct {
-	ID      string
-	Synced  bool
-	Version string
+	ID        string
+	Synced    bool
+	Version   string
+	ManaDecay float64
 }

--- a/client/wallet/wallet.go
+++ b/client/wallet/wallet.go
@@ -187,8 +187,8 @@ func (wallet *Wallet) RemainderAddress() walletaddr.Address {
 }
 
 // UnspentOutputs returns the unspent outputs that are available for spending.
-func (wallet *Wallet) UnspentOutputs() map[walletaddr.Address]map[transaction.ID]*Output {
-	return wallet.unspentOutputManager.UnspentOutputs()
+func (wallet *Wallet) UnspentOutputs(addresses ...walletaddr.Address) map[walletaddr.Address]map[transaction.ID]*Output {
+	return wallet.unspentOutputManager.UnspentOutputs(addresses...)
 }
 
 // RequestFaucetFunds requests some funds from the faucet for testing purposes.

--- a/client/wallet/webconnector.go
+++ b/client/wallet/webconnector.go
@@ -33,6 +33,7 @@ func (webConnector *WebConnector) ServerStatus() (status ServerStatus, err error
 	status.ID = response.IdentityID
 	status.Synced = response.Synced
 	status.Version = response.Version
+	status.ManaDecay = response.ManaDecay
 
 	return
 }
@@ -88,6 +89,7 @@ func (webConnector WebConnector) UnspentOutputs(addresses ...walletaddr.Address)
 
 			// build output
 			walletOutput := &Output{
+				ID:            outputID,
 				Address:       addr.Address,
 				TransactionID: outputID.TransactionID(),
 				Balances:      balancesByColor,
@@ -97,6 +99,9 @@ func (webConnector WebConnector) UnspentOutputs(addresses ...walletaddr.Address)
 					Rejected:    output.InclusionState.Rejected,
 					Conflicting: output.InclusionState.Conflicting,
 					Spent:       false,
+				},
+				Metadata: OutputMetadata{
+					Timestamp: output.Metadata.Timestamp,
 				},
 			}
 

--- a/packages/mana/base.go
+++ b/packages/mana/base.go
@@ -37,6 +37,11 @@ func (bm *BaseMana) updateBM2(n time.Duration) {
 	bm.BaseMana2 = bm.BaseMana2 * math.Pow(math.E, -decay*n.Seconds())
 }
 
+// GetBM2 computes and returns the EBM2 based on the value and duration specified.
+func GetBM2(value float64, n time.Duration) float64 {
+	return value * math.Pow(math.E, -decay*n.Seconds())
+}
+
 func (bm *BaseMana) updateEBM2(n time.Duration) {
 	if emaCoeff2 != decay {
 		bm.EffectiveBaseMana2 = math.Pow(math.E, -emaCoeff2*n.Seconds())*bm.EffectiveBaseMana2 +

--- a/packages/mana/base.go
+++ b/packages/mana/base.go
@@ -34,22 +34,22 @@ func (bm *BaseMana) updateEBM1(n time.Duration) {
 }
 
 func (bm *BaseMana) updateBM2(n time.Duration) {
-	bm.BaseMana2 = bm.BaseMana2 * math.Pow(math.E, -decay*n.Seconds())
+	bm.BaseMana2 = bm.BaseMana2 * math.Pow(math.E, -Decay*n.Seconds())
 }
 
 // GetBM2 computes and returns the EBM2 based on the value and duration specified.
 func GetBM2(value float64, n time.Duration) float64 {
-	return value * math.Pow(math.E, -decay*n.Seconds())
+	return value * math.Pow(math.E, -Decay*n.Seconds())
 }
 
 func (bm *BaseMana) updateEBM2(n time.Duration) {
-	if emaCoeff2 != decay {
+	if emaCoeff2 != Decay {
 		bm.EffectiveBaseMana2 = math.Pow(math.E, -emaCoeff2*n.Seconds())*bm.EffectiveBaseMana2 +
-			(math.Pow(math.E, -decay*n.Seconds())-math.Pow(math.E, -emaCoeff2*n.Seconds()))/
-				(emaCoeff2-decay)*emaCoeff2/math.Pow(math.E, -decay*n.Seconds())*bm.BaseMana2
+			(math.Pow(math.E, -Decay*n.Seconds())-math.Pow(math.E, -emaCoeff2*n.Seconds()))/
+				(emaCoeff2-Decay)*emaCoeff2/math.Pow(math.E, -Decay*n.Seconds())*bm.BaseMana2
 	} else {
-		bm.EffectiveBaseMana2 = math.Pow(math.E, -decay*n.Seconds())*bm.EffectiveBaseMana2 +
-			decay*n.Seconds()*bm.BaseMana2
+		bm.EffectiveBaseMana2 = math.Pow(math.E, -Decay*n.Seconds())*bm.EffectiveBaseMana2 +
+			Decay*n.Seconds()*bm.BaseMana2
 	}
 }
 
@@ -98,7 +98,7 @@ func (bm *BaseMana) pledgeAndUpdate(tx *TxInfo) (bm1Pledged float64, bm2Pledged 
 		bm.BaseMana1 += bm1Pledged
 		// pending mana awarded, need to see how long funds sat
 		for _, input := range tx.InputInfos {
-			bm2Add := input.Amount * (1 - math.Pow(math.E, -decay*(t.Sub(input.TimeStamp).Seconds())))
+			bm2Add := input.Amount * (1 - math.Pow(math.E, -Decay*(t.Sub(input.TimeStamp).Seconds())))
 			bm.BaseMana2 += bm2Add
 			bm2Pledged += bm2Add
 		}
@@ -109,18 +109,18 @@ func (bm *BaseMana) pledgeAndUpdate(tx *TxInfo) (bm1Pledged float64, bm2Pledged 
 		bm.BaseMana1 += bm1Pledged
 		oldMana2 := bm.BaseMana2
 		for _, input := range tx.InputInfos {
-			bm2Add := input.Amount * (1 - math.Pow(math.E, -decay*(t.Sub(input.TimeStamp).Seconds()))) *
-				math.Pow(math.E, -decay*n.Seconds())
+			bm2Add := input.Amount * (1 - math.Pow(math.E, -Decay*(t.Sub(input.TimeStamp).Seconds()))) *
+				math.Pow(math.E, -Decay*n.Seconds())
 			bm.BaseMana2 += bm2Add
 			bm2Pledged += bm2Add
 		}
 		// update EBM1 and EBM2 to `bm.LastUpdated`
 		bm.EffectiveBaseMana1 += bm1Pledged * (1 - math.Pow(math.E, -emaCoeff1*n.Seconds()))
-		if emaCoeff2 != decay {
-			bm.EffectiveBaseMana2 += (bm.BaseMana2 - oldMana2) * emaCoeff2 * (math.Pow(math.E, -decay*n.Seconds()) -
-				math.Pow(math.E, -emaCoeff2*n.Seconds())) / (emaCoeff2 - decay) / math.Pow(math.E, -decay*n.Seconds())
+		if emaCoeff2 != Decay {
+			bm.EffectiveBaseMana2 += (bm.BaseMana2 - oldMana2) * emaCoeff2 * (math.Pow(math.E, -Decay*n.Seconds()) -
+				math.Pow(math.E, -emaCoeff2*n.Seconds())) / (emaCoeff2 - Decay) / math.Pow(math.E, -Decay*n.Seconds())
 		} else {
-			bm.EffectiveBaseMana2 += (bm.BaseMana2 - oldMana2) * decay * n.Seconds()
+			bm.EffectiveBaseMana2 += (bm.BaseMana2 - oldMana2) * Decay * n.Seconds()
 		}
 	}
 	return bm1Pledged, bm2Pledged

--- a/packages/mana/base.go
+++ b/packages/mana/base.go
@@ -37,11 +37,6 @@ func (bm *BaseMana) updateBM2(n time.Duration) {
 	bm.BaseMana2 = bm.BaseMana2 * math.Pow(math.E, -Decay*n.Seconds())
 }
 
-// GetBM2 computes and returns the EBM2 based on the value and duration specified.
-func GetBM2(value float64, n time.Duration) float64 {
-	return value * math.Pow(math.E, -Decay*n.Seconds())
-}
-
 func (bm *BaseMana) updateEBM2(n time.Duration) {
 	if emaCoeff2 != Decay {
 		bm.EffectiveBaseMana2 = math.Pow(math.E, -emaCoeff2*n.Seconds())*bm.EffectiveBaseMana2 +

--- a/packages/mana/base_test.go
+++ b/packages/mana/base_test.go
@@ -59,15 +59,6 @@ func TestUpdateBM2(t *testing.T) {
 	assert.InDelta(t, 0.5, bm2.BaseMana2, delta)
 }
 
-func TestGetBM2(t *testing.T) {
-	value := 1.0
-	// with emaCoeff1 = 0.00003209, half value should be reached within 6 hours
-	for i := 0; i < 6; i++ {
-		value = GetBM2(value, time.Hour)
-	}
-	assert.InDelta(t, 0.5, value, delta)
-}
-
 func TestUpdateEBM2CoeffEqual(t *testing.T) {
 	bm1 := BaseMana{}
 	bm2 := BaseMana{}

--- a/packages/mana/base_test.go
+++ b/packages/mana/base_test.go
@@ -59,6 +59,15 @@ func TestUpdateBM2(t *testing.T) {
 	assert.InDelta(t, 0.5, bm2.BaseMana2, delta)
 }
 
+func TestGetBM2(t *testing.T) {
+	value := 1.0
+	// with emaCoeff1 = 0.00003209, half value should be reached within 6 hours
+	for i := 0; i < 6; i++ {
+		value = GetBM2(value, time.Hour)
+	}
+	assert.InDelta(t, 0.5, value, delta)
+}
+
 func TestUpdateEBM2CoeffEqual(t *testing.T) {
 	bm1 := BaseMana{}
 	bm2 := BaseMana{}

--- a/packages/mana/base_test.go
+++ b/packages/mana/base_test.go
@@ -98,8 +98,8 @@ func TestUpdateEBM2CoeffEqual(t *testing.T) {
 }
 
 //func TestUpdateEBM2CoeffNotEqual(t *testing.T) {
-//	// set coefficients such that emaCoeff2 != decay
-//	SetCoefficients(emaCoeff1, 0.0004, decay)
+//	// set coefficients such that emaCoeff2 != Decay
+//	SetCoefficients(emaCoeff1, 0.0004, Decay)
 //	bm1 := BaseMana{}
 //	bm2 := BaseMana{}
 //

--- a/packages/mana/parameters.go
+++ b/packages/mana/parameters.go
@@ -15,7 +15,8 @@ var (
 	// default values are for half life of 6 hours, unit is 1/s
 	emaCoeff1 = 0.00003209
 	emaCoeff2 = 0.00003209
-	Decay     = 0.00003209
+	// Decay is the mana decay (gamma).
+	Decay = 0.00003209
 )
 
 // SetCoefficients sets the coefficients for mana calculation.

--- a/packages/mana/parameters.go
+++ b/packages/mana/parameters.go
@@ -15,7 +15,7 @@ var (
 	// default values are for half life of 6 hours, unit is 1/s
 	emaCoeff1 = 0.00003209
 	emaCoeff2 = 0.00003209
-	decay     = 0.00003209
+	Decay     = 0.00003209
 )
 
 // SetCoefficients sets the coefficients for mana calculation.
@@ -31,5 +31,5 @@ func SetCoefficients(ema1 float64, ema2 float64, dec float64) {
 	}
 	emaCoeff1 = ema1
 	emaCoeff2 = ema2
-	decay = dec
+	Decay = dec
 }

--- a/plugins/dashboard/explorer_routes.go
+++ b/plugins/dashboard/explorer_routes.go
@@ -8,6 +8,7 @@ import (
 	"github.com/iotaledger/goshimmer/dapps/valuetransfers/packages/address"
 	"github.com/iotaledger/goshimmer/dapps/valuetransfers/packages/tangle"
 	"github.com/iotaledger/goshimmer/packages/binary/messagelayer/message"
+	"github.com/iotaledger/goshimmer/plugins/mana"
 	"github.com/iotaledger/goshimmer/plugins/messagelayer"
 	"github.com/iotaledger/goshimmer/plugins/webapi/value/utils"
 	"github.com/labstack/echo"
@@ -75,6 +76,7 @@ type ExplorerOutput struct {
 	InclusionState     utils.InclusionState `json:"inclusion_state"`
 	SolidificationTime int64                `json:"solidification_time"`
 	ConsumerCount      int                  `json:"consumer_count"`
+	PendingMana        float64              `json:"pending_mana"`
 }
 
 // SearchResult defines the struct of the SearchResult.
@@ -195,12 +197,14 @@ func findAddress(strAddress string) (*ExplorerAddress, error) {
 				inclusionState.Confirmed = output.Confirmed()
 			}
 
+			pendingMana := mana.PendingManaOnOutput(id)
 			outputids = append(outputids, ExplorerOutput{
 				ID:                 id.String(),
 				Balances:           b,
 				InclusionState:     inclusionState,
 				ConsumerCount:      output.ConsumerCount(),
 				SolidificationTime: solidificationTime,
+				PendingMana:        pendingMana,
 			})
 		})
 	}

--- a/plugins/dashboard/frontend/src/app/components/ExplorerAddressResult.tsx
+++ b/plugins/dashboard/frontend/src/app/components/ExplorerAddressResult.tsx
@@ -9,6 +9,7 @@ import Spinner from "react-bootstrap/Spinner";
 import ListGroup from "react-bootstrap/ListGroup";
 import Alert from "react-bootstrap/Alert";
 import * as dateformat from 'dateformat';
+import {displayManaUnit} from "app/utils";
 
 interface Props {
     nodeStore?: NodeStore;
@@ -117,7 +118,8 @@ export class ExplorerAddressQueryResult extends React.Component<Props, any> {
                             <div>{status}</div>
                             <div>{consumed}</div>
                             <div>{conflicting}</div>
-                            <div>{'Balance:'} {balances}</div>   
+                            <div>{'Balance:'} {balances}</div>
+                            <div>Pending Mana: {displayManaUnit(output.pending_mana)}</div>
                         </small>
                     </ListGroup.Item>
                 );

--- a/plugins/dashboard/frontend/src/app/components/ManaGauge.tsx
+++ b/plugins/dashboard/frontend/src/app/components/ManaGauge.tsx
@@ -4,6 +4,7 @@ import Card from "react-bootstrap/Card";
 import UpArrow from "../../assets/up.svg";
 import DownArrow from "../../assets/down.svg";
 import {Col, Container, Row} from "react-bootstrap";
+import {displayManaUnit} from "app/utils";
 
 
 interface Props {
@@ -47,25 +48,3 @@ export function displayChangeIcon(cur: number, prev: number) {
     }
 }
 
-export function displayManaUnit(mana: number): string {
-    let result = ""
-    // round to nearest integer
-    let roundedMana = Math.round(mana);
-    if (roundedMana < 1000) {
-        result = roundedMana.toString(10) + " m"; // mana
-    } else if (roundedMana < 1000000) {
-        result = (roundedMana / 1000).toFixed(3) + " Km"; // kilomana
-    }
-    else if (roundedMana < 1000000000) {
-        result = (roundedMana / 1000000).toFixed(3) + " Mm"; // megamana
-    }
-    else if (roundedMana < 1000000000000) {
-        result = (roundedMana / 1000000000).toFixed(3) + " Gm"; // gigamana
-    }
-    else if (roundedMana < 1000000000000000) {
-        result = (roundedMana / 1000000000000).toFixed(3) + " Tm"; // terramana
-    } else {
-        result = (roundedMana / 1000000000000000).toFixed(3) + " Pm"; // petamana
-    }
-    return result
-}

--- a/plugins/dashboard/frontend/src/app/stores/ExplorerStore.tsx
+++ b/plugins/dashboard/frontend/src/app/stores/ExplorerStore.tsx
@@ -32,6 +32,7 @@ class Output {
     inclusion_state: InclusionState;
     consumer_count: number;
     solidification_time: number;
+    pending_mana: number;
 }
 
 class Balance {

--- a/plugins/dashboard/frontend/src/app/stores/ManaStore.tsx
+++ b/plugins/dashboard/frontend/src/app/stores/ManaStore.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import {Col, ListGroupItem, OverlayTrigger, Popover, Row} from "react-bootstrap";
 import Plus from "../../assets/plus.svg";
 import Minus from "../../assets/minus.svg";
-import {displayManaUnit} from "app/components/ManaGauge";
+import {displayManaUnit} from "app/utils";
 
 class ManaMsg {
     nodeID: string;

--- a/plugins/dashboard/frontend/src/app/utils/index.ts
+++ b/plugins/dashboard/frontend/src/app/utils/index.ts
@@ -1,0 +1,22 @@
+export function displayManaUnit(mana: number): string {
+    let result = ""
+    // round to nearest integer
+    let roundedMana = Math.round(mana);
+    if (roundedMana < 1000) {
+        result = roundedMana.toString(10) + " m"; // mana
+    } else if (roundedMana < 1000000) {
+        result = (roundedMana / 1000).toFixed(3) + " Km"; // kilomana
+    }
+    else if (roundedMana < 1000000000) {
+        result = (roundedMana / 1000000).toFixed(3) + " Mm"; // megamana
+    }
+    else if (roundedMana < 1000000000000) {
+        result = (roundedMana / 1000000000).toFixed(3) + " Gm"; // gigamana
+    }
+    else if (roundedMana < 1000000000000000) {
+        result = (roundedMana / 1000000000000).toFixed(3) + " Tm"; // terramana
+    } else {
+        result = (roundedMana / 1000000000000000).toFixed(3) + " Pm"; // petamana
+    }
+    return result
+}

--- a/plugins/mana/plugin.go
+++ b/plugins/mana/plugin.go
@@ -355,7 +355,12 @@ func PendingManaOnOutput(outputID transaction.OutputID) float64 {
 	cachedTx := valuetransfers.Tangle().Transaction(output.TransactionID())
 	defer cachedTx.Release()
 	tx := cachedTx.Unwrap()
-	return value * (1 - math.Pow(math.E, -mana.Decay*(time.Since(tx.Timestamp()).Seconds())))
+	return GetPendingMana(value, time.Since(tx.Timestamp()))
+}
+
+// GetPendingMana returns the mana pledged by spending a `value` output that sat for `n` duration.
+func GetPendingMana(value float64, n time.Duration) float64 {
+	return value * (1 - math.Pow(math.E, -mana.Decay*(n.Seconds())))
 }
 
 // AllowedPledge represents the nodes that mana is allowed to be pledged to.

--- a/plugins/mana/plugin.go
+++ b/plugins/mana/plugin.go
@@ -1,6 +1,7 @@
 package mana
 
 import (
+	"math"
 	"math/rand"
 	"sort"
 	"sync"
@@ -354,7 +355,7 @@ func PendingManaOnOutput(outputID transaction.OutputID) float64 {
 	cachedTx := valuetransfers.Tangle().Transaction(output.TransactionID())
 	defer cachedTx.Release()
 	tx := cachedTx.Unwrap()
-	return mana.GetBM2(value, time.Now().Sub(tx.Timestamp()))
+	return value * (1 - math.Pow(math.E, -mana.Decay*(time.Since(tx.Timestamp()).Seconds())))
 }
 
 // AllowedPledge represents the nodes that mana is allowed to be pledged to.

--- a/plugins/webapi/info/plugin.go
+++ b/plugins/webapi/info/plugin.go
@@ -124,6 +124,7 @@ func getInfo(c echo.Context) error {
 		EnabledPlugins:          enabledPlugins,
 		DisabledPlugins:         disabledPlugins,
 		Mana:                    nodeMana,
+		ManaDecay:               mana.Decay,
 	})
 }
 
@@ -153,6 +154,8 @@ type Response struct {
 	DisabledPlugins []string `json:"disabledPlugins,omitempty"`
 	// Mana values
 	Mana Mana `json:"mana,omitempty"`
+	// ManaDecay is the decay coefficient of bm2.
+	ManaDecay float64 `json:"mana_decay"`
 	// error of the response
 	Error string `json:"error,omitempty"`
 }

--- a/plugins/webapi/mana/pending.go
+++ b/plugins/webapi/mana/pending.go
@@ -1,0 +1,38 @@
+package mana
+
+import (
+	"net/http"
+
+	"github.com/iotaledger/goshimmer/dapps/valuetransfers/packages/transaction"
+	manaPlugin "github.com/iotaledger/goshimmer/plugins/mana"
+	"github.com/labstack/echo"
+)
+
+// getPendingHandler handles the request.
+func getPendingHandler(c echo.Context) error {
+	var req PendingRequest
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, PendingResponse{Error: err.Error()})
+	}
+	outputID, err := transaction.OutputIDFromBase58(req.OutputID)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, PendingResponse{Error: err.Error()})
+	}
+	pending := manaPlugin.PendingManaOnOutput(outputID)
+	return c.JSON(http.StatusOK, PendingResponse{
+		Mana:     pending,
+		OutputID: outputID.String(),
+	})
+}
+
+// PendingRequest is the pending mana request.
+type PendingRequest struct {
+	OutputID string `json:"outputID"`
+}
+
+// PendingResponse is the pending mana response.
+type PendingResponse struct {
+	Mana     float64 `json:"mana"`
+	OutputID string  `json:"outputID"`
+	Error    string  `json:"error,omitempty"`
+}

--- a/plugins/webapi/mana/plugin.go
+++ b/plugins/webapi/mana/plugin.go
@@ -32,4 +32,5 @@ func configure(_ *node.Plugin) {
 	webapi.Server().GET("/mana/percentile", getPercentileHandler)
 	webapi.Server().GET("/mana/access/online", getOnlineAccessHandler)
 	webapi.Server().GET("/mana/consensus/online", getOnlineConsensusHandler)
+	webapi.Server().GET("/mana/pending", getPendingHandler)
 }

--- a/tools/cli-wallet/main.go
+++ b/tools/cli-wallet/main.go
@@ -41,6 +41,7 @@ func main() {
 	requestFaucetFundsCommand := flag.NewFlagSet("request-funds", flag.ExitOnError)
 	serverStatusCommand := flag.NewFlagSet("server-status", flag.ExitOnError)
 	allowedPledgeIDCommand := flag.NewFlagSet("pledge-id", flag.ExitOnError)
+	pendingManaCommand := flag.NewFlagSet("pending-mana", flag.ExitOnError)
 
 	// switch logic according to provided sub command
 	switch os.Args[1] {
@@ -56,6 +57,8 @@ func main() {
 		execRequestFundsCommand(requestFaucetFundsCommand, wallet)
 	case "pledge-id":
 		execAllowedPledgeNodeIDsCommand(allowedPledgeIDCommand, wallet)
+	case "pending-mana":
+		execPendingMana(pendingManaCommand, wallet)
 	case "init":
 		fmt.Println()
 		fmt.Println("CREATING WALLET STATE FILE (wallet.dat) ...               [DONE]")

--- a/tools/cli-wallet/pendingmana.go
+++ b/tools/cli-wallet/pendingmana.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"math"
+	"os"
+	"time"
+
+	"github.com/iotaledger/goshimmer/client/wallet"
+)
+
+func execPendingMana(command *flag.FlagSet, cliWallet *wallet.Wallet) {
+	err := command.Parse(os.Args[2:])
+	if err != nil {
+		printUsage(nil, err.Error())
+	}
+
+	status, err := cliWallet.ServerStatus()
+	if err != nil {
+		printUsage(nil, err.Error())
+	}
+
+	unspentOutputs := cliWallet.UnspentOutputs()
+	for addr, v := range unspentOutputs {
+		fmt.Printf("Address: %s\n\n", addr.String())
+		for _, output := range v {
+			var total float64
+			for _, balance := range output.Balances {
+				total += float64(balance)
+			}
+			pendingMana := getBM2(total, time.Since(output.Metadata.Timestamp), status.ManaDecay)
+			fmt.Printf("\tOutputID: %s - Pending Mana: %f\n", output.ID.String(), pendingMana)
+		}
+	}
+}
+
+func getBM2(value float64, n time.Duration, decay float64) float64 {
+	return value * math.Pow(math.E, -decay*n.Seconds())
+}

--- a/tools/cli-wallet/pendingmana.go
+++ b/tools/cli-wallet/pendingmana.go
@@ -33,6 +33,7 @@ func execPendingMana(command *flag.FlagSet, cliWallet *wallet.Wallet) {
 			fmt.Printf("\tOutputID: %s - Pending Mana: %f\n", output.ID.String(), pendingMana)
 		}
 	}
+	fmt.Println()
 }
 
 func getBM2(value float64, n time.Duration, decay float64) float64 {

--- a/tools/cli-wallet/pendingmana.go
+++ b/tools/cli-wallet/pendingmana.go
@@ -21,9 +21,11 @@ func execPendingMana(command *flag.FlagSet, cliWallet *wallet.Wallet) {
 		printUsage(nil, err.Error())
 	}
 
+	fmt.Println("\nPending Mana for all unspent outputs")
+	fmt.Println("-----------------------------------")
 	unspentOutputs := cliWallet.UnspentOutputs()
 	for addr, v := range unspentOutputs {
-		fmt.Printf("Address: %s\n\n", addr.String())
+		fmt.Printf("Address: %s\n", addr.String())
 		for _, output := range v {
 			var total float64
 			for _, balance := range output.Balances {
@@ -37,5 +39,5 @@ func execPendingMana(command *flag.FlagSet, cliWallet *wallet.Wallet) {
 }
 
 func getBM2(value float64, n time.Duration, decay float64) float64 {
-	return value * math.Pow(math.E, -decay*n.Seconds())
+	return value * (1 - math.Pow(math.E, -decay*(n.Seconds())))
 }

--- a/tools/cli-wallet/pendingmana.go
+++ b/tools/cli-wallet/pendingmana.go
@@ -31,13 +31,13 @@ func execPendingMana(command *flag.FlagSet, cliWallet *wallet.Wallet) {
 			for _, balance := range output.Balances {
 				total += float64(balance)
 			}
-			pendingMana := getBM2(total, time.Since(output.Metadata.Timestamp), status.ManaDecay)
+			pendingMana := getPendingMana(total, time.Since(output.Metadata.Timestamp), status.ManaDecay)
 			fmt.Printf("\tOutputID: %s - Pending Mana: %f\n", output.ID.String(), pendingMana)
 		}
 	}
 	fmt.Println()
 }
 
-func getBM2(value float64, n time.Duration, decay float64) float64 {
+func getPendingMana(value float64, n time.Duration, decay float64) float64 {
 	return value * (1 - math.Pow(math.E, -decay*(n.Seconds())))
 }


### PR DESCRIPTION
# Description of change

Predicts how much mana will be pledged by spending an output.
#817 

- Added API to query pending mana for a given `outputID`
- Added command in cli wallet to get pending mana for unspent outputs `pending-mana`
```
IOTA Pollen CLI-Wallet 0.1

Pending Mana for all unspent outputs
-----------------------------------
Address: SSZSK5kDZSgvirg9fxyJ46ELBwKLuRabCXLcTXTWZaRk
        OutputID: 8ZLJ3vT7z3vENqFYZfGRiqZMfRCFhxqUw9mjCPUBJZvxiWNSbj6WAQmvHGqFdTZC2P3pt1cjrMWP3g6EoFk4gAr1 - Pending Mana: 1327.405267
```
- Added pending mana to explorer output details page
<img width="873" alt="Screenshot 2020-11-02 at 17 17 53" src="https://user-images.githubusercontent.com/57879913/97893482-a1cb7280-1d31-11eb-893f-d969057456ea.png">

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested
- unit tests

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
