### PR TITLE
Reconnect dashboard on lost websocket connection

### DIFF
--- a/plugins/dashboard/frontend/src/app/stores/NodeStore.ts
+++ b/plugins/dashboard/frontend/src/app/stores/NodeStore.ts
@@ -207,10 +207,17 @@ export class NodeStore {
         this.collected_tips_metrics = [];
     }
 
+    reconnect() {
+        this.updateWebSocketConnected(false);
+        setTimeout(() => {
+            this.connect();
+        }, 5000);
+    }
+
     connect() {
         connectWebSocket(statusWebSocketPath,
             () => this.updateWebSocketConnected(true),
-            () => this.updateWebSocketConnected(false),
+            () => this.reconnect(),
             () => this.updateWebSocketConnected(false))
     }
 


### PR DESCRIPTION
Borrowed from hornet dashboard.  :running::package::running:
