### PR TITLE
feat: Add TransactionOpinionFormed event

### DIFF
--- a/packages/tangle/tangle_test.go
+++ b/packages/tangle/tangle_test.go
@@ -392,15 +392,16 @@ func TestTangle_Flow(t *testing.T) {
 
 	// counter for the different stages
 	var (
-		parsedMessages        int32
-		storedMessages        int32
-		missingMessages       int32
-		solidMessages         int32
-		scheduledMessages     int32
-		bookedMessages        int32
-		opinionFormedMessages int32
-		invalidMessages       int32
-		rejectedMessages      int32
+		parsedMessages            int32
+		storedMessages            int32
+		missingMessages           int32
+		solidMessages             int32
+		scheduledMessages         int32
+		bookedMessages            int32
+		opinionFormedMessages     int32
+		opinionFormedTransactions int32
+		invalidMessages           int32
+		rejectedMessages          int32
 	)
 
 	// filter rejected events
@@ -459,6 +460,12 @@ func TestTangle_Flow(t *testing.T) {
 		t.Logf("opinion formed messages %d/%d", n, totalMsgCount)
 	}))
 
+	// data messages should not trigger this event
+	tangle.OpinionFormer.Events.TransactionOpinionFormed.Attach(events.NewClosure(func(messageID MessageID) {
+		n := atomic.AddInt32(&opinionFormedTransactions, 1)
+		t.Logf("opinion formed transaction %d/%d", n, totalMsgCount)
+	}))
+
 	tangle.Events.Error.Attach(events.NewClosure(func(err error) {
 		t.Logf("Error %s", err)
 	}))
@@ -486,6 +493,7 @@ func TestTangle_Flow(t *testing.T) {
 	assert.EqualValues(t, totalMsgCount, atomic.LoadInt32(&storedMessages))
 	assert.EqualValues(t, totalMsgCount, atomic.LoadInt32(&parsedMessages))
 	assert.EqualValues(t, invalidMsgCount, atomic.LoadInt32(&invalidMessages))
+	assert.EqualValues(t, 0, atomic.LoadInt32(&opinionFormedTransactions))
 	assert.EqualValues(t, 0, atomic.LoadInt32(&missingMessages))
 }
 

--- a/packages/tangle/tangle_test.go
+++ b/packages/tangle/tangle_test.go
@@ -461,7 +461,7 @@ func TestTangle_Flow(t *testing.T) {
 	}))
 
 	// data messages should not trigger this event
-	tangle.OpinionFormer.Events.TransactionOpinionFormed.Attach(events.NewClosure(func(messageID MessageID) {
+	tangle.OpinionFormer.Events.TransactionConfirmed.Attach(events.NewClosure(func(messageID MessageID) {
 		n := atomic.AddInt32(&opinionFormedTransactions, 1)
 		t.Logf("opinion formed transaction %d/%d", n, totalMsgCount)
 	}))


### PR DESCRIPTION
# Description of change

Add TransactionOpinionFormed event, those plugins that are only interested in transactions can listen to this event instead of MessageOpinionFormed event.

## Type of change

- Enhancement

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
