### PR TITLE
feat: Avoid gossiping requested messages

### DIFF
--- a/plugins/gossip/gossip.go
+++ b/plugins/gossip/gossip.go
@@ -120,8 +120,6 @@ func (r *requestedMessages) append(msgID tangle.MessageID) {
 	defer r.Unlock()
 
 	r.msgs[msgID] = types.Void
-
-	return
 }
 
 func (r *requestedMessages) delete(msgID tangle.MessageID) (deleted bool) {

--- a/plugins/gossip/gossip.go
+++ b/plugins/gossip/gossip.go
@@ -16,6 +16,7 @@ import (
 	"github.com/iotaledger/hive.go/autopeering/peer/service"
 	"github.com/iotaledger/hive.go/logger"
 	"github.com/iotaledger/hive.go/netutil"
+	"github.com/iotaledger/hive.go/types"
 )
 
 var (
@@ -99,4 +100,38 @@ func loadMessage(msgID tangle.MessageID) ([]byte, error) {
 	}
 	msg := cachedMessage.Unwrap()
 	return msg.Bytes(), nil
+}
+
+// requestedMessages represents a list of requested messages that will not be gossiped.
+type requestedMessages struct {
+	sync.Mutex
+
+	msgs map[tangle.MessageID]types.Empty
+}
+
+func newRequestedMessages() *requestedMessages {
+	return &requestedMessages{
+		msgs: make(map[tangle.MessageID]types.Empty),
+	}
+}
+
+func (r *requestedMessages) append(msgID tangle.MessageID) {
+	r.Lock()
+	defer r.Unlock()
+
+	r.msgs[msgID] = types.Void
+
+	return
+}
+
+func (r *requestedMessages) delete(msgID tangle.MessageID) (deleted bool) {
+	r.Lock()
+	defer r.Unlock()
+
+	if _, exist := r.msgs[msgID]; exist {
+		delete(r.msgs, msgID)
+		return true
+	}
+
+	return false
 }

--- a/plugins/gossip/plugin.go
+++ b/plugins/gossip/plugin.go
@@ -31,7 +31,7 @@ var (
 	ageThreshold            time.Duration
 	tipsBroadcasterInterval time.Duration
 
-	requestedMsgs map[tangle.MessageID]types.Empty
+	requestedMsgs     map[tangle.MessageID]types.Empty
 	requestedMsgMutex sync.Mutex
 )
 
@@ -143,7 +143,7 @@ func configureMessageLayer() {
 		}
 
 		msg := cachedMsgEvent.Message.Unwrap()
-		
+
 		// do not gossip requested messages
 		requestedMsgMutex.Lock()
 		if _, exist := requestedMsgs[msg.ID()]; exist {

--- a/plugins/gossip/plugin.go
+++ b/plugins/gossip/plugin.go
@@ -16,6 +16,7 @@ import (
 	"github.com/iotaledger/hive.go/events"
 	"github.com/iotaledger/hive.go/logger"
 	"github.com/iotaledger/hive.go/node"
+	"github.com/iotaledger/hive.go/types"
 )
 
 // PluginName is the name of the gossip plugin.
@@ -29,6 +30,9 @@ var (
 	log                     *logger.Logger
 	ageThreshold            time.Duration
 	tipsBroadcasterInterval time.Duration
+
+	requestedMsgs map[tangle.MessageID]types.Empty
+	requestedMsgMutex sync.Mutex
 )
 
 // Plugin gets the plugin instance.
@@ -43,6 +47,7 @@ func configure(*node.Plugin) {
 	log = logger.NewLogger(PluginName)
 	ageThreshold = config.Node().Duration(CfgGossipAgeThreshold)
 	tipsBroadcasterInterval = config.Node().Duration(CfgGossipTipsBroadcastInterval)
+	requestedMsgs = make(map[tangle.MessageID]types.Empty)
 
 	configureLogging()
 	configureMessageLayer()
@@ -138,11 +143,40 @@ func configureMessageLayer() {
 		}
 
 		msg := cachedMsgEvent.Message.Unwrap()
+		
+		// do not gossip requested messages
+		requestedMsgMutex.Lock()
+		if _, exist := requestedMsgs[msg.ID()]; exist {
+			delete(requestedMsgs, msg.ID())
+			return
+		}
+		requestedMsgMutex.Unlock()
+
 		mgr.SendMessage(msg.Bytes())
 	}))
 
 	// request missing messages
 	messagelayer.MessageRequester().Events.SendRequest.Attach(events.NewClosure(func(sendRequest *tangle.SendRequestEvent) {
 		mgr.RequestMessage(sendRequest.ID[:])
+	}))
+
+	messagelayer.Tangle().MessageStore.Events.MissingMessageReceived.Attach(events.NewClosure(func(cachedMsgEvent *tangle.CachedMessageEvent) {
+		cachedMsgEvent.MessageMetadata.Release()
+		cachedMsgEvent.Message.Consume(func(msg *tangle.Message) {
+			requestedMsgMutex.Lock()
+			requestedMsgs[msg.ID()] = types.Void
+			requestedMsgMutex.Unlock()
+		})
+	}))
+
+	// delete the message from requestedMsg if it's invalid, otherwise it will always be in the list but never get removed in some cases.
+	messagelayer.Tangle().Events.MessageInvalid.Attach(events.NewClosure(func(cachedMsgEvent *tangle.CachedMessageEvent) {
+		cachedMsgEvent.MessageMetadata.Release()
+
+		cachedMsgEvent.Message.Consume(func(msg *tangle.Message) {
+			requestedMsgMutex.Lock()
+			delete(requestedMsgs, msg.ID())
+			requestedMsgMutex.Unlock()
+		})
 	}))
 }


### PR DESCRIPTION
# Description of change

* Add `requestedMsgs` to record requested messages
* Insert messages to `requestedMsgs` in `MissingMessageReceived` event
* Remove messages in `MessageSolid` and `MessageInvalid` event
* Add a check in `MessageSolid` event so that we won't gossip the requested message

Close #928 

## Type of change

- Enhancement

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
