### PR TITLE
update entry node

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -14,7 +14,7 @@
   "autopeering": {
     "entryNodes": [
       "2PV5487xMw5rasGBXXWeqSi4hLz7r19YBt8Y1TGAsQbj@ressims.iota.cafe:15626",
-      "5EDH4uY78EA6wrBkHHAVBWBMDt7EcksRq6pjzipoW15B@entrynode.alphanet.tanglebay.org:14656"
+      "5EDH4uY78EA6wrBkHHAVBWBMDt7EcksRq6pjzipoW15B@entrynode.alphanet.einfachiota.de:14656"
     ],
     "port": 14626
   },


### PR DESCRIPTION
Tangle Bay is now completly integrated to einfachIOTA and the new URL should be used. The old URL will still be valid but it is better to use the new one.