### PR TITLE
feat: Introduce invalid to MessageMetadata

### DIFF
--- a/packages/tangle/messagemetadata.go
+++ b/packages/tangle/messagemetadata.go
@@ -220,7 +220,7 @@ func (m *MessageMetadata) SetEligible(eligible bool) (modified bool) {
 	m.eligibleMutex.Lock()
 	defer m.eligibleMutex.Unlock()
 
-	if m.eligble == eligible {
+	if m.eligible == eligible {
 		return false
 	}
 

--- a/packages/tangle/messagemetadata.go
+++ b/packages/tangle/messagemetadata.go
@@ -171,21 +171,16 @@ func (m *MessageMetadata) IsEligible() (result bool) {
 // SetBooked sets the message associated with this metadata as booked.
 // It returns true if the booked status is modified. False otherwise.
 func (m *MessageMetadata) SetBooked(booked bool) (modified bool) {
-	m.bookedMutex.RLock()
-	if m.booked != booked {
-		m.bookedMutex.RUnlock()
+	m.bookedMutex.Lock()
+	defer m.bookedMutex.Unlock()
 
-		m.bookedMutex.Lock()
-		if m.booked != booked {
-			m.booked = booked
-			m.SetModified()
-			modified = true
-		}
-		m.bookedMutex.Unlock()
-
-	} else {
-		m.bookedMutex.RUnlock()
+	if m.booked == booked {
+		return false
 	}
+
+	m.booked = booked
+	m.SetModified()
+	modified = true
 
 	return
 }
@@ -222,22 +217,16 @@ func (m *MessageMetadata) SetTimestampOpinion(timestampOpinion TimestampOpinion)
 // SetEligible sets the message associated with this metadata as eligible.
 // It returns true if the eligible status is modified. False otherwise.
 func (m *MessageMetadata) SetEligible(eligible bool) (modified bool) {
-	m.eligibleMutex.RLock()
-	if m.eligible != eligible {
-		m.eligibleMutex.RUnlock()
+	m.eligibleMutex.Lock()
+	defer m.eligibleMutex.Unlock()
 
-		m.eligibleMutex.Lock()
-		if m.eligible != eligible {
-			m.eligible = eligible
-			m.SetModified()
-
-			modified = true
-		}
-		m.eligibleMutex.Unlock()
-
-	} else {
-		m.eligibleMutex.RUnlock()
+	if m.eligble == eligible {
+		return false
 	}
+
+	m.eligible = eligible
+	m.SetModified()
+	modified = true
 
 	return
 }
@@ -254,22 +243,16 @@ func (m *MessageMetadata) IsInvalid() (result bool) {
 // SetInvalid sets the message associated with this metadata as invalid.
 // It returns true if the invalid status is modified. False otherwise.
 func (m *MessageMetadata) SetInvalid(invalid bool) (modified bool) {
-	m.invalidMutex.RLock()
-	if m.invalid != invalid {
-		m.invalidMutex.RUnlock()
+	m.invalidMutex.Lock()
+	defer m.invalidMutex.Unlock()
 
-		m.invalidMutex.Lock()
-		if m.invalid != invalid {
-			m.invalid = invalid
-			m.SetModified()
-
-			modified = true
-		}
-		m.invalidMutex.Unlock()
-
-	} else {
-		m.invalidMutex.RUnlock()
+	if m.invalid == invalid {
+		return false
 	}
+
+	m.invalid = invalid
+	m.SetModified()
+	modified = true
 
 	return
 }

--- a/packages/tangle/messagemetadata.go
+++ b/packages/tangle/messagemetadata.go
@@ -107,8 +107,8 @@ func (m *MessageMetadata) ReceivedTime() time.Time {
 // IsSolid returns true if the message represented by this metadata is solid. False otherwise.
 func (m *MessageMetadata) IsSolid() (result bool) {
 	m.solidMutex.RLock()
+	defer m.solidMutex.RUnlock()
 	result = m.solid
-	m.solidMutex.RUnlock()
 
 	return
 }
@@ -153,8 +153,8 @@ func (m *MessageMetadata) SolidificationTime() time.Time {
 // IsBooked returns true if the message represented by this metadata is booked. False otherwise.
 func (m *MessageMetadata) IsBooked() (result bool) {
 	m.bookedMutex.RLock()
+	defer m.bookedMutex.RUnlock()
 	result = m.booked
-	m.bookedMutex.RUnlock()
 
 	return
 }
@@ -162,8 +162,8 @@ func (m *MessageMetadata) IsBooked() (result bool) {
 // IsEligible returns true if the message represented by this metadata is eligible. False otherwise.
 func (m *MessageMetadata) IsEligible() (result bool) {
 	m.eligibleMutex.RLock()
+	defer m.eligibleMutex.RUnlock()
 	result = m.eligible
-	m.eligibleMutex.RUnlock()
 
 	return
 }
@@ -234,8 +234,8 @@ func (m *MessageMetadata) SetEligible(eligible bool) (modified bool) {
 // IsInvalid returns true if the message represented by this metadata is invalid. False otherwise.
 func (m *MessageMetadata) IsInvalid() (result bool) {
 	m.invalidMutex.RLock()
+	defer m.invalidMutex.RUnlock()
 	result = m.invalid
-	m.invalidMutex.RUnlock()
 
 	return
 }

--- a/packages/tangle/solidifier.go
+++ b/packages/tangle/solidifier.go
@@ -202,7 +202,7 @@ func (t *Tangle) isAgeOfParentValid(childTime time.Time, parentID MessageID) boo
 
 // checks whether parents of the given message are valid.
 func (t *Tangle) isParentsValid(msg *Message) bool {
-	if msg == nil {
+	if msg == nil || msg.IsDeleted() {
 		return false
 	}
 
@@ -214,7 +214,7 @@ func (t *Tangle) isParentsValid(msg *Message) bool {
 	return valid
 }
 
-// checks whether parent is valid.
+// checks whether the given message is valid.
 func (t *Tangle) isMessageValid(messageID MessageID) bool {
 	if messageID == EmptyMessageID {
 		return true

--- a/packages/tangle/solidifier.go
+++ b/packages/tangle/solidifier.go
@@ -94,12 +94,15 @@ func (t *Tangle) checkMessageSolidityAndPropagate(cachedMessage *CachedMessage, 
 
 		// check if the parents are solid
 		if t.isMessageSolid(currentMessage, currentMsgMetadata) {
-			// check parents age
-			valid := t.checkParentsMaxDepth(currentMessage)
+			// check if parents are valid and parents age
+			valid := t.isParentsValid(currentMessage) && t.checkParentsMaxDepth(currentMessage)
 			if !valid {
-				t.Events.MessageInvalid.Trigger(&CachedMessageEvent{
-					Message:         currentCachedMessage,
-					MessageMetadata: currentCachedMsgMetadata})
+				// set the message invalid, trigger MessageInvalid event only if the msg is first set to invalid
+				if currentMsgMetadata.SetInvalid(true) {
+					t.Events.MessageInvalid.Trigger(&CachedMessageEvent{
+						Message:         currentCachedMessage,
+						MessageMetadata: currentCachedMsgMetadata})
+				}
 				currentCachedMessage.Release()
 				currentCachedMsgMetadata.Release()
 				continue
@@ -195,6 +198,39 @@ func (t *Tangle) isAgeOfParentValid(childTime time.Time, parentID MessageID) boo
 	}
 
 	return true
+}
+
+// checks whether parents of the given message are valid.
+func (t *Tangle) isParentsValid(msg *Message) bool {
+	if msg == nil {
+		return false
+	}
+
+	valid := true
+	msg.ForEachParent(func(parent Parent) {
+		valid = valid && t.isMessageValid(parent.ID)
+	})
+
+	return valid
+}
+
+// checks whether parent is valid.
+func (t *Tangle) isMessageValid(messageID MessageID) bool {
+	if messageID == EmptyMessageID {
+		return true
+	}
+
+	// retrieve the CachedMessageMetadata
+	cachedMsgMetadata := t.MessageMetadata(messageID)
+	defer cachedMsgMetadata.Release()
+
+	// return false if the message metadata does not exist
+	msgMetadata := cachedMsgMetadata.Unwrap()
+	if msgMetadata == nil {
+		return false
+	}
+
+	return !msgMetadata.IsInvalid()
 }
 
 // CheckParentsEligibility checks if the parents are eligible, then set the eligible flag of the message.

--- a/plugins/messagelayer/plugin.go
+++ b/plugins/messagelayer/plugin.go
@@ -133,14 +133,6 @@ func configure(*node.Plugin) {
 		cachedMsgEvent.Message.Consume(tipSelector.AddTip)
 	}))
 
-	// setup messageStore cleaner
-	_tangle.Events.MessageInvalid.Attach(events.NewClosure(func(cachedMsgEvent *tangle.CachedMessageEvent) {
-		cachedMsgEvent.MessageMetadata.Release()
-		cachedMsgEvent.Message.Consume(func(msg *tangle.Message) {
-			_tangle.DeleteMessage(msg.ID())
-		})
-	}))
-
 	MessageRequester().Events.MissingMessageAppeared.Attach(events.NewClosure(func(missingMessageAppeared *tangle.MissingMessageAppearedEvent) {
 		_tangle.DeleteMissingMessage(missingMessageAppeared.ID)
 	}))

--- a/plugins/messagelayer/plugin.go
+++ b/plugins/messagelayer/plugin.go
@@ -133,6 +133,14 @@ func configure(*node.Plugin) {
 		cachedMsgEvent.Message.Consume(tipSelector.AddTip)
 	}))
 
+	// setup messageStore cleaner
+	_tangle.Events.MessageInvalid.Attach(events.NewClosure(func(cachedMsgEvent *tangle.CachedMessageEvent) {
+		cachedMsgEvent.MessageMetadata.Release()
+		cachedMsgEvent.Message.Consume(func(msg *tangle.Message) {
+			_tangle.DeleteMessage(msg.ID())
+		})
+	}))
+
 	MessageRequester().Events.MissingMessageAppeared.Attach(events.NewClosure(func(missingMessageAppeared *tangle.MissingMessageAppearedEvent) {
 		_tangle.DeleteMissingMessage(missingMessageAppeared.ID)
 	}))


### PR DESCRIPTION
# Description of change

Mark the message as invalid when:
* at least one of its parent is invalid
* at least one parent doesn't pass the parents age check

## Type of change
- Enhancement

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
