### PR TITLE
Evenly distribute issued msgs in spammer

### DIFF
--- a/plugins/issuer/plugin.go
+++ b/plugins/issuer/plugin.go
@@ -1,7 +1,6 @@
 package issuer
 
 import (
-	"fmt"
 	goSync "sync"
 
 	"github.com/iotaledger/goshimmer/packages/tangle"
@@ -9,6 +8,7 @@ import (
 	"github.com/iotaledger/goshimmer/plugins/messagelayer"
 	"github.com/iotaledger/goshimmer/plugins/syncbeaconfollower"
 	"github.com/iotaledger/hive.go/node"
+	"golang.org/x/xerrors"
 )
 
 // PluginName is the name of the issuer plugin.
@@ -34,7 +34,7 @@ func configure(_ *node.Plugin) {}
 // If the node is not synchronized an error is returned.
 func IssuePayload(payload payload.Payload) (*tangle.Message, error) {
 	if !syncbeaconfollower.Synced() {
-		return nil, fmt.Errorf("can't issue payload: %w", syncbeaconfollower.ErrNodeNotSynchronized)
+		return nil, xerrors.Errorf("can't issue payload: %w", syncbeaconfollower.ErrNodeNotSynchronized)
 	}
 
 	msg, err := messagelayer.MessageFactory().IssuePayload(payload)

--- a/plugins/spammer/webapi.go
+++ b/plugins/spammer/webapi.go
@@ -21,9 +21,11 @@ func handleRequest(c echo.Context) error {
 
 		messageSpammer.Shutdown()
 		messageSpammer.Start(request.MPM, time.Minute)
+		log.Infof("Started spamming messages with %d MPM", request.MPM)
 		return c.JSON(http.StatusOK, Response{Message: "started spamming messages"})
 	case "stop":
 		messageSpammer.Shutdown()
+		log.Info("Stopped spamming messages")
 		return c.JSON(http.StatusOK, Response{Message: "stopped spamming messages"})
 	default:
 		return c.JSON(http.StatusBadRequest, Response{Error: "invalid cmd in request"})


### PR DESCRIPTION
Fixes #833 

- Distribute issued spam messages evenly.
- Stop the spammer when node is not in sync.
- Add log messages to `spammer` webapi.
- Remove unused `shutdownSignal` from `Spammer` struct.