### PR TITLE
Re-enable banner plugin

### DIFF
--- a/plugins/banner/plugin.go
+++ b/plugins/banner/plugin.go
@@ -30,7 +30,7 @@ const (
 // Plugin gets the plugin instance.
 func Plugin() *node.Plugin {
 	once.Do(func() {
-		plugin = node.NewPlugin(PluginName, node.Disabled, configure, run)
+		plugin = node.NewPlugin(PluginName, node.Enabled, configure, run)
 	})
 	return plugin
 }


### PR DESCRIPTION
It was probably mistakenly disabled in [this commit](https://github.com/iotaledger/goshimmer/commit/68fdcf49382514a2d73be0968b2e52ac86f180cf).

Adds a banner to the beginning of the log output.