### PR TITLE
prepare faucet

### DIFF
--- a/tools/integration-tests/tester/framework/docker.go
+++ b/tools/integration-tests/tester/framework/docker.go
@@ -111,6 +111,7 @@ func (d *DockerContainer) CreateGoShimmerPeer(config GoShimmerConfig) error {
 				return fmt.Sprintf("--faucet.seed=%s", genesisSeedBase58)
 			}(),
 			fmt.Sprintf("--faucet.tokensPerRequest=%d", ParaFaucetTokensPerRequest),
+			fmt.Sprintf("--faucet.preparedOutputsCounts=%d", config.FaucetPreparedOutputsCount),
 			fmt.Sprintf("--valueLayer.snapshot.file=%s", config.SnapshotFilePath),
 			"--webapi.bindAddress=0.0.0.0:8080",
 			fmt.Sprintf("--autopeering.seed=base58:%s", config.Seed),

--- a/tools/integration-tests/tester/framework/docker.go
+++ b/tools/integration-tests/tester/framework/docker.go
@@ -86,6 +86,7 @@ func (d *DockerContainer) CreateGoShimmerPeer(config GoShimmerConfig) error {
 			fmt.Sprintf("--node.disablePlugins=%s", config.DisabledPlugins),
 			fmt.Sprintf("--pow.difficulty=%d", ParaPoWDifficulty),
 			fmt.Sprintf("--faucet.powDifficulty=%d", ParaPoWFaucetDifficulty),
+			fmt.Sprintf("--faucet.preparedOutputsCounts=%d", ParaFaucetPreparedOutputsCount),
 			fmt.Sprintf("--gracefulshutdown.waitToKillTime=%d", ParaWaitToKill),
 			fmt.Sprintf("--node.enablePlugins=%s", func() string {
 				var plugins []string
@@ -111,7 +112,6 @@ func (d *DockerContainer) CreateGoShimmerPeer(config GoShimmerConfig) error {
 				return fmt.Sprintf("--faucet.seed=%s", genesisSeedBase58)
 			}(),
 			fmt.Sprintf("--faucet.tokensPerRequest=%d", ParaFaucetTokensPerRequest),
-			fmt.Sprintf("--faucet.preparedOutputsCounts=%d", config.FaucetPreparedOutputsCount),
 			fmt.Sprintf("--valueLayer.snapshot.file=%s", config.SnapshotFilePath),
 			"--webapi.bindAddress=0.0.0.0:8080",
 			fmt.Sprintf("--autopeering.seed=base58:%s", config.Seed),

--- a/tools/integration-tests/tester/framework/parameters.go
+++ b/tools/integration-tests/tester/framework/parameters.go
@@ -66,7 +66,8 @@ type GoShimmerConfig struct {
 	DRNGInstance  int
 	DRNGThreshold int
 
-	Faucet bool
+	Faucet                     bool
+	FaucetPreparedOutputsCount int
 
 	SyncBeacon                  bool
 	SyncBeaconFollower          bool

--- a/tools/integration-tests/tester/framework/parameters.go
+++ b/tools/integration-tests/tester/framework/parameters.go
@@ -40,6 +40,8 @@ var (
 	ParaWaitToKill = 60
 	// ParaPoWFaucetDifficulty defines the PoW difficulty for faucet payloads.
 	ParaPoWFaucetDifficulty = 2
+	// ParaFaucetPreparedOutputsCount defines the number of outputs the faucet should prepare.
+	ParaFaucetPreparedOutputsCount = 10
 	// ParaSyncBeaconOnEveryNode defines whether all nodes should be sync beacons.
 	ParaSyncBeaconOnEveryNode = false
 	// ParaManaOnEveryNode defines whether all nodes should have mana enabled.
@@ -66,8 +68,7 @@ type GoShimmerConfig struct {
 	DRNGInstance  int
 	DRNGThreshold int
 
-	Faucet                     bool
-	FaucetPreparedOutputsCount int
+	Faucet bool
 
 	SyncBeacon                  bool
 	SyncBeaconFollower          bool

--- a/tools/integration-tests/tester/tests/faucet/faucetmoveallfunds_test.go
+++ b/tools/integration-tests/tester/tests/faucet/faucetmoveallfunds_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Tests that the faucet splits genesis funds to CfgFaucetPreparedOutputsCount outputs.
+// TestPrepareGenesis tests that the faucet splits genesis funds to CfgFaucetPreparedOutputsCount outputs.
 func TestPrepareGenesis(t *testing.T) {
 	prevPoWDiff := framework.ParaPoWDifficulty
 	framework.ParaPoWDifficulty = 0
@@ -22,10 +22,9 @@ func TestPrepareGenesis(t *testing.T) {
 	defer tests.ShutdownNetwork(t, n)
 
 	faucet, err := n.CreatePeer(framework.GoShimmerConfig{
-		Faucet:                     true,
-		Mana:                       true,
-		FaucetPreparedOutputsCount: 10,
-		SyncBeacon:                 true,
+		Faucet:     true,
+		Mana:       true,
+		SyncBeacon: true,
 	})
 	require.NoError(t, err)
 	time.Sleep(10 * time.Second)

--- a/tools/integration-tests/tester/tests/faucet/faucetmoveallfunds_test.go
+++ b/tools/integration-tests/tester/tests/faucet/faucetmoveallfunds_test.go
@@ -10,12 +10,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestPrepareGenesis tests that the faucet splits genesis funds to CfgFaucetPreparedOutputsCount outputs.
-func TestPrepareGenesis(t *testing.T) {
+// TestPrepareFaucet tests that the faucet prepares outputs to be consumed by faucet requests.
+func TestPrepareFaucet(t *testing.T) {
 	prevPoWDiff := framework.ParaPoWDifficulty
+	prevFaucetPreparedOutputsCount := framework.ParaFaucetPreparedOutputsCount
 	framework.ParaPoWDifficulty = 0
+	framework.ParaFaucetPreparedOutputsCount = 10
 	defer func() {
 		framework.ParaPoWDifficulty = prevPoWDiff
+		framework.ParaFaucetPreparedOutputsCount = prevFaucetPreparedOutputsCount
 	}()
 	n, err := f.CreateNetwork("faucet_testPrepareGenesis", 0, 0, framework.CreateNetworkConfig{Faucet: true})
 	require.NoError(t, err)
@@ -27,8 +30,9 @@ func TestPrepareGenesis(t *testing.T) {
 		SyncBeacon: true,
 	})
 	require.NoError(t, err)
-	time.Sleep(10 * time.Second)
+	time.Sleep(5 * time.Second)
 
+	// Tests genesis output is split into 10 outputs. [1,2,...10] and balance,
 	const genesisBalance = int64(1000000000)
 	var totalSplit int64
 	var i uint64
@@ -40,8 +44,57 @@ func TestPrepareGenesis(t *testing.T) {
 		totalSplit += framework.ParaFaucetTokensPerRequest
 	}
 	balance := genesisBalance - totalSplit
-	addr := faucet.Seed.Address(i).String()
-	outputs, err := faucet.GetUnspentOutputs([]string{addr})
+	faucetAddr := faucet.Seed.Address(i).String()
+	outputs, err := faucet.GetUnspentOutputs([]string{faucetAddr})
 	require.NoError(t, err)
 	assert.Equal(t, balance, outputs.UnspentOutputs[0].OutputIDs[0].Balances[0].Value)
+
+	// add 1 node to the network
+	peer, err := n.CreatePeer(framework.GoShimmerConfig{
+		Mana:       true,
+		SyncBeacon: true,
+	})
+	require.NoError(t, err)
+
+	err = n.WaitForAutopeering(1)
+	require.NoError(t, err)
+	time.Sleep(5 * time.Second)
+
+	// issue 9 requests to consume the 1st 9 faucet prepared outputs.
+	for i = 0; i < 9; i++ {
+		addr := peer.Address(i).Address
+		tests.SendFaucetRequest(t, peer, addr)
+	}
+	time.Sleep(5 * time.Second)
+
+	// 1 prepared output is left on the 10th address.
+	lastPreparedOutputAddress := faucet.Seed.Address(10).String()
+	lastPreparedOutput, err := faucet.GetUnspentOutputs([]string{lastPreparedOutputAddress})
+	require.NoError(t, err)
+	assert.Equal(t, framework.ParaFaucetTokensPerRequest, lastPreparedOutput.UnspentOutputs[0].OutputIDs[0].Balances[0].Value)
+
+	// check balance is untouched
+	balanceOutputAddress := faucet.Seed.Address(11).String()
+	balanceOutput, err := faucet.GetUnspentOutputs([]string{balanceOutputAddress})
+	require.NoError(t, err)
+	assert.Equal(t, genesisBalance-(10*framework.ParaFaucetTokensPerRequest), balanceOutput.UnspentOutputs[0].OutputIDs[0].Balances[0].Value)
+
+	// issue 1 more request to split the balance at [11]
+	addr := peer.Seed.Address(10).Address
+	tests.SendFaucetRequest(t, peer, addr)
+	time.Sleep(2 * time.Second)
+
+	// check split of balance [11] to [12...21]
+	_addr := faucet.Seed.Address(11).String()
+	outputs, err = faucet.GetUnspentOutputs([]string{_addr})
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(outputs.UnspentOutputs[0].OutputIDs)) //output is spent.
+
+	for i := 12; i < 22; i++ {
+		_addr := faucet.Seed.Address(uint64(i)).String()
+		outputs, err = faucet.GetUnspentOutputs([]string{_addr})
+		require.NoError(t, err)
+		assert.Equal(t, framework.ParaFaucetTokensPerRequest, outputs.UnspentOutputs[0].OutputIDs[0].Balances[0].Value)
+	}
+
 }


### PR DESCRIPTION
Prepares `x` faucet outputs to be consumed on requests. Keeps the balance in another output. When prepared outputs are all consumed, prepare more.

Fixes #916 