### PR TITLE
chore: Use Go 1.15.5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.15
       - name: Copy config.default.json to config.json
         run: cp config.default.json config.json
       - name: Run GoReleaser

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.14.4
+    - name: Set up Go 1.15.5
       uses: actions/setup-go@v1
       with:
-        go-version: 1.14.4
+        go-version: 1.15.5
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 ############################
 # Build
 ############################
-# golang:1.14.4-buster
-FROM golang@sha256:fbaba67d3bd0a6fd154eaa27d1a0a9e5e80ecdb0792736017fde7326d9bf8d69 AS build
+# golang:1.15.5-buster
+FROM golang@sha256:eb88b20326f70fbf943af9d62650d8293d62fb5764c50e7477cdcb33caf9ff73 AS build
 
 # Ensure ca-certficates are up to date
 RUN update-ca-certificates

--- a/tools/docker-network/builder/docker-compose.builder.yml
+++ b/tools/docker-network/builder/docker-compose.builder.yml
@@ -3,7 +3,7 @@ version: "3.5"
 services:
   builder:
     container_name: builder
-    image: golang:1.14.4
+    image: golang:1.15.5
     working_dir: /tmp/goshimmer/
     entrypoint: go install main.go
     volumes:

--- a/tools/docker-network/docker-compose.yml
+++ b/tools/docker-network/docker-compose.yml
@@ -4,7 +4,7 @@ services:
  
   entry_node:
     container_name: entry_node
-    image: golang:1.14.4
+    image: golang:1.15.5
     stop_grace_period: 1m
     entrypoint: /go/bin/main
     command: >
@@ -34,7 +34,7 @@ services:
 
   peer_master:
     container_name: peer_master
-    image: golang:1.14.4
+    image: golang:1.15.5
     stop_grace_period: 1m
     entrypoint: /go/bin/main
     command: >
@@ -59,7 +59,7 @@ services:
       - entry_node
 
   peer_replica:
-    image: golang:1.14.4
+    image: golang:1.15.5
     stop_grace_period: 1m
     entrypoint: /go/bin/main
     command: >

--- a/tools/integration-tests/tester/docker-compose.yml
+++ b/tools/integration-tests/tester/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.5"
 services:
   tester:
     container_name: tester
-    image: golang:1.14.4
+    image: golang:1.15.5
     working_dir: /tmp/goshimmer/tools/integration-tests/tester
     command: /tmp/assets/entrypoint.sh
     environment:


### PR DESCRIPTION
# Description of change

Previous versions of Go have an issue where a specially crafted input to a math operation can cause a panic ([CVE-2020-28362](https://security.archlinux.org/CVE-2020-28362)). This bug is fixed in Go 1.15.5.

## Type of change

- Chore

## How the change has been tested

CI passes successfully

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
