### PR TITLE
fix: Fix wrong tips count in visualizer

### DIFF
--- a/plugins/dashboard/frontend/src/app/stores/VisualizerStore.ts
+++ b/plugins/dashboard/frontend/src/app/stores/VisualizerStore.ts
@@ -108,26 +108,6 @@ export class VisualizerStore {
             }
             this.verticesIncomingOrder.push(vert.id);
             this.checkLimit();
-
-            if (vert.strongParentIDs) {
-                // clear tip status of strong and weak parents
-                vert.strongParentIDs.forEach((value, index) => {
-                    let strongParentVert = this.vertices.get(value);
-                    if (strongParentVert) {
-                        strongParentVert.is_tip = false;
-                        this.vertices.set(strongParentVert.id, strongParentVert)
-                    }
-                });
-            }
-            if (vert.weakParentIDs) {
-                vert.weakParentIDs.forEach((value, index) => {
-                    let weakParentVert = this.vertices.get(value);
-                    if (weakParentVert) {
-                        weakParentVert.is_tip = false;
-                        this.vertices.set(weakParentVert.id, weakParentVert)
-                    }
-                });
-            }
         }
 
         this.vertices.set(vert.id, vert);


### PR DESCRIPTION
# Description of change

Since the tip status of the new msg's parents is set to `false` in `addVertex` right before we get the update status from `addTipInfo` (triggered by `TipRemoved` event), this causes the `tips_count` not updated in this line:
 `this.tips_count += tipInfo.is_tip ? 1 : vert.is_tip ? -1 : 0;`.

We can solve this by removing the parents' tip status update in `addVertex`, and leave it to `addTipInfo`. 

## Type of change
 Bug fix
 
## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
