### PR TITLE
feat: Load old messages in visualizer

### DIFF
--- a/plugins/dashboard/frontend/src/app/components/Root.tsx
+++ b/plugins/dashboard/frontend/src/app/components/Root.tsx
@@ -90,6 +90,7 @@ export class Root extends React.Component<Props, any> {
                     <Route exact path="/drng" component={Drng}/>
                     <Route exact path="/explorer" component={Explorer}/>
                     <Route exact path="/visualizer" component={Visualizer}/>
+                    <Route exact path="/visualizer/history" component={Visualizer}/>
                     <Route exact path="/faucet" component={Faucet}/>
                     <Redirect to="/dashboard"/>
                 </Switch>

--- a/plugins/dashboard/frontend/src/app/stores/VisualizerStore.ts
+++ b/plugins/dashboard/frontend/src/app/stores/VisualizerStore.ts
@@ -16,6 +16,10 @@ export class TipInfo {
     is_tip: boolean;
 }
 
+class history {
+    vertices: Array<Vertex>;
+}
+
 const vertexSize = 20;
 
 export class VisualizerStore {
@@ -24,7 +28,7 @@ export class VisualizerStore {
     @observable solid_count = 0;
     @observable tips_count = 0;
     verticesIncomingOrder = [];
-    collect: boolean = false;
+    draw: boolean = false;
     routerStore: RouterStore;
 
     // the currently selected vertex via hover
@@ -45,8 +49,22 @@ export class VisualizerStore {
 
     constructor(routerStore: RouterStore) {
         this.routerStore = routerStore;
+        this.fetchHistory();
         registerHandler(WSMsgType.Vertex, this.addVertex);
-        registerHandler(WSMsgType.TipInfo, this.addTipInfo);
+        registerHandler(WSMsgType.TipInfo, this.addTipInfo);     
+    }
+
+    fetchHistory = async () => {
+        try {
+            let res = await fetch(`/api/visualizer/history`);           
+            let history: history = await res.json();
+            history.vertices.forEach(v => {
+               this.addVertex(v); 
+            });
+        } catch (err) {
+            console.log("Fail to fetch history in visualizer", err);
+        }
+        return
     }
 
     @action
@@ -87,9 +105,7 @@ export class VisualizerStore {
     }
 
     @action
-    addVertex = (vert: Vertex) => {
-        if (!this.collect) return;
-
+    addVertex = (vert: Vertex) => {        
         let existing = this.vertices.get(vert.id);
         if (existing) {
             // can only go from unsolid to solid
@@ -131,12 +147,13 @@ export class VisualizerStore {
         }
 
         this.vertices.set(vert.id, vert);
-        this.drawVertex(vert);
+        if (this.draw) {
+            this.drawVertex(vert);
+        }
     };
 
     @action
     addTipInfo = (tipInfo: TipInfo) => {
-        if (!this.collect) return;
         let vert = this.vertices.get(tipInfo.id);
         if (!vert) {
             // create a new empty one for now
@@ -148,7 +165,9 @@ export class VisualizerStore {
         this.tips_count += tipInfo.is_tip ? 1 : vert.is_tip ? -1 : 0;
         vert.is_tip = tipInfo.is_tip;
         this.vertices.set(vert.id, vert);
-        this.drawVertex(vert);
+        if (this.draw) {
+            this.drawVertex(vert);
+        }
     };
 
     @action
@@ -161,7 +180,9 @@ export class VisualizerStore {
                 this.clearSelected();
             }
             this.vertices.delete(deleteId);
-            this.graph.removeNode(deleteId);
+            if (this.draw) {
+                this.graph.removeNode(deleteId);
+            }
             if (!vert) {
                 continue;
             }
@@ -198,7 +219,9 @@ export class VisualizerStore {
             }
             this.vertices.delete(approveeId);
         }
-        this.graph.removeNode(approveeId);
+        if (this.draw) {
+            this.graph.removeNode(approveeId);
+        }
     }
 
     drawVertex = (vert: Vertex) => {
@@ -243,7 +266,7 @@ export class VisualizerStore {
     }
 
     start = () => {
-        this.collect = true;
+        this.draw = true;
         this.graph = Viva.Graph.graph();
 
         let graphics: any = Viva.Graph.View.webglGraphics();
@@ -280,17 +303,18 @@ export class VisualizerStore {
         });
         this.graphics = graphics;
         this.renderer.run();
+
+        this.vertices.forEach((vertex) => {
+            this.drawVertex(vertex)
+        })
     }
 
     stop = () => {
-        this.collect = false;
+        this.draw = false;
         this.renderer.dispose();
         this.graph = null;
         this.paused = false;
         this.selected = null;
-        this.solid_count = 0;
-        this.tips_count = 0;
-        this.vertices.clear();
     }
 
     @action

--- a/plugins/dashboard/routes.go
+++ b/plugins/dashboard/routes.go
@@ -89,6 +89,7 @@ func setupRoutes(e *echo.Echo) {
 
 	setupExplorerRoutes(apiRoutes)
 	setupFaucetRoutes(apiRoutes)
+	setupVisualizerRoutes(apiRoutes)
 
 	e.HTTPErrorHandler = func(err error, c echo.Context) {
 		log.Warnf("Request failed: %s", err)

--- a/plugins/dashboard/visualizer.go
+++ b/plugins/dashboard/visualizer.go
@@ -1,18 +1,28 @@
 package dashboard
 
 import (
+	"net/http"
+	"sync"
+
 	"github.com/iotaledger/goshimmer/packages/shutdown"
 	"github.com/iotaledger/goshimmer/packages/tangle"
 	"github.com/iotaledger/goshimmer/plugins/messagelayer"
 	"github.com/iotaledger/hive.go/daemon"
 	"github.com/iotaledger/hive.go/events"
 	"github.com/iotaledger/hive.go/workerpool"
+
+	"github.com/labstack/echo"
 )
 
 var (
 	visualizerWorkerCount     = 1
 	visualizerWorkerQueueSize = 500
 	visualizerWorkerPool      *workerpool.WorkerPool
+
+	msgHistoryMutex   sync.RWMutex
+	msgSolid          map[string]bool
+	msgHistory        []*tangle.Message
+	maxMsgHistorySize = 1000
 )
 
 // vertex defines a vertex in a DAG.
@@ -29,6 +39,11 @@ type tipinfo struct {
 	IsTip bool   `json:"is_tip"`
 }
 
+// history holds a set of vertices in a DAG.
+type history struct {
+	Vertices []vertex `json:"vertices"`
+}
+
 func configureVisualizer() {
 	visualizerWorkerPool = workerpool.New(func(task workerpool.Task) {
 
@@ -41,6 +56,10 @@ func configureVisualizer() {
 
 		task.Return(nil)
 	}, workerpool.WorkerCount(visualizerWorkerCount), workerpool.QueueSize(visualizerWorkerQueueSize))
+
+	// configure msgHistory, msgSolid
+	msgSolid = make(map[string]bool, maxMsgHistorySize)
+	msgHistory = make([]*tangle.Message, 0, maxMsgHistorySize)
 }
 
 func sendVertex(cachedMessage *tangle.CachedMessage, cachedMessageMetadata *tangle.CachedMessageMetadata) {
@@ -70,6 +89,14 @@ func runVisualizer() {
 	notifyNewMsg := events.NewClosure(func(cachedMsgEvent *tangle.CachedMessageEvent) {
 		defer cachedMsgEvent.Message.Release()
 		defer cachedMsgEvent.MessageMetadata.Release()
+
+		// manage message history
+		msg := cachedMsgEvent.Message.Unwrap()
+		if msg == nil {
+			return
+		}
+		addToHistory(msg, cachedMsgEvent.MessageMetadata.Unwrap().IsSolid())
+
 		_, ok := visualizerWorkerPool.TrySubmit(cachedMsgEvent.Message.Retain(), cachedMsgEvent.MessageMetadata.Retain())
 		if !ok {
 			cachedMsgEvent.Message.Release()
@@ -102,4 +129,47 @@ func runVisualizer() {
 	}, shutdown.PriorityDashboard); err != nil {
 		log.Panicf("Failed to start as daemon: %s", err)
 	}
+}
+
+func setupVisualizerRoutes(routeGroup *echo.Group) {
+	routeGroup.GET("/visualizer/history", func(c echo.Context) (err error) {
+		msgHistoryMutex.RLock()
+		cpyHistory := make([]*tangle.Message, len(msgHistory))
+		copy(cpyHistory, msgHistory)
+		msgHistoryMutex.RUnlock()
+
+		var res []vertex
+		for _, msg := range cpyHistory {
+			res = append(res, vertex{
+				ID:              msg.ID().String(),
+				StrongParentIDs: msg.StrongParents().ToStrings(),
+				WeakParentIDs:   msg.WeakParents().ToStrings(),
+				IsSolid:         msgSolid[msg.ID().String()],
+			})
+		}
+
+		return c.JSON(http.StatusOK, history{Vertices: res})
+	})
+}
+
+func addToHistory(msg *tangle.Message, solid bool) {
+	msgHistoryMutex.Lock()
+	defer msgHistoryMutex.Unlock()
+	if _, exist := msgSolid[msg.ID().String()]; exist {
+		msgSolid[msg.ID().String()] = solid
+		return
+	}
+
+	// remove 100 old msgs if the slice is full
+	if len(msgHistory) >= maxMsgHistorySize {
+		for i := 0; i < 100; i++ {
+			delete(msgSolid, msgHistory[i].ID().String())
+		}
+		msgHistory = append(msgHistory[:0], msgHistory[100:maxMsgHistorySize]...)
+	}
+	// add new msg
+	msgHistory = append(msgHistory, msg)
+	msgSolid[msg.ID().String()] = solid
+
+	return
 }

--- a/plugins/dashboard/visualizer.go
+++ b/plugins/dashboard/visualizer.go
@@ -170,6 +170,4 @@ func addToHistory(msg *tangle.Message, solid bool) {
 	// add new msg
 	msgHistory = append(msgHistory, msg)
 	msgSolid[msg.ID().String()] = solid
-
-	return
 }


### PR DESCRIPTION
# Description of change

* node manages a list of 1000 msgs as history, which will be sent to the visualizer
* request old messages in visualizer constructor
* keep collecting incoming messages and update `vertices` in the background
* draw the existing `vertices` first when switching to the visualizer tab

Fixes #634 

## Type of change
Enhancement

## Change checklist
- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
