### PR TITLE
update integration tests with mana changes

### DIFF
--- a/packages/tangle/tangle.go
+++ b/packages/tangle/tangle.go
@@ -101,10 +101,10 @@ func (t *Tangle) Prune() (err error) {
 // Shutdown marks the tangle as stopped, so it will not accept any new messages (waits for all backgroundTasks to finish).
 func (t *Tangle) Shutdown() {
 	t.MessageFactory.Shutdown()
-	t.Scheduler.Shutdown()
 	if !t.Options.WithoutOpinionFormer {
 		t.OpinionFormer.Shutdown()
 	}
+	t.Scheduler.Shutdown()
 	t.Booker.Shutdown()
 	t.LedgerState.Shutdown()
 	t.Storage.Shutdown()

--- a/packages/tangle/tangle.go
+++ b/packages/tangle/tangle.go
@@ -101,10 +101,10 @@ func (t *Tangle) Prune() (err error) {
 // Shutdown marks the tangle as stopped, so it will not accept any new messages (waits for all backgroundTasks to finish).
 func (t *Tangle) Shutdown() {
 	t.MessageFactory.Shutdown()
+	t.Scheduler.Shutdown()
 	if !t.Options.WithoutOpinionFormer {
 		t.OpinionFormer.Shutdown()
 	}
-	t.Scheduler.Shutdown()
 	t.Booker.Shutdown()
 	t.LedgerState.Shutdown()
 	t.Storage.Shutdown()

--- a/tools/integration-tests/tester/framework/docker.go
+++ b/tools/integration-tests/tester/framework/docker.go
@@ -141,7 +141,7 @@ func (d *DockerContainer) CreateGoShimmerPeer(config GoShimmerConfig) error {
 				return strings.Join(config.ManaAllowedAccessPledge[:], ",")
 			}()),
 			fmt.Sprintf("--mana.allowedConsensusPledge=%s", func() string {
-				return strings.Join(config.ManaAllowedAccessPledge[:], ",")
+				return strings.Join(config.ManaAllowedConsensusPledge[:], ",")
 			}()),
 		},
 	}

--- a/tools/integration-tests/tester/tests/testutil.go
+++ b/tools/integration-tests/tester/tests/testutil.go
@@ -280,7 +280,7 @@ func SendIotaTransaction(t *testing.T, from *framework.Peer, to *framework.Peer,
 // SendColoredTransaction sends IOTA and colored tokens from and to a given peer and returns the ok flag and transaction ID.
 // 1. Get the first unspent outputs of `from`
 // 2. Send 50 IOTA and 50 ColorMint to `to`
-func SendColoredTransaction(t *testing.T, from *framework.Peer, to *framework.Peer, addrBalance map[string]map[ledgerstate.Color]int64, txConfig TransactionConfig) (ok bool, txId string) {
+func SendColoredTransaction(t *testing.T, from *framework.Peer, to *framework.Peer, addrBalance map[string]map[ledgerstate.Color]int64, txConfig TransactionConfig) (fail bool, txId string) {
 	var sentIOTAValue int64 = 50
 	var sentMintValue int64 = 50
 	var balanceList []coloredBalance
@@ -330,12 +330,15 @@ func SendColoredTransaction(t *testing.T, from *framework.Peer, to *framework.Pe
 
 	// send transaction
 	txId, err = from.SendTransaction(txn.Bytes())
-	require.NoErrorf(t, err, "could not send transaction on %s", from.String())
+	if err != nil {
+		fmt.Println(fmt.Errorf("could not send transaction on %s: %w", from.String(), err).Error())
+		return true, ""
+	}
 
 	// update balance list
 	updateBalanceList(addrBalance, balanceList, inputAddr.Base58(), outputAddr.Base58(), txn.Essence().Outputs()[0])
 
-	return true, txId
+	return false, txId
 }
 
 // updateBalanceList updates the token amount map with given peers and balances.

--- a/tools/integration-tests/tester/tests/testutil.go
+++ b/tools/integration-tests/tester/tests/testutil.go
@@ -163,17 +163,19 @@ func SendTransactionFromFaucet(t *testing.T, peers []*framework.Peer, sentValue 
 	}
 
 	faucetPeer := peers[0]
-	// faucet has moved all its funds to the next address
-	faucetAddrStr := faucetPeer.Seed.Address(1).Address().Base58()
-	// get faucet balances
-	unspentOutputs, err := faucetPeer.GetUnspentOutputs([]string{faucetAddrStr})
-	require.NoErrorf(t, err, "could not get unspent outputs on %s", faucetPeer.String())
-	addrBalance[faucetAddrStr][ledgerstate.ColorIOTA] = unspentOutputs.UnspentOutputs[0].OutputIDs[0].Balances[0].Value
+	var i uint64
+	// faucet has split genesis output into n bits of 1337 each and remainder on n + 1
+	for i = 1; i < uint64(len(peers)); i++ {
+		faucetAddrStr := faucetPeer.Seed.Address(i).Address().Base58()
+		addrBalance[faucetAddrStr] = make(map[ledgerstate.Color]int64)
+		// get faucet balances
+		unspentOutputs, err := faucetPeer.GetUnspentOutputs([]string{faucetAddrStr})
+		require.NoErrorf(t, err, "could not get unspent outputs on %s", faucetPeer.String())
+		addrBalance[faucetAddrStr][ledgerstate.ColorIOTA] = unspentOutputs.UnspentOutputs[0].OutputIDs[0].Balances[0].Value
 
-	// send funds to other peers
-	for i := 1; i < len(peers); i++ {
+		// send funds to other peers
 		fail, txId := SendIotaTransaction(t, faucetPeer, peers[i], addrBalance, sentValue, TransactionConfig{
-			FromAddressIndex:      1,
+			FromAddressIndex:      i,
 			ToAddressIndex:        0,
 			AccessManaPledgeID:    peers[i].ID(),
 			ConsensusManaPledgeID: peers[i].ID(),
@@ -258,13 +260,16 @@ func SendIotaTransaction(t *testing.T, from *framework.Peer, to *framework.Peer,
 		outputs = append(outputs, output)
 	}
 	txEssence := ledgerstate.NewTransactionEssence(0, time.Now(), txConfig.AccessManaPledgeID, txConfig.ConsensusManaPledgeID, ledgerstate.NewInputs(input), ledgerstate.NewOutputs(outputs...))
-	sig := ledgerstate.NewED25519Signature(from.KeyPair(0).PublicKey, from.KeyPair(0).PrivateKey.Sign(txEssence.Bytes()))
+	sig := ledgerstate.NewED25519Signature(from.KeyPair(txConfig.FromAddressIndex).PublicKey, from.KeyPair(txConfig.FromAddressIndex).PrivateKey.Sign(txEssence.Bytes()))
 	unlockBlock := ledgerstate.NewSignatureUnlockBlock(sig)
 	txn := ledgerstate.NewTransaction(txEssence, ledgerstate.UnlockBlocks{unlockBlock})
 
 	// send transaction
 	txId, err = from.SendTransaction(txn.Bytes())
-	require.NoErrorf(t, err, "could not send transaction on %s", from.String())
+	if err != nil {
+		fmt.Println(fmt.Errorf("could not send transaction on %s: %w", from.String(), err).Error())
+		return true, ""
+	}
 
 	addrBalance[inputAddr.Base58()][ledgerstate.ColorIOTA] -= sentValue
 	addrBalance[outputAddr.Base58()][ledgerstate.ColorIOTA] += sentValue
@@ -275,12 +280,12 @@ func SendIotaTransaction(t *testing.T, from *framework.Peer, to *framework.Peer,
 // SendColoredTransaction sends IOTA and colored tokens from and to a given peer and returns the ok flag and transaction ID.
 // 1. Get the first unspent outputs of `from`
 // 2. Send 50 IOTA and 50 ColorMint to `to`
-func SendColoredTransaction(t *testing.T, from *framework.Peer, to *framework.Peer, addrBalance map[string]map[ledgerstate.Color]int64) (ok bool, txId string) {
+func SendColoredTransaction(t *testing.T, from *framework.Peer, to *framework.Peer, addrBalance map[string]map[ledgerstate.Color]int64, txConfig TransactionConfig) (ok bool, txId string) {
 	var sentIOTAValue int64 = 50
 	var sentMintValue int64 = 50
 	var balanceList []coloredBalance
-	inputAddr := from.Seed.Address(0).Address()
-	outputAddr := to.Seed.Address(0).Address()
+	inputAddr := from.Seed.Address(txConfig.FromAddressIndex).Address()
+	outputAddr := to.Seed.Address(txConfig.ToAddressIndex).Address()
 
 	// prepare inputs
 	resp, err := from.GetUnspentOutputs([]string{inputAddr.Base58()})
@@ -304,7 +309,7 @@ func SendColoredTransaction(t *testing.T, from *framework.Peer, to *framework.Pe
 	txEssence := ledgerstate.NewTransactionEssence(0, time.Now(), identity.ID{}, identity.ID{}, ledgerstate.NewInputs(input), ledgerstate.NewOutputs(output))
 
 	// sign transaction
-	sig := ledgerstate.NewED25519Signature(from.KeyPair(0).PublicKey, from.KeyPair(0).PrivateKey.Sign(txEssence.Bytes()))
+	sig := ledgerstate.NewED25519Signature(from.KeyPair(txConfig.FromAddressIndex).PublicKey, from.KeyPair(txConfig.FromAddressIndex).PrivateKey.Sign(txEssence.Bytes()))
 	unlockBlock := ledgerstate.NewSignatureUnlockBlock(sig)
 	txn := ledgerstate.NewTransaction(txEssence, ledgerstate.UnlockBlocks{unlockBlock})
 

--- a/tools/integration-tests/tester/tests/value/value_test.go
+++ b/tools/integration-tests/tester/tests/value/value_test.go
@@ -107,8 +107,8 @@ func TestValueColoredPersistence(t *testing.T) {
 
 	// send funds to node 2
 	for _, peer := range n.Peers()[1:] {
-		ok, txId := tests.SendColoredTransaction(t, peer, n.Peers()[0], addrBalance, tests.TransactionConfig{})
-		require.True(t, ok)
+		fail, txId := tests.SendColoredTransaction(t, peer, n.Peers()[0], addrBalance, tests.TransactionConfig{})
+		require.False(t, fail)
 		txIds[txId] = nil
 	}
 	// wait for value messages to be gossiped

--- a/tools/integration-tests/tester/tests/value/value_test.go
+++ b/tools/integration-tests/tester/tests/value/value_test.go
@@ -5,13 +5,14 @@ import (
 	"time"
 
 	"github.com/iotaledger/goshimmer/plugins/messagelayer"
+	"github.com/iotaledger/goshimmer/tools/integration-tests/tester/framework"
 	"github.com/iotaledger/goshimmer/tools/integration-tests/tester/tests"
 	"github.com/stretchr/testify/require"
 )
 
 // TestTransactionPersistence issues messages on random peers, restarts them and checks for persistence after restart.
 func TestTransactionPersistence(t *testing.T) {
-	n, err := f.CreateNetwork("transaction_TestPersistence", 4, 2)
+	n, err := f.CreateNetwork("transaction_TestPersistence", 4, 2, framework.CreateNetworkConfig{Faucet: true})
 	require.NoError(t, err)
 	defer tests.ShutdownNetwork(t, n)
 
@@ -79,7 +80,7 @@ func TestTransactionPersistence(t *testing.T) {
 
 // TestValueColoredPersistence issues colored tokens on random peers, restarts them and checks for persistence after restart.
 func TestValueColoredPersistence(t *testing.T) {
-	n, err := f.CreateNetwork("valueColor_TestPersistence", 4, 2)
+	n, err := f.CreateNetwork("valueColor_TestPersistence", 4, 2, framework.CreateNetworkConfig{Faucet: true})
 	require.NoError(t, err)
 	defer tests.ShutdownNetwork(t, n)
 
@@ -106,7 +107,7 @@ func TestValueColoredPersistence(t *testing.T) {
 
 	// send funds to node 2
 	for _, peer := range n.Peers()[1:] {
-		ok, txId := tests.SendColoredTransaction(t, peer, n.Peers()[0], addrBalance)
+		ok, txId := tests.SendColoredTransaction(t, peer, n.Peers()[0], addrBalance, tests.TransactionConfig{})
 		require.True(t, ok)
 		txIds[txId] = nil
 	}


### PR DESCRIPTION
Noteworthy change: 
Made scheduler shutdown before opinion former.

I was seeing an issue where the scheduler will hang on shutdown coz the opinion former has already shut down and left the scheduler with *opinionless* messages. 