### PR TITLE
Add MPS Per Component Graph in Grafana

### DIFF
--- a/plugins/metrics/message.go
+++ b/plugins/metrics/message.go
@@ -10,6 +10,36 @@ import (
 	"go.uber.org/atomic"
 )
 
+// Defines the component for the different MPS metrics.
+type ComponentType byte
+
+const (
+	// Store denotes messages stored by the message store.
+	Store ComponentType = iota
+	// Solidifier denotes messages solidified by the solidifier.
+	Solidifier
+	// Scheduler denotes messages scheduled by the scheduler.
+	Scheduler
+	// Booker denotes messages booked by the booker.
+	Booker
+)
+
+// String returns the stringified component type.
+func (c ComponentType) String() string {
+	switch c {
+	case Store:
+		return "Store"
+	case Solidifier:
+		return "Solidifier"
+	case Scheduler:
+		return "Scheduler"
+	case Booker:
+		return "Booker"
+	default:
+		return "Unknown"
+	}
+}
+
 var (
 	// Total number of processed messages since start of the node.
 	messageTotalCount atomic.Uint64
@@ -54,6 +84,12 @@ var (
 	// protect map from concurrent read/write.
 	messageCountPerPayloadMutex syncutils.RWMutex
 
+	// Number of messages per componenet (store, scheduler, booker) type since start of the node.
+	messageCountPerComponent = make(map[ComponentType]uint64)
+
+	// protect map from concurrent read/write.
+	messageCountPerComponentMutex syncutils.RWMutex
+
 	// number of messages being requested by the message layer.
 	requestQueueSize atomic.Int64
 )
@@ -73,6 +109,20 @@ func MessageCountSinceStartPerPayload() map[payload.Type]uint64 {
 	// copy the original map
 	clone := make(map[payload.Type]uint64)
 	for key, element := range messageCountPerPayload {
+		clone[key] = element
+	}
+
+	return clone
+}
+
+// MessageCountSinceStartPerComponent returns a map of message count per component types and their count since the start of the node.
+func MessageCountSinceStartPerComponent() map[ComponentType]uint64 {
+	messageCountPerComponentMutex.RLock()
+	defer messageCountPerComponentMutex.RUnlock()
+
+	// copy the original map
+	clone := make(map[ComponentType]uint64)
+	for key, element := range messageCountPerComponent {
 		clone[key] = element
 	}
 
@@ -129,6 +179,14 @@ func increasePerPayloadCounter(p payload.Type) {
 	// increase cumulative metrics
 	messageCountPerPayload[p]++
 	messageTotalCount.Inc()
+}
+
+func increasePerComponentCounter(c ComponentType) {
+	messageCountPerComponentMutex.Lock()
+	defer messageCountPerComponentMutex.Unlock()
+
+	// increase cumulative metrics
+	messageCountPerComponent[c]++
 }
 
 func measureMessageTips() {

--- a/plugins/metrics/message.go
+++ b/plugins/metrics/message.go
@@ -84,7 +84,7 @@ var (
 	// protect map from concurrent read/write.
 	messageCountPerPayloadMutex syncutils.RWMutex
 
-	// Number of messages per componenet (store, scheduler, booker) type since start of the node.
+	// Number of messages per component (store, scheduler, booker) type since start of the node.
 	messageCountPerComponent = make(map[ComponentType]uint64)
 
 	// protect map from concurrent read/write.

--- a/plugins/metrics/message.go
+++ b/plugins/metrics/message.go
@@ -10,7 +10,7 @@ import (
 	"go.uber.org/atomic"
 )
 
-// Defines the component for the different MPS metrics.
+// ComponentType defines the component for the different MPS metrics.
 type ComponentType byte
 
 const (

--- a/plugins/metrics/plugin.go
+++ b/plugins/metrics/plugin.go
@@ -96,6 +96,7 @@ func registerLocalMetrics() {
 			// MessageStored is triggered in storeMessageWorker that saves the msg to database
 			messageTotalCountDB.Inc()
 		})
+		increasePerComponentCounter(Store)
 	}))
 
 	messagelayer.Tangle().Storage.Events.MessageRemoved.Attach(events.NewClosure(func(messageId tangle.MessageID) {
@@ -105,6 +106,7 @@ func registerLocalMetrics() {
 
 	// messages can only become solid once, then they stay like that, hence no .Dec() part
 	messagelayer.Tangle().Solidifier.Events.MessageSolid.Attach(events.NewClosure(func(messageID tangle.MessageID) {
+		increasePerComponentCounter(Solidifier)
 		solidTimeMutex.Lock()
 		defer solidTimeMutex.Unlock()
 
@@ -125,6 +127,14 @@ func registerLocalMetrics() {
 	// fired when a missing message was received and removed from missing message storage
 	messagelayer.Tangle().Storage.Events.MissingMessageStored.Attach(events.NewClosure(func(tangle.MessageID) {
 		missingMessageCountDB.Dec()
+	}))
+
+	messagelayer.Tangle().Scheduler.Events.MessageScheduled.Attach(events.NewClosure(func(messageID tangle.MessageID) {
+		increasePerComponentCounter(Scheduler)
+	}))
+
+	messagelayer.Tangle().Booker.Events.MessageBooked.Attach(events.NewClosure(func(message tangle.MessageID) {
+		increasePerComponentCounter(Booker)
 	}))
 
 	// // Value payload attached

--- a/plugins/prometheus/tangle.go
+++ b/plugins/prometheus/tangle.go
@@ -6,14 +6,15 @@ import (
 )
 
 var (
-	messageTips           prometheus.Gauge
-	messagePerTypeCount   *prometheus.GaugeVec
-	messageTotalCount     prometheus.Gauge
-	messageTotalCountDB   prometheus.Gauge
-	messageSolidCountDB   prometheus.Gauge
-	avgSolidificationTime prometheus.Gauge
-	messageMissingCountDB prometheus.Gauge
-	messageRequestCount   prometheus.Gauge
+	messageTips              prometheus.Gauge
+	messagePerTypeCount      *prometheus.GaugeVec
+	messagePerComponentCount *prometheus.GaugeVec
+	messageTotalCount        prometheus.Gauge
+	messageTotalCountDB      prometheus.Gauge
+	messageSolidCountDB      prometheus.Gauge
+	avgSolidificationTime    prometheus.Gauge
+	messageMissingCountDB    prometheus.Gauge
+	messageRequestCount      prometheus.Gauge
 
 	transactionCounter prometheus.Gauge
 	valueTips          prometheus.Gauge
@@ -31,6 +32,14 @@ func registerTangleMetrics() {
 			Help: "number of messages per payload type seen since the start of the node",
 		}, []string{
 			"message_type",
+		})
+
+	messagePerComponentCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "tangle_messages_per_component_count",
+			Help: "number of messages per component seen since the start of the node",
+		}, []string{
+			"component",
 		})
 
 	messageTotalCount = prometheus.NewGauge(prometheus.GaugeOpts{
@@ -70,6 +79,7 @@ func registerTangleMetrics() {
 
 	registry.MustRegister(messageTips)
 	registry.MustRegister(messagePerTypeCount)
+	registry.MustRegister(messagePerComponentCount)
 	registry.MustRegister(messageTotalCount)
 	registry.MustRegister(messageTotalCountDB)
 	registry.MustRegister(messageSolidCountDB)
@@ -86,6 +96,10 @@ func collectTangleMetrics() {
 	msgCountPerPayload := metrics.MessageCountSinceStartPerPayload()
 	for payloadType, count := range msgCountPerPayload {
 		messagePerTypeCount.WithLabelValues(payloadType.String()).Set(float64(count))
+	}
+	msgCountPerComponent := metrics.MessageCountSinceStartPerComponent()
+	for component, count := range msgCountPerComponent {
+		messagePerComponentCount.WithLabelValues(component.String()).Set(float64(count))
 	}
 	messageTotalCount.Set(float64(metrics.MessageTotalCountSinceStart()))
 	messageTotalCountDB.Set(float64(metrics.MessageTotalCountDB()))

--- a/tools/docker-network/grafana/dashboards/local_dashboard.json
+++ b/tools/docker-network/grafana/dashboards/local_dashboard.json
@@ -73,9 +73,10 @@
           "fields": "/^version$/",
           "values": false
         },
+        "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "targets": [
         {
           "expr": "iota_info_app",
@@ -133,9 +134,10 @@
           "fields": "/^nodeID$/",
           "values": false
         },
+        "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "targets": [
         {
           "expr": "iota_info_app",
@@ -194,9 +196,10 @@
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "value"
       },
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "targets": [
         {
           "expr": "time() - process_start_time_seconds",
@@ -268,9 +271,10 @@
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "targets": [
         {
           "expr": "sync",
@@ -328,9 +332,10 @@
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "targets": [
         {
           "expr": "irate(tangle_message_total_count[5m])",
@@ -387,9 +392,10 @@
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "targets": [
         {
           "expr": "process_cpu_usage",
@@ -442,9 +448,10 @@
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "targets": [
         {
           "expr": "process_mem_usage_bytes/1024/1024",
@@ -501,9 +508,10 @@
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "targets": [
         {
           "expr": "db_size_bytes/1024/1024",
@@ -548,7 +556,7 @@
       "fillGradient": 0,
       "gridPos": {
         "h": 11,
-        "w": 11,
+        "w": 12,
         "x": 0,
         "y": 4
       },
@@ -566,8 +574,11 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -666,6 +677,224 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "Prometheus",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
+      "hiddenSeries": false,
+      "id": 82,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.4.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "irate(tangle_messages_per_component_count{component=\"Store\"}[5m])",
+          "interval": "",
+          "legendFormat": "Stored Messages Per Second",
+          "refId": "A"
+        },
+        {
+          "expr": "irate(tangle_messages_per_component_count{component=\"Solidifier\"}[5m])",
+          "interval": "",
+          "legendFormat": "Solidified Messages Per Second",
+          "refId": "B"
+        },
+        {
+          "expr": "irate(tangle_messages_per_component_count{component=\"Scheduler\"}[5m])",
+          "interval": "",
+          "legendFormat": "Scheduled Messages Per Second",
+          "refId": "C"
+        },
+        {
+          "expr": "irate(tangle_messages_per_component_count{component=\"Booker\"}[5m])",
+          "interval": "",
+          "legendFormat": "Booked Messages Per Second",
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Message Per Second Per Component",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "MPS",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "description": "Shows tips in message and value layer.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 10,
+        "w": 11,
+        "x": 0,
+        "y": 15
+      },
+      "hiddenSeries": false,
+      "id": 52,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.4.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "tangle_message_tips_count",
+          "interval": "",
+          "legendFormat": "Message Layer Tips",
+          "refId": "A"
+        },
+        {
+          "expr": "tangle_value_tips",
+          "interval": "",
+          "legendFormat": "Value Layer Tips",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Tips",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -679,7 +908,7 @@
         "h": 8,
         "w": 13,
         "x": 11,
-        "y": 4
+        "y": 15
       },
       "hiddenSeries": false,
       "id": 4,
@@ -695,8 +924,11 @@
       "lines": false,
       "linewidth": 1,
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "pointradius": 0.5,
       "points": true,
       "renderer": "flot",
@@ -793,7 +1025,7 @@
         "h": 4,
         "w": 3,
         "x": 11,
-        "y": 12
+        "y": 23
       },
       "id": 6,
       "options": {
@@ -808,9 +1040,10 @@
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "targets": [
         {
           "expr": "autopeering_neighbor_connections_count - autopeering_neighbor_drop_count",
@@ -848,7 +1081,7 @@
         "h": 4,
         "w": 4,
         "x": 14,
-        "y": 12
+        "y": 23
       },
       "id": 2,
       "options": {
@@ -863,9 +1096,10 @@
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "targets": [
         {
           "expr": "autopeering_avg_neighbor_connection_lifetime",
@@ -906,7 +1140,7 @@
         "h": 4,
         "w": 3,
         "x": 18,
-        "y": 12
+        "y": 23
       },
       "id": 8,
       "options": {
@@ -921,9 +1155,10 @@
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "targets": [
         {
           "expr": "autopeering_neighbor_connections_count",
@@ -964,7 +1199,7 @@
         "h": 4,
         "w": 3,
         "x": 21,
-        "y": 12
+        "y": 23
       },
       "id": 10,
       "options": {
@@ -979,9 +1214,10 @@
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "targets": [
         {
           "expr": "autopeering_neighbor_drop_count",
@@ -1001,7 +1237,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "Prometheus",
-      "description": "Shows tips in message and value layer.",
+      "description": "Number of messages in missingMessageStore. These are the message the node knows it doesn't have and tries to requests them.",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -1012,13 +1248,13 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 10,
+        "h": 8,
         "w": 11,
         "x": 0,
-        "y": 15
+        "y": 25
       },
       "hiddenSeries": false,
-      "id": 52,
+      "id": 77,
       "legend": {
         "avg": false,
         "current": false,
@@ -1031,8 +1267,11 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1042,23 +1281,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "tangle_message_tips_count",
+          "expr": "tangle_message_missing_count_db",
           "interval": "",
-          "legendFormat": "Message Layer Tips",
+          "legendFormat": "Missing Messages",
           "refId": "A"
-        },
-        {
-          "expr": "tangle_value_tips",
-          "interval": "",
-          "legendFormat": "Value Layer Tips",
-          "refId": "B"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Tips",
+      "title": "Missing Messages",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1114,7 +1347,7 @@
         "h": 9,
         "w": 7,
         "x": 11,
-        "y": 16
+        "y": 27
       },
       "hiddenSeries": false,
       "id": 16,
@@ -1130,8 +1363,11 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1207,7 +1443,7 @@
         "h": 9,
         "w": 6,
         "x": 18,
-        "y": 16
+        "y": 27
       },
       "hiddenSeries": false,
       "id": 18,
@@ -1223,8 +1459,11 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1287,7 +1526,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "Prometheus",
-      "description": "Number of messages in missingMessageStore. These are the message the node knows it doesn't have and tries to requests them.",
+      "description": "Number of messages currently requested by the message tangle.",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -1301,10 +1540,10 @@
         "h": 8,
         "w": 11,
         "x": 0,
-        "y": 25
+        "y": 33
       },
       "hiddenSeries": false,
-      "id": 77,
+      "id": 69,
       "legend": {
         "avg": false,
         "current": false,
@@ -1317,8 +1556,11 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1328,9 +1570,9 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "tangle_message_missing_count_db",
+          "expr": "tangle_message_request_queue_size",
           "interval": "",
-          "legendFormat": "Missing Messages",
+          "legendFormat": "Message Request Queue Size",
           "refId": "A"
         }
       ],
@@ -1338,7 +1580,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Missing Messages",
+      "title": "Message Request Queue Size",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1358,7 +1600,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -1366,8 +1608,8 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
-          "show": true
+          "min": "0",
+          "show": false
         }
       ],
       "yaxis": {
@@ -1395,7 +1637,7 @@
         "h": 16,
         "w": 13,
         "x": 11,
-        "y": 25
+        "y": 36
       },
       "hiddenSeries": false,
       "id": 73,
@@ -1413,8 +1655,11 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1489,100 +1734,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "Prometheus",
-      "description": "Number of messages currently requested by the message tangle.",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "links": []
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 8,
-        "w": 11,
-        "x": 0,
-        "y": 33
-      },
-      "hiddenSeries": false,
-      "id": 69,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "percentage": false,
-      "pluginVersion": "7.1.1",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "tangle_message_request_queue_size",
-          "interval": "",
-          "legendFormat": "Message Request Queue Size",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Message Request Queue Size",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -1612,8 +1763,11 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1707,6 +1861,252 @@
       }
     },
     {
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 0,
+        "y": 51
+      },
+      "id": 61,
+      "options": {
+        "content": "\n# Total Network Traffic\n\n\nSince the start of the node.\n",
+        "mode": "markdown"
+      },
+      "pluginVersion": "7.4.3",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "",
+      "type": "text"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 3,
+        "y": 51
+      },
+      "id": 67,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.4.3",
+      "targets": [
+        {
+          "expr": "traffic_gossip_outbound_bytes",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Gossip TX",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 5,
+        "y": 51
+      },
+      "id": 66,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.4.3",
+      "targets": [
+        {
+          "expr": "traffic_gossip_inbound_bytes",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Gossip RX",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 7,
+        "y": 51
+      },
+      "id": 63,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.4.3",
+      "targets": [
+        {
+          "expr": "traffic_autopeering_outbound_bytes",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Autopeering TX",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 9,
+        "y": 51
+      },
+      "id": 62,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.4.3",
+      "targets": [
+        {
+          "expr": "traffic_autopeering_inbound_bytes",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Autopeering RX",
+      "type": "stat"
+    },
+    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -1726,7 +2126,7 @@
         "h": 10,
         "w": 11,
         "x": 11,
-        "y": 41
+        "y": 52
       },
       "hiddenSeries": false,
       "id": 75,
@@ -1743,7 +2143,7 @@
       "linewidth": 1,
       "nullPointMode": "null",
       "percentage": false,
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1801,250 +2201,6 @@
       }
     },
     {
-      "content": "\n# Total Network Traffic\n\n\nSince the start of the node.\n",
-      "datasource": null,
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 3,
-        "x": 0,
-        "y": 51
-      },
-      "id": 61,
-      "mode": "markdown",
-      "options": {
-        "content": "\n# Total Network Traffic\n\n\nSince the start of the node.\n",
-        "mode": "markdown"
-      },
-      "pluginVersion": "7.1.0",
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "",
-      "type": "text"
-    },
-    {
-      "datasource": "Prometheus",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "decbytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 2,
-        "w": 2,
-        "x": 3,
-        "y": 51
-      },
-      "id": 67,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "7.1.1",
-      "targets": [
-        {
-          "expr": "traffic_gossip_outbound_bytes",
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Gossip TX",
-      "type": "stat"
-    },
-    {
-      "datasource": "Prometheus",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "decbytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 2,
-        "w": 2,
-        "x": 5,
-        "y": 51
-      },
-      "id": 66,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "7.1.1",
-      "targets": [
-        {
-          "expr": "traffic_gossip_inbound_bytes",
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Gossip RX",
-      "type": "stat"
-    },
-    {
-      "datasource": "Prometheus",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "decbytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 2,
-        "w": 2,
-        "x": 7,
-        "y": 51
-      },
-      "id": 63,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "7.1.1",
-      "targets": [
-        {
-          "expr": "traffic_autopeering_outbound_bytes",
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Autopeering TX",
-      "type": "stat"
-    },
-    {
-      "datasource": "Prometheus",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "decbytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 2,
-        "w": 2,
-        "x": 9,
-        "y": 51
-      },
-      "id": 62,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "7.1.1",
-      "targets": [
-        {
-          "expr": "traffic_autopeering_inbound_bytes",
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Autopeering RX",
-      "type": "stat"
-    },
-    {
       "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
@@ -2082,9 +2238,10 @@
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "targets": [
         {
           "expr": "traffic_fpc_inbound_bytes",
@@ -2136,9 +2293,10 @@
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "targets": [
         {
           "expr": "traffic_fpc_outbound_bytes",
@@ -2190,9 +2348,10 @@
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "targets": [
         {
           "expr": "traffic_analysis_outbound_bytes",
@@ -2213,7 +2372,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 55
+        "y": 62
       },
       "id": 34,
       "panels": [],
@@ -2239,7 +2398,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 56
+        "y": 63
       },
       "hiddenSeries": false,
       "id": 36,
@@ -2256,7 +2415,7 @@
       "linewidth": 1,
       "nullPointMode": "null",
       "percentage": false,
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2340,7 +2499,7 @@
         "h": 8,
         "w": 4,
         "x": 12,
-        "y": 56
+        "y": 63
       },
       "id": 38,
       "options": {
@@ -2355,9 +2514,10 @@
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "targets": [
         {
           "expr": "fpc_avg_rounds_to_finalize",
@@ -2398,7 +2558,7 @@
         "h": 8,
         "w": 3,
         "x": 16,
-        "y": 56
+        "y": 63
       },
       "id": 42,
       "options": {
@@ -2413,9 +2573,10 @@
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "targets": [
         {
           "expr": "fpc_finalized_conflicts",
@@ -2456,7 +2617,7 @@
         "h": 8,
         "w": 3,
         "x": 19,
-        "y": 56
+        "y": 63
       },
       "id": 40,
       "options": {
@@ -2471,9 +2632,10 @@
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "targets": [
         {
           "expr": "fpc_failed_conflicts",
@@ -2507,7 +2669,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 64
+        "y": 71
       },
       "hiddenSeries": false,
       "id": 44,
@@ -2524,7 +2686,7 @@
       "linewidth": 1,
       "nullPointMode": "null",
       "percentage": false,
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2600,7 +2762,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 64
+        "y": 71
       },
       "hiddenSeries": false,
       "id": 50,
@@ -2617,7 +2779,7 @@
       "linewidth": 1,
       "nullPointMode": "null",
       "percentage": false,
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2694,7 +2856,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 72
+        "y": 79
       },
       "hiddenSeries": false,
       "id": 49,
@@ -2711,7 +2873,7 @@
       "linewidth": 1,
       "nullPointMode": "null",
       "percentage": false,
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2787,7 +2949,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 72
+        "y": 79
       },
       "hiddenSeries": false,
       "id": 46,
@@ -2804,7 +2966,7 @@
       "linewidth": 1,
       "nullPointMode": "null",
       "percentage": false,
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2866,7 +3028,7 @@
     }
   ],
   "refresh": "5s",
-  "schemaVersion": 26,
+  "schemaVersion": 27,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -2878,6 +3040,7 @@
   },
   "timepicker": {
     "refresh_intervals": [
+      "5s",
       "10s",
       "30s",
       "1m",
@@ -2892,5 +3055,5 @@
   "timezone": "",
   "title": "GoShimmer Local Metrics",
   "uid": "kjOQZ2ZMk",
-  "version": 17
+  "version": 4
 }

--- a/tools/monitoring/grafana/dashboards/local_dashboard.json
+++ b/tools/monitoring/grafana/dashboards/local_dashboard.json
@@ -73,9 +73,10 @@
           "fields": "/^version$/",
           "values": false
         },
+        "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "targets": [
         {
           "expr": "iota_info_app",
@@ -133,9 +134,10 @@
           "fields": "/^nodeID$/",
           "values": false
         },
+        "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "targets": [
         {
           "expr": "iota_info_app",
@@ -194,9 +196,10 @@
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "value"
       },
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "targets": [
         {
           "expr": "time() - process_start_time_seconds",
@@ -268,9 +271,10 @@
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "targets": [
         {
           "expr": "sync",
@@ -328,9 +332,10 @@
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "targets": [
         {
           "expr": "irate(tangle_message_total_count[5m])",
@@ -387,9 +392,10 @@
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "targets": [
         {
           "expr": "process_cpu_usage",
@@ -442,9 +448,10 @@
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "targets": [
         {
           "expr": "process_mem_usage_bytes/1024/1024",
@@ -501,9 +508,10 @@
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "targets": [
         {
           "expr": "db_size_bytes/1024/1024",
@@ -548,7 +556,7 @@
       "fillGradient": 0,
       "gridPos": {
         "h": 11,
-        "w": 11,
+        "w": 12,
         "x": 0,
         "y": 4
       },
@@ -566,8 +574,11 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -666,6 +677,224 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "Prometheus",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
+      "hiddenSeries": false,
+      "id": 82,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.4.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "irate(tangle_messages_per_component_count{component=\"Store\"}[5m])",
+          "interval": "",
+          "legendFormat": "Stored Messages Per Second",
+          "refId": "A"
+        },
+        {
+          "expr": "irate(tangle_messages_per_component_count{component=\"Solidifier\"}[5m])",
+          "interval": "",
+          "legendFormat": "Solidified Messages Per Second",
+          "refId": "B"
+        },
+        {
+          "expr": "irate(tangle_messages_per_component_count{component=\"Scheduler\"}[5m])",
+          "interval": "",
+          "legendFormat": "Scheduled Messages Per Second",
+          "refId": "C"
+        },
+        {
+          "expr": "irate(tangle_messages_per_component_count{component=\"Booker\"}[5m])",
+          "interval": "",
+          "legendFormat": "Booked Messages Per Second",
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Message Per Second Per Component",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "MPS",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "description": "Shows tips in message and value layer.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 10,
+        "w": 11,
+        "x": 0,
+        "y": 15
+      },
+      "hiddenSeries": false,
+      "id": 52,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.4.3",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "tangle_message_tips_count",
+          "interval": "",
+          "legendFormat": "Message Layer Tips",
+          "refId": "A"
+        },
+        {
+          "expr": "tangle_value_tips",
+          "interval": "",
+          "legendFormat": "Value Layer Tips",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Tips",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -679,7 +908,7 @@
         "h": 8,
         "w": 13,
         "x": 11,
-        "y": 4
+        "y": 15
       },
       "hiddenSeries": false,
       "id": 4,
@@ -695,8 +924,11 @@
       "lines": false,
       "linewidth": 1,
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "pointradius": 0.5,
       "points": true,
       "renderer": "flot",
@@ -793,7 +1025,7 @@
         "h": 4,
         "w": 3,
         "x": 11,
-        "y": 12
+        "y": 23
       },
       "id": 6,
       "options": {
@@ -808,9 +1040,10 @@
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "targets": [
         {
           "expr": "autopeering_neighbor_connections_count - autopeering_neighbor_drop_count",
@@ -848,7 +1081,7 @@
         "h": 4,
         "w": 4,
         "x": 14,
-        "y": 12
+        "y": 23
       },
       "id": 2,
       "options": {
@@ -863,9 +1096,10 @@
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "targets": [
         {
           "expr": "autopeering_avg_neighbor_connection_lifetime",
@@ -906,7 +1140,7 @@
         "h": 4,
         "w": 3,
         "x": 18,
-        "y": 12
+        "y": 23
       },
       "id": 8,
       "options": {
@@ -921,9 +1155,10 @@
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "targets": [
         {
           "expr": "autopeering_neighbor_connections_count",
@@ -964,7 +1199,7 @@
         "h": 4,
         "w": 3,
         "x": 21,
-        "y": 12
+        "y": 23
       },
       "id": 10,
       "options": {
@@ -979,9 +1214,10 @@
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "targets": [
         {
           "expr": "autopeering_neighbor_drop_count",
@@ -1001,7 +1237,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "Prometheus",
-      "description": "Shows tips in message and value layer.",
+      "description": "Number of messages in missingMessageStore. These are the message the node knows it doesn't have and tries to requests them.",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -1012,13 +1248,13 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 10,
+        "h": 8,
         "w": 11,
         "x": 0,
-        "y": 15
+        "y": 25
       },
       "hiddenSeries": false,
-      "id": 52,
+      "id": 77,
       "legend": {
         "avg": false,
         "current": false,
@@ -1031,8 +1267,11 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1042,23 +1281,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "tangle_message_tips_count",
+          "expr": "tangle_message_missing_count_db",
           "interval": "",
-          "legendFormat": "Message Layer Tips",
+          "legendFormat": "Missing Messages",
           "refId": "A"
-        },
-        {
-          "expr": "tangle_value_tips",
-          "interval": "",
-          "legendFormat": "Value Layer Tips",
-          "refId": "B"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Tips",
+      "title": "Missing Messages",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1114,7 +1347,7 @@
         "h": 9,
         "w": 7,
         "x": 11,
-        "y": 16
+        "y": 27
       },
       "hiddenSeries": false,
       "id": 16,
@@ -1130,8 +1363,11 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1207,7 +1443,7 @@
         "h": 9,
         "w": 6,
         "x": 18,
-        "y": 16
+        "y": 27
       },
       "hiddenSeries": false,
       "id": 18,
@@ -1223,8 +1459,11 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1287,7 +1526,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "Prometheus",
-      "description": "Number of messages in missingMessageStore. These are the message the node knows it doesn't have and tries to requests them.",
+      "description": "Number of messages currently requested by the message tangle.",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -1301,10 +1540,10 @@
         "h": 8,
         "w": 11,
         "x": 0,
-        "y": 25
+        "y": 33
       },
       "hiddenSeries": false,
-      "id": 77,
+      "id": 69,
       "legend": {
         "avg": false,
         "current": false,
@@ -1317,8 +1556,11 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1328,9 +1570,9 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "tangle_message_missing_count_db",
+          "expr": "tangle_message_request_queue_size",
           "interval": "",
-          "legendFormat": "Missing Messages",
+          "legendFormat": "Message Request Queue Size",
           "refId": "A"
         }
       ],
@@ -1338,7 +1580,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Missing Messages",
+      "title": "Message Request Queue Size",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1358,7 +1600,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         },
         {
@@ -1366,8 +1608,8 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
-          "show": true
+          "min": "0",
+          "show": false
         }
       ],
       "yaxis": {
@@ -1395,7 +1637,7 @@
         "h": 16,
         "w": 13,
         "x": 11,
-        "y": 25
+        "y": 36
       },
       "hiddenSeries": false,
       "id": 73,
@@ -1413,8 +1655,11 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1489,100 +1734,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "Prometheus",
-      "description": "Number of messages currently requested by the message tangle.",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "links": []
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 8,
-        "w": 11,
-        "x": 0,
-        "y": 33
-      },
-      "hiddenSeries": false,
-      "id": 69,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "percentage": false,
-      "pluginVersion": "7.1.1",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "tangle_message_request_queue_size",
-          "interval": "",
-          "legendFormat": "Message Request Queue Size",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Message Request Queue Size",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -1612,8 +1763,11 @@
       "lines": true,
       "linewidth": 1,
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1707,6 +1861,252 @@
       }
     },
     {
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 0,
+        "y": 51
+      },
+      "id": 61,
+      "options": {
+        "content": "\n# Total Network Traffic\n\n\nSince the start of the node.\n",
+        "mode": "markdown"
+      },
+      "pluginVersion": "7.4.3",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "",
+      "type": "text"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 3,
+        "y": 51
+      },
+      "id": 67,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.4.3",
+      "targets": [
+        {
+          "expr": "traffic_gossip_outbound_bytes",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Gossip TX",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 5,
+        "y": 51
+      },
+      "id": 66,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.4.3",
+      "targets": [
+        {
+          "expr": "traffic_gossip_inbound_bytes",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Gossip RX",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 7,
+        "y": 51
+      },
+      "id": 63,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.4.3",
+      "targets": [
+        {
+          "expr": "traffic_autopeering_outbound_bytes",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Autopeering TX",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 9,
+        "y": 51
+      },
+      "id": 62,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.4.3",
+      "targets": [
+        {
+          "expr": "traffic_autopeering_inbound_bytes",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Autopeering RX",
+      "type": "stat"
+    },
+    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -1726,7 +2126,7 @@
         "h": 10,
         "w": 11,
         "x": 11,
-        "y": 41
+        "y": 52
       },
       "hiddenSeries": false,
       "id": 75,
@@ -1743,7 +2143,7 @@
       "linewidth": 1,
       "nullPointMode": "null",
       "percentage": false,
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1801,250 +2201,6 @@
       }
     },
     {
-      "content": "\n# Total Network Traffic\n\n\nSince the start of the node.\n",
-      "datasource": null,
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 3,
-        "x": 0,
-        "y": 51
-      },
-      "id": 61,
-      "mode": "markdown",
-      "options": {
-        "content": "\n# Total Network Traffic\n\n\nSince the start of the node.\n",
-        "mode": "markdown"
-      },
-      "pluginVersion": "7.1.0",
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "",
-      "type": "text"
-    },
-    {
-      "datasource": "Prometheus",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "decbytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 2,
-        "w": 2,
-        "x": 3,
-        "y": 51
-      },
-      "id": 67,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "7.1.1",
-      "targets": [
-        {
-          "expr": "traffic_gossip_outbound_bytes",
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Gossip TX",
-      "type": "stat"
-    },
-    {
-      "datasource": "Prometheus",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "decbytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 2,
-        "w": 2,
-        "x": 5,
-        "y": 51
-      },
-      "id": 66,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "7.1.1",
-      "targets": [
-        {
-          "expr": "traffic_gossip_inbound_bytes",
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Gossip RX",
-      "type": "stat"
-    },
-    {
-      "datasource": "Prometheus",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "decbytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 2,
-        "w": 2,
-        "x": 7,
-        "y": 51
-      },
-      "id": 63,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "7.1.1",
-      "targets": [
-        {
-          "expr": "traffic_autopeering_outbound_bytes",
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Autopeering TX",
-      "type": "stat"
-    },
-    {
-      "datasource": "Prometheus",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "decbytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 2,
-        "w": 2,
-        "x": 9,
-        "y": 51
-      },
-      "id": 62,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "7.1.1",
-      "targets": [
-        {
-          "expr": "traffic_autopeering_inbound_bytes",
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Autopeering RX",
-      "type": "stat"
-    },
-    {
       "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
@@ -2082,9 +2238,10 @@
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "targets": [
         {
           "expr": "traffic_fpc_inbound_bytes",
@@ -2136,9 +2293,10 @@
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "targets": [
         {
           "expr": "traffic_fpc_outbound_bytes",
@@ -2190,9 +2348,10 @@
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "targets": [
         {
           "expr": "traffic_analysis_outbound_bytes",
@@ -2213,7 +2372,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 55
+        "y": 62
       },
       "id": 34,
       "panels": [],
@@ -2239,7 +2398,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 56
+        "y": 63
       },
       "hiddenSeries": false,
       "id": 36,
@@ -2256,7 +2415,7 @@
       "linewidth": 1,
       "nullPointMode": "null",
       "percentage": false,
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2340,7 +2499,7 @@
         "h": 8,
         "w": 4,
         "x": 12,
-        "y": 56
+        "y": 63
       },
       "id": 38,
       "options": {
@@ -2355,9 +2514,10 @@
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "targets": [
         {
           "expr": "fpc_avg_rounds_to_finalize",
@@ -2398,7 +2558,7 @@
         "h": 8,
         "w": 3,
         "x": 16,
-        "y": 56
+        "y": 63
       },
       "id": 42,
       "options": {
@@ -2413,9 +2573,10 @@
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "targets": [
         {
           "expr": "fpc_finalized_conflicts",
@@ -2456,7 +2617,7 @@
         "h": 8,
         "w": 3,
         "x": 19,
-        "y": 56
+        "y": 63
       },
       "id": 40,
       "options": {
@@ -2471,9 +2632,10 @@
           "fields": "",
           "values": false
         },
+        "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "targets": [
         {
           "expr": "fpc_failed_conflicts",
@@ -2507,7 +2669,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 64
+        "y": 71
       },
       "hiddenSeries": false,
       "id": 44,
@@ -2524,7 +2686,7 @@
       "linewidth": 1,
       "nullPointMode": "null",
       "percentage": false,
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2600,7 +2762,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 64
+        "y": 71
       },
       "hiddenSeries": false,
       "id": 50,
@@ -2617,7 +2779,7 @@
       "linewidth": 1,
       "nullPointMode": "null",
       "percentage": false,
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2694,7 +2856,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 72
+        "y": 79
       },
       "hiddenSeries": false,
       "id": 49,
@@ -2711,7 +2873,7 @@
       "linewidth": 1,
       "nullPointMode": "null",
       "percentage": false,
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2787,7 +2949,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 72
+        "y": 79
       },
       "hiddenSeries": false,
       "id": 46,
@@ -2804,7 +2966,7 @@
       "linewidth": 1,
       "nullPointMode": "null",
       "percentage": false,
-      "pluginVersion": "7.1.1",
+      "pluginVersion": "7.4.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2866,7 +3028,7 @@
     }
   ],
   "refresh": "5s",
-  "schemaVersion": 26,
+  "schemaVersion": 27,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -2878,6 +3040,7 @@
   },
   "timepicker": {
     "refresh_intervals": [
+      "5s",
       "10s",
       "30s",
       "1m",
@@ -2892,5 +3055,5 @@
   "timezone": "",
   "title": "GoShimmer Local Metrics",
   "uid": "kjOQZ2ZMk",
-  "version": 17
+  "version": 4
 }


### PR DESCRIPTION
# Description of change
Adds a graph to Grafana local dashboard where the MPS figures for different components are displayed:
 - Message Store
 - Solidifier
 - Scheduler
 - Booker

![mps_per_component](https://user-images.githubusercontent.com/32927267/109183102-e5893280-778d-11eb-9e3a-fc00c2846ab8.png)
