### PR TITLE
Fix: Fixed bug with missing payload length

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Pull additional Docker images
         run: |
-          docker pull angelocapossele/drand:1.1.3
+          docker pull angelocapossele/drng:payloadfix
           docker pull gaiaadm/pumba:0.7.2
           docker pull gaiadocker/iproute2:latest
 
@@ -54,7 +54,7 @@ jobs:
 
       - name: Pull additional Docker images
         run: |
-          docker pull angelocapossele/drand:1.1.3
+          docker pull angelocapossele/drng:payloadfix
           docker pull gaiaadm/pumba:0.7.2
           docker pull gaiadocker/iproute2:latest
 
@@ -88,7 +88,7 @@ jobs:
 
       - name: Pull additional Docker images
         run: |
-          docker pull angelocapossele/drand:1.1.3
+          docker pull angelocapossele/drng:payloadfix
           docker pull gaiaadm/pumba:0.7.2
           docker pull gaiadocker/iproute2:latest
 
@@ -123,7 +123,7 @@ jobs:
 
       - name: Pull additional Docker images
         run: |
-          docker pull angelocapossele/drand:1.1.3
+          docker pull angelocapossele/drng:payloadfix
           docker pull gaiaadm/pumba:0.7.2
           docker pull gaiadocker/iproute2:latest
 
@@ -159,7 +159,7 @@ jobs:
 
       - name: Pull additional Docker images
         run: |
-          docker pull angelocapossele/drand:1.1.3
+          docker pull angelocapossele/drng:payloadfix
           docker pull gaiaadm/pumba:0.7.2
           docker pull gaiadocker/iproute2:latest
 
@@ -195,7 +195,7 @@ jobs:
 
       - name: Pull additional Docker images
         run: |
-          docker pull angelocapossele/drand:1.1.3
+          docker pull angelocapossele/drng:payloadfix
           docker pull gaiaadm/pumba:0.7.2
           docker pull gaiadocker/iproute2:latest
 
@@ -229,7 +229,7 @@ jobs:
 
       - name: Pull additional Docker images
         run: |
-          docker pull angelocapossele/drand:1.1.3
+          docker pull angelocapossele/drng:payloadfix
           docker pull gaiaadm/pumba:0.7.2
           docker pull gaiadocker/iproute2:latest
 
@@ -263,7 +263,7 @@ jobs:
 
       - name: Pull additional Docker images
         run: |
-          docker pull angelocapossele/drand:1.1.3
+          docker pull angelocapossele/drng:payloadfix
           docker pull gaiaadm/pumba:0.7.2
           docker pull gaiadocker/iproute2:latest
 

--- a/dapps/valuetransfers/packages/payload/payload.go
+++ b/dapps/valuetransfers/packages/payload/payload.go
@@ -223,8 +223,8 @@ func (p *Payload) ObjectStorageValue() (bytes []byte) {
 
 	// marshal fields
 	payloadLength := IDLength + IDLength + len(transferBytes)
-	marshalUtil := marshalutil.New(marshalutil.Uint32Size + marshalutil.Uint32Size + payloadLength)
-	marshalUtil.WriteUint32(uint32(payloadLength))
+	marshalUtil := marshalutil.New(marshalutil.Uint32Size + payload.TypeLength + payloadLength)
+	marshalUtil.WriteUint32(payload.TypeLength + uint32(payloadLength))
 	marshalUtil.WriteBytes(Type.Bytes())
 	marshalUtil.WriteBytes(p.parent1PayloadID.Bytes())
 	marshalUtil.WriteBytes(p.parent2PayloadID.Bytes())

--- a/packages/drng/collective_beacon_payload.go
+++ b/packages/drng/collective_beacon_payload.go
@@ -130,7 +130,7 @@ func (p *CollectiveBeaconPayload) Bytes() (bytes []byte) {
 	// marshal fields
 	payloadLength := HeaderLength + marshalutil.Uint64Size + SignatureSize*2 + PublicKeySize
 	marshalUtil := marshalutil.New(marshalutil.Uint32Size + marshalutil.Uint32Size + payloadLength)
-	marshalUtil.WriteUint32(uint32(payloadLength))
+	marshalUtil.WriteUint32(payload.TypeLength + uint32(payloadLength))
 	marshalUtil.WriteBytes(PayloadType.Bytes())
 	marshalUtil.WriteBytes(p.Header.Bytes())
 	marshalUtil.WriteUint64(p.Round)

--- a/packages/drng/payload.go
+++ b/packages/drng/payload.go
@@ -67,7 +67,7 @@ func FromBytes(bytes []byte) (result *Payload, consumedBytes int, err error) {
 	}
 
 	// parse data
-	if result.Data, err = marshalUtil.ReadBytes(int(len - HeaderLength)); err != nil {
+	if result.Data, err = marshalUtil.ReadBytes(int(len - payload.TypeLength - HeaderLength)); err != nil {
 		err = fmt.Errorf("failed to parse data of drng payload: %w", err)
 		return
 	}

--- a/packages/drng/payload.go
+++ b/packages/drng/payload.go
@@ -105,7 +105,7 @@ func (p *Payload) Bytes() (bytes []byte) {
 	marshalUtil := marshalutil.New()
 
 	// marshal the payload specific information
-	marshalUtil.WriteUint32(uint32(len(p.Data) + HeaderLength))
+	marshalUtil.WriteUint32(payload.TypeLength + uint32(len(p.Data)+HeaderLength))
 	marshalUtil.WriteBytes(PayloadType.Bytes())
 	marshalUtil.WriteBytes(p.Header.Bytes())
 	marshalUtil.WriteBytes(p.Data[:])

--- a/packages/tangle/payload/data.go
+++ b/packages/tangle/payload/data.go
@@ -75,7 +75,7 @@ func (g *GenericDataPayload) Blob() []byte {
 // Bytes returns a marshaled version of the Payload.
 func (g *GenericDataPayload) Bytes() []byte {
 	return marshalutil.New().
-		WriteUint32(uint32(len(g.data))).
+		WriteUint32(TypeLength + uint32(len(g.data))).
 		WriteBytes(g.Type().Bytes()).
 		WriteBytes(g.Blob()).
 		Bytes()

--- a/packages/tangle/payload/data.go
+++ b/packages/tangle/payload/data.go
@@ -54,7 +54,7 @@ func GenericDataPayloadFromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (ge
 		err = xerrors.Errorf("failed to parse Type from MarshalUtil: %w", err)
 		return
 	}
-	if genericDataPayload.data, err = marshalUtil.ReadBytes(int(payloadSize)); err != nil {
+	if genericDataPayload.data, err = marshalUtil.ReadBytes(int(payloadSize) - TypeLength); err != nil {
 		err = xerrors.Errorf("failed to parse data (%v): %w", err, cerrors.ErrParseBytesFailed)
 		return
 	}

--- a/packages/tangle/payload/payload.go
+++ b/packages/tangle/payload/payload.go
@@ -57,7 +57,7 @@ func FromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (payload Payload, err
 	}
 
 	marshalUtil.ReadSeek(-marshalutil.Uint32Size * 2)
-	payloadBytes, err := marshalUtil.ReadBytes(int(payloadSize) + 8)
+	payloadBytes, err := marshalUtil.ReadBytes(int(payloadSize) + 4)
 	if err != nil {
 		err = xerrors.Errorf("failed to unmarshal payload bytes (%v): %w", err, cerrors.ErrParseBytesFailed)
 		return

--- a/packages/tangle/payload/type.go
+++ b/packages/tangle/payload/type.go
@@ -10,6 +10,9 @@ import (
 	"golang.org/x/xerrors"
 )
 
+// TypeLength contains the amount of bytes of a marshaled Type.
+const TypeLength = marshalutil.Uint32Size
+
 // Type represents the Type of a payload.
 type Type uint32
 

--- a/packages/vote/statement/payload.go
+++ b/packages/vote/statement/payload.go
@@ -125,7 +125,7 @@ func Parse(marshalUtil *marshalutil.MarshalUtil) (statement *Statement, err erro
 
 	// return the number of bytes we processed
 	parsedBytes = marshalUtil.ReadOffset() - readStartOffset
-	if parsedBytes != int(payloadSize)+8 { //skip the payload size and type
+	if parsedBytes != int(payloadSize)+4 { //skip the payload size
 		err = xerrors.Errorf("parsed bytes (%d) did not match expected size (%d): %w", parsedBytes, payloadSize, cerrors.ErrParseBytesFailed)
 		return
 	}

--- a/packages/vote/statement/payload.go
+++ b/packages/vote/statement/payload.go
@@ -165,7 +165,7 @@ func (s *Statement) Bytes() (bytes []byte) {
 
 	// add uint32 for length and type
 	return marshalutil.New(2*marshalutil.Uint32Size + payloadBytesLength).
-		WriteUint32(uint32(payloadBytesLength)).
+		WriteUint32(payload.TypeLength + uint32(payloadBytesLength)).
 		Write(StatementType).
 		WriteBytes(payloadBytes).
 		Bytes()

--- a/plugins/faucet/request.go
+++ b/plugins/faucet/request.go
@@ -104,7 +104,7 @@ func (p *Request) Bytes() []byte {
 	marshalUtil := marshalutil.New()
 
 	// marshal the payload specific information
-	marshalUtil.WriteUint32(uint32(address.Length + pow.NonceBytes))
+	marshalUtil.WriteUint32(payload.TypeLength + uint32(address.Length+pow.NonceBytes))
 	marshalUtil.WriteBytes(p.Type().Bytes())
 	marshalUtil.WriteBytes(p.address.Bytes())
 	marshalUtil.WriteUint64(p.nonce)

--- a/plugins/networkdelay/object.go
+++ b/plugins/networkdelay/object.go
@@ -110,7 +110,7 @@ func (o *Object) Bytes() (bytes []byte) {
 	marshalUtil := marshalutil.New(marshalutil.Uint32Size + marshalutil.Uint32Size + objectLength)
 
 	// marshal the payload specific information
-	marshalUtil.WriteUint32(uint32(objectLength))
+	marshalUtil.WriteUint32(payload.TypeLength + uint32(objectLength))
 	marshalUtil.WriteBytes(Type.Bytes())
 	marshalUtil.WriteBytes(o.id[:])
 	marshalUtil.WriteInt64(o.sentTime)

--- a/plugins/syncbeacon/payload/payload.go
+++ b/plugins/syncbeacon/payload/payload.go
@@ -82,7 +82,7 @@ func (p *Payload) Bytes() []byte {
 	objectLength := marshalutil.Int64Size
 
 	// marshal the p specific information
-	marshalUtil.WriteUint32(uint32(objectLength))
+	marshalUtil.WriteUint32(payload.TypeLength + uint32(objectLength))
 	marshalUtil.WriteBytes(Type.Bytes())
 	marshalUtil.WriteInt64(p.sentTime)
 

--- a/tools/integration-tests/runTests.sh
+++ b/tools/integration-tests/runTests.sh
@@ -6,7 +6,7 @@ echo "Build GoShimmer image"
 docker build -t iotaledger/goshimmer ../../.
 
 echo "Pull additional Docker images"
-docker pull angelocapossele/drand:1.1.3
+docker pull angelocapossele/drng:payloadfix
 docker pull gaiaadm/pumba:0.7.2
 docker pull gaiadocker/iproute2:latest
 

--- a/tools/integration-tests/tester/framework/docker.go
+++ b/tools/integration-tests/tester/framework/docker.go
@@ -148,7 +148,7 @@ func (d *DockerContainer) CreateDrandMember(name string, goShimmerAPI string, le
 	}
 	env = append(env, "GOSHIMMER=http://"+goShimmerAPI)
 	containerConfig := &container.Config{
-		Image: "angelocapossele/drand:1.1.3",
+		Image: "angelocapossele/drng:payloadfix",
 		ExposedPorts: nat.PortSet{
 			nat.Port("8000/tcp"): {},
 		},


### PR DESCRIPTION
# Description of change

Payloads get marshaled as an Array of bytes which is encoded as `[lengthOfBytes][bytes]`.  The first 4 bytes of every Payload start with its type so we can generically process different payload types accordingly. The type is however part of the serialized payload and therefore part of the size info at the beginning. The size was previously encoded without counting the 4 bytes of the type.

This PR fixes this problem.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
