### PR TITLE
Handle doc updates in GitHub Actions

### DIFF
--- a/.github/workflows/docker-develop.yml
+++ b/.github/workflows/docker-develop.yml
@@ -1,14 +1,21 @@
-name: Develop
-'on':
+name: Develop Docker Image
+
+on:
   push:
     branches:
       - develop
+    paths-ignore:
+      - 'docs/**'
+
 jobs:
+
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+
+      - name: Checkout repository
         uses: actions/checkout@v2
+
       - name: Publish to Docker Hub
         uses: docker/build-push-action@92e71463491f2d026a477188b8ad3a0fdd9d672c
         with:

--- a/.github/workflows/gh-mdbook.yml
+++ b/.github/workflows/gh-mdbook.yml
@@ -1,24 +1,29 @@
-name: github pages
+name: GoShimmer mdBook
 
 on:
   push:
     branches:
       - develop
+    paths: 
+      - 'docs/**'
 
 jobs:
+
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Check out 
+        uses: actions/checkout@v2
 
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v1
         with:
           mdbook-version: 'latest'
 
-      - run: mdbook build
+      - name: Run mdBook 
+        run: mdbook build
 
-      - name: Deploy
+      - name: Deploy to GitHub Pages
         uses: iotaledger/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gh-mdbook.yml
+++ b/.github/workflows/gh-mdbook.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - develop
-    paths: 
+    paths:
       - 'docs/**'
 
 jobs:
@@ -12,7 +12,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: Check out 
+
+      - name: Checkout repository
         uses: actions/checkout@v2
 
       - name: Setup mdBook
@@ -20,7 +21,7 @@ jobs:
         with:
           mdbook-version: 'latest'
 
-      - name: Run mdBook 
+      - name: Run mdBook
         run: mdbook build
 
       - name: Deploy to GitHub Pages

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,6 +1,9 @@
 name: Integration tests
 
-on: pull_request
+on:
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
 
 jobs:
 
@@ -11,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Check out code
+      - name: Checkout repository
         uses: actions/checkout@v2
 
       - name: Build GoShimmer image
@@ -46,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Check out code
+      - name: Checkout repository
         uses: actions/checkout@v2
 
       - name: Build GoShimmer image
@@ -80,7 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Check out code
+      - name: Checkout repository
         uses: actions/checkout@v2
 
       - name: Build GoShimmer image
@@ -115,7 +118,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Check out code
+      - name: Checkout repository
         uses: actions/checkout@v2
 
       - name: Build GoShimmer image
@@ -151,7 +154,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Check out code
+      - name: Checkout repository
         uses: actions/checkout@v2
 
       - name: Build GoShimmer image
@@ -187,7 +190,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Check out code
+      - name: Checkout repository
         uses: actions/checkout@v2
 
       - name: Build GoShimmer image
@@ -221,7 +224,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Check out code
+      - name: Checkout repository
         uses: actions/checkout@v2
 
       - name: Build GoShimmer image
@@ -255,7 +258,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Check out code
+      - name: Checkout repository
         uses: actions/checkout@v2
 
       - name: Build GoShimmer image

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,20 +1,20 @@
-name: reviewdog
+name: Reviewdog
 
 on: pull_request
 
 jobs:
 
   golangci-lint:
-    name: GolangCI-Lint 
+    name: GolangCI-Lint
     runs-on: ubuntu-latest
     steps:
 
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
-    
-    - name: Run golangci-lint
-      uses: docker://reviewdog/action-golangci-lint:v1.9
-      with:
-        github_token: ${{ secrets.github_token }}
-        golangci_lint_flags: "--timeout=10m"
-        reporter: "github-pr-review"
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Run golangci-lint
+        uses: docker://reviewdog/action-golangci-lint:v1.9
+        with:
+          github_token: ${{ secrets.github_token }}
+          golangci_lint_flags: "--timeout=10m"
+          reporter: "github-pr-review"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,12 @@
 name: Test GoShimmer
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'docs/**'
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
 
 jobs:
 
@@ -9,13 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.15.5
-      uses: actions/setup-go@v1
-      with:
-        go-version: 1.15.5
+      - name: Setup Go 1.15.5
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.15.5
 
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v2
 
-    - name: Run Tests
-      run: go test ./...
+      - name: Run Tests
+        run: go test ./...


### PR DESCRIPTION
This PR updates the GH actions.
Actions that are _only_ run for changes in `docs/`:
 - mdBook

Actions that are _not_ run for changes only in `docs`:
 - Docker image `develop`
 - Integration tests
 - Unit tests 

The remaining actions are still run regardless of the changes.