### PR TITLE
SendTransaction timestamp check

### DIFF
--- a/tools/docker-network/config.docker.json
+++ b/tools/docker-network/config.docker.json
@@ -71,5 +71,8 @@
       "password": "goshimmer"
     },
     "bindAddress": "0.0.0.0:8080"
+  },
+  "faucet": {
+    "powDifficulty": 2
   }
 }


### PR DESCRIPTION
Adds a check for a transaction's timestamp
- if older than `MaxReattachmentTimeMin` an error message is returned
- if in the future, the node waits until the time has arrived and issues the transaction

Misc: set PoW difficulty of faucet in Docker network to 2