### PR TITLE
Finalize Transaction Layout

### DIFF
--- a/packages/ledgerstate/transaction_test.go
+++ b/packages/ledgerstate/transaction_test.go
@@ -2,8 +2,10 @@ package ledgerstate
 
 import (
 	"testing"
+	"time"
 
 	"github.com/iotaledger/hive.go/crypto/ed25519"
+	"github.com/iotaledger/hive.go/identity"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,6 +34,9 @@ func TestTransaction_Complex(t *testing.T) {
 
 	// party1 prepares a TransactionEssence that party2 is supposed to complete for the exchange of tokens
 	sentParty1Essence := NewTransactionEssence(0,
+		time.Now(),
+		identity.ID{},
+		identity.ID{},
 		// he consumes 200 tokens of Color2
 		NewInputs(unspentOutputsDB[party1ControlledOutputID].Input()),
 
@@ -52,6 +57,9 @@ func TestTransaction_Complex(t *testing.T) {
 
 	// party2 completes the prepared TransactionEssence by adding his Inputs and his Outputs
 	completedEssence := NewTransactionEssence(0,
+		receivedParty1Essence.Timestamp(),
+		receivedParty1Essence.AccessPledgeID(),
+		receivedParty1Essence.ConsensusPledgeID(),
 		NewInputs(append(receivedParty1Essence.Inputs(), unspentOutputsDB[party2ControlledOutputID].Input())...),
 		NewOutputs(append(receivedParty1Essence.Outputs(),
 			// he wants to receive 100 tokens of Color2 on his destination address

--- a/packages/ledgerstate/utxo_dag_test.go
+++ b/packages/ledgerstate/utxo_dag_test.go
@@ -3,8 +3,10 @@ package ledgerstate
 import (
 	"math"
 	"testing"
+	"time"
 
 	"github.com/iotaledger/hive.go/crypto/ed25519"
+	"github.com/iotaledger/hive.go/identity"
 	"github.com/iotaledger/hive.go/kvstore/mapdb"
 	"github.com/iotaledger/hive.go/objectstorage"
 	"github.com/iotaledger/hive.go/types"
@@ -666,7 +668,7 @@ func singleInputTransaction(utxoDAG *UTXODAG, a, b wallet, outputToSpend *SigLoc
 	input := NewUTXOInput(outputToSpend.ID())
 	output := NewSigLockedSingleOutput(100, b.address)
 
-	txEssence := NewTransactionEssence(0, NewInputs(input), NewOutputs(output))
+	txEssence := NewTransactionEssence(0, time.Now(), identity.ID{}, identity.ID{}, NewInputs(input), NewOutputs(output))
 
 	tx := NewTransaction(txEssence, a.unlockBlocks(txEssence))
 
@@ -705,7 +707,7 @@ func multipleInputsTransaction(utxoDAG *UTXODAG, a, b wallet, outputsToSpend []*
 
 	output := NewSigLockedSingleOutput(100, b.address)
 
-	txEssence := NewTransactionEssence(0, inputs, NewOutputs(output))
+	txEssence := NewTransactionEssence(0, time.Now(), identity.ID{}, identity.ID{}, inputs, NewOutputs(output))
 
 	tx := NewTransaction(txEssence, a.unlockBlocks(txEssence))
 
@@ -755,7 +757,7 @@ func buildTransaction(utxoDAG *UTXODAG, a, b wallet, outputsToSpend []*SigLocked
 
 	output := NewSigLockedSingleOutput(sum, b.address)
 
-	txEssence := NewTransactionEssence(0, inputs, NewOutputs(output))
+	txEssence := NewTransactionEssence(0, time.Now(), identity.ID{}, identity.ID{}, inputs, NewOutputs(output))
 
 	tx := NewTransaction(txEssence, a.unlockBlocks(txEssence))
 


### PR DESCRIPTION
# Description

- Adds transaction timestamp to the transaction essence.
- Adds `accessPledgeID` and `consensusPledgeID` fields to the transaction essence to accomodate for post-mana layout.

Note: client lib and wallet still use the old tx layout from `dapps/valuetransfers`, their integration needs to wait until we switch to using the new `ledgerstate` package.
