### PR TITLE
same timestamp for mana maps

### DIFF
--- a/packages/mana/accessbasevector.go
+++ b/packages/mana/accessbasevector.go
@@ -92,19 +92,17 @@ func (a *AccessBaseManaVector) GetMana(nodeID identity.ID, t ...time.Time) (floa
 }
 
 // GetManaMap returns mana perception of the node..
-func (a *AccessBaseManaVector) GetManaMap(timestamp ...time.Time) (res NodeMap, t time.Time, err error) {
+func (a *AccessBaseManaVector) GetManaMap(optionalUpdateTime ...time.Time) (res NodeMap, t time.Time, err error) {
 	a.Lock()
 	defer a.Unlock()
-	updateAt := time.Now()
-	if len(timestamp) > 0 {
-		if timestamp[0].Before(t) {
-			t = timestamp[0]
-		}
+	t = time.Now()
+	if len(optionalUpdateTime) > 0 {
+		t = optionalUpdateTime[0]
 	}
 	res = make(map[identity.ID]float64)
 	for ID := range a.vector {
 		var mana float64
-		mana, t, err = a.getMana(ID, updateAt)
+		mana, _, err = a.getMana(ID, t)
 		if err != nil {
 			return
 		}
@@ -121,10 +119,10 @@ func (a *AccessBaseManaVector) GetHighestManaNodes(n uint) (res []Node, t time.T
 		// don't lock the vector after this func returns
 		a.Lock()
 		defer a.Unlock()
-		updateAt := time.Now()
+		t = time.Now()
 		for ID := range a.vector {
 			var mana float64
-			mana, t, err = a.getMana(ID, updateAt)
+			mana, _, err = a.getMana(ID, t)
 			if err != nil {
 				return err
 			}
@@ -229,15 +227,13 @@ func (a *AccessBaseManaVector) update(nodeID identity.ID, t time.Time) error {
 }
 
 // getMana returns the current effective mana value. Not concurrency safe.
-func (a *AccessBaseManaVector) getMana(nodeID identity.ID, updateTime ...time.Time) (float64, time.Time, error) {
+func (a *AccessBaseManaVector) getMana(nodeID identity.ID, optionalUpdateTime ...time.Time) (float64, time.Time, error) {
 	t := time.Now()
 	if _, exist := a.vector[nodeID]; !exist {
 		return 0.0, t, ErrNodeNotFoundInBaseManaVector
 	}
-	if len(updateTime) > 0 {
-		if updateTime[0].Before(t) {
-			t = updateTime[0]
-		}
+	if len(optionalUpdateTime) > 0 {
+		t = optionalUpdateTime[0]
 	}
 	_ = a.update(nodeID, t)
 

--- a/packages/mana/accessbasevector.go
+++ b/packages/mana/accessbasevector.go
@@ -85,10 +85,10 @@ func (a *AccessBaseManaVector) UpdateAll(t time.Time) error {
 }
 
 // GetMana returns Effective Base Mana 2.
-func (a *AccessBaseManaVector) GetMana(nodeID identity.ID, t ...time.Time) (float64, time.Time, error) {
+func (a *AccessBaseManaVector) GetMana(nodeID identity.ID, optionalUpdateTime ...time.Time) (float64, time.Time, error) {
 	a.Lock()
 	defer a.Unlock()
-	return a.getMana(nodeID, t...)
+	return a.getMana(nodeID, optionalUpdateTime...)
 }
 
 // GetManaMap returns mana perception of the node..

--- a/packages/mana/accessbasevector.go
+++ b/packages/mana/accessbasevector.go
@@ -95,10 +95,16 @@ func (a *AccessBaseManaVector) GetMana(nodeID identity.ID, t ...time.Time) (floa
 func (a *AccessBaseManaVector) GetManaMap(timestamp ...time.Time) (res NodeMap, t time.Time, err error) {
 	a.Lock()
 	defer a.Unlock()
+	updateAt := time.Now()
+	if len(timestamp) > 0 {
+		if timestamp[0].Before(t) {
+			t = timestamp[0]
+		}
+	}
 	res = make(map[identity.ID]float64)
 	for ID := range a.vector {
 		var mana float64
-		mana, t, err = a.getMana(ID, timestamp...)
+		mana, t, err = a.getMana(ID, updateAt)
 		if err != nil {
 			return
 		}
@@ -115,9 +121,10 @@ func (a *AccessBaseManaVector) GetHighestManaNodes(n uint) (res []Node, t time.T
 		// don't lock the vector after this func returns
 		a.Lock()
 		defer a.Unlock()
+		updateAt := time.Now()
 		for ID := range a.vector {
 			var mana float64
-			mana, t, err = a.getMana(ID)
+			mana, t, err = a.getMana(ID, updateAt)
 			if err != nil {
 				return err
 			}

--- a/packages/mana/consensusbasevector.go
+++ b/packages/mana/consensusbasevector.go
@@ -185,10 +185,16 @@ func (c *ConsensusBaseManaVector) GetMana(nodeID identity.ID, t ...time.Time) (f
 func (c *ConsensusBaseManaVector) GetManaMap(timestamp ...time.Time) (res NodeMap, t time.Time, err error) {
 	c.Lock()
 	defer c.Unlock()
+	updateAt := time.Now()
+	if len(timestamp) > 0 {
+		if timestamp[0].Before(t) {
+			t = timestamp[0]
+		}
+	}
 	res = make(map[identity.ID]float64)
 	for ID := range c.vector {
 		var mana float64
-		mana, t, err = c.getMana(ID, timestamp...)
+		mana, t, err = c.getMana(ID, updateAt)
 		if err != nil {
 			return nil, t, err
 		}
@@ -205,9 +211,10 @@ func (c *ConsensusBaseManaVector) GetHighestManaNodes(n uint) (res []Node, t tim
 		// don't lock the vector after this func returns
 		c.Lock()
 		defer c.Unlock()
+		updateAt := time.Now()
 		for ID := range c.vector {
 			var mana float64
-			mana, t, err = c.getMana(ID)
+			mana, t, err = c.getMana(ID, updateAt)
 			if err != nil {
 				return err
 			}

--- a/packages/mana/consensusbasevector.go
+++ b/packages/mana/consensusbasevector.go
@@ -175,10 +175,10 @@ func (c *ConsensusBaseManaVector) UpdateAll(t time.Time) error {
 }
 
 // GetMana returns the Effective Base Mana.
-func (c *ConsensusBaseManaVector) GetMana(nodeID identity.ID, t ...time.Time) (float64, time.Time, error) {
+func (c *ConsensusBaseManaVector) GetMana(nodeID identity.ID, optionalUpdateTime ...time.Time) (float64, time.Time, error) {
 	c.Lock()
 	defer c.Unlock()
-	return c.getMana(nodeID, t...)
+	return c.getMana(nodeID, optionalUpdateTime...)
 }
 
 // GetManaMap returns mana perception of the node.
@@ -317,15 +317,13 @@ func (c *ConsensusBaseManaVector) update(nodeID identity.ID, t time.Time) error 
 }
 
 // getMana returns the Effective Base Mana 1. Will update base mana by default.
-func (c *ConsensusBaseManaVector) getMana(nodeID identity.ID, updateTime ...time.Time) (float64, time.Time, error) {
+func (c *ConsensusBaseManaVector) getMana(nodeID identity.ID, optionalUpdateTime ...time.Time) (float64, time.Time, error) {
 	t := time.Now()
 	if _, exist := c.vector[nodeID]; !exist {
 		return 0.0, t, ErrNodeNotFoundInBaseManaVector
 	}
-	if len(updateTime) > 0 {
-		if updateTime[0].Before(t) {
-			t = updateTime[0]
-		}
+	if len(optionalUpdateTime) > 0 {
+		t = optionalUpdateTime[0]
 	}
 	_ = c.update(nodeID, t)
 

--- a/packages/mana/consensusbasevector.go
+++ b/packages/mana/consensusbasevector.go
@@ -182,19 +182,17 @@ func (c *ConsensusBaseManaVector) GetMana(nodeID identity.ID, t ...time.Time) (f
 }
 
 // GetManaMap returns mana perception of the node.
-func (c *ConsensusBaseManaVector) GetManaMap(timestamp ...time.Time) (res NodeMap, t time.Time, err error) {
+func (c *ConsensusBaseManaVector) GetManaMap(optionalUpdateTime ...time.Time) (res NodeMap, t time.Time, err error) {
 	c.Lock()
 	defer c.Unlock()
-	updateAt := time.Now()
-	if len(timestamp) > 0 {
-		if timestamp[0].Before(t) {
-			t = timestamp[0]
-		}
+	t = time.Now()
+	if len(optionalUpdateTime) > 0 {
+		t = optionalUpdateTime[0]
 	}
 	res = make(map[identity.ID]float64)
 	for ID := range c.vector {
 		var mana float64
-		mana, t, err = c.getMana(ID, updateAt)
+		mana, _, err = c.getMana(ID, t)
 		if err != nil {
 			return nil, t, err
 		}
@@ -211,10 +209,10 @@ func (c *ConsensusBaseManaVector) GetHighestManaNodes(n uint) (res []Node, t tim
 		// don't lock the vector after this func returns
 		c.Lock()
 		defer c.Unlock()
-		updateAt := time.Now()
+		t = time.Now()
 		for ID := range c.vector {
 			var mana float64
-			mana, t, err = c.getMana(ID, updateAt)
+			mana, _, err = c.getMana(ID, t)
 			if err != nil {
 				return err
 			}

--- a/packages/mana/weightedbasevector.go
+++ b/packages/mana/weightedbasevector.go
@@ -139,19 +139,17 @@ func (w *WeightedBaseManaVector) GetMana(nodeID identity.ID, t ...time.Time) (fl
 }
 
 // GetManaMap returns mana perception of the node..
-func (w *WeightedBaseManaVector) GetManaMap(timestamp ...time.Time) (res NodeMap, t time.Time, err error) {
+func (w *WeightedBaseManaVector) GetManaMap(optionalUpdateTime ...time.Time) (res NodeMap, t time.Time, err error) {
 	w.Lock()
 	defer w.Unlock()
-	updateAt := time.Now()
-	if len(timestamp) > 0 {
-		if timestamp[0].Before(t) {
-			t = timestamp[0]
-		}
+	t = time.Now()
+	if len(optionalUpdateTime) > 0 {
+		t = optionalUpdateTime[0]
 	}
 	res = make(map[identity.ID]float64)
 	for ID := range w.vector {
 		var mana float64
-		mana, t, err = w.getMana(ID, updateAt)
+		mana, _, err = w.getMana(ID, t)
 		if err != nil {
 			return nil, t, err
 		}
@@ -168,10 +166,10 @@ func (w *WeightedBaseManaVector) GetHighestManaNodes(n uint) (res []Node, t time
 		// don't lock the vector after this func returns
 		w.Lock()
 		defer w.Unlock()
-		updateAt := time.Now()
+		t = time.Now()
 		for ID := range w.vector {
 			var mana float64
-			mana, t, err = w.getMana(ID, updateAt)
+			mana, _, err = w.getMana(ID, t)
 			if err != nil {
 				return err
 			}

--- a/packages/mana/weightedbasevector.go
+++ b/packages/mana/weightedbasevector.go
@@ -132,10 +132,10 @@ func (w *WeightedBaseManaVector) UpdateAll(t time.Time) error {
 }
 
 // GetMana returns combination of Effective Base Mana 1 & 2 weighted as 50-50.
-func (w *WeightedBaseManaVector) GetMana(nodeID identity.ID, t ...time.Time) (float64, time.Time, error) {
+func (w *WeightedBaseManaVector) GetMana(nodeID identity.ID, optionalUpdateTime ...time.Time) (float64, time.Time, error) {
 	w.Lock()
 	defer w.Unlock()
-	return w.getMana(nodeID, t...)
+	return w.getMana(nodeID, optionalUpdateTime...)
 }
 
 // GetManaMap returns mana perception of the node..
@@ -314,15 +314,13 @@ func (w *WeightedBaseManaVector) update(nodeID identity.ID, t time.Time) error {
 }
 
 // getMana returns the current effective mana value. Not concurrency safe.
-func (w *WeightedBaseManaVector) getMana(nodeID identity.ID, updateTime ...time.Time) (float64, time.Time, error) {
+func (w *WeightedBaseManaVector) getMana(nodeID identity.ID, optionalUpdateTime ...time.Time) (float64, time.Time, error) {
 	t := time.Now()
 	if _, exist := w.vector[nodeID]; !exist {
 		return 0.0, t, ErrNodeNotFoundInBaseManaVector
 	}
-	if len(updateTime) > 0 {
-		if updateTime[0].Before(t) {
-			t = updateTime[0]
-		}
+	if len(optionalUpdateTime) > 0 {
+		t = optionalUpdateTime[0]
 	}
 	_ = w.update(nodeID, t)
 

--- a/packages/mana/weightedbasevector.go
+++ b/packages/mana/weightedbasevector.go
@@ -142,10 +142,16 @@ func (w *WeightedBaseManaVector) GetMana(nodeID identity.ID, t ...time.Time) (fl
 func (w *WeightedBaseManaVector) GetManaMap(timestamp ...time.Time) (res NodeMap, t time.Time, err error) {
 	w.Lock()
 	defer w.Unlock()
+	updateAt := time.Now()
+	if len(timestamp) > 0 {
+		if timestamp[0].Before(t) {
+			t = timestamp[0]
+		}
+	}
 	res = make(map[identity.ID]float64)
 	for ID := range w.vector {
 		var mana float64
-		mana, t, err = w.getMana(ID, timestamp...)
+		mana, t, err = w.getMana(ID, updateAt)
 		if err != nil {
 			return nil, t, err
 		}
@@ -162,9 +168,10 @@ func (w *WeightedBaseManaVector) GetHighestManaNodes(n uint) (res []Node, t time
 		// don't lock the vector after this func returns
 		w.Lock()
 		defer w.Unlock()
+		updateAt := time.Now()
 		for ID := range w.vector {
 			var mana float64
-			mana, t, err = w.getMana(ID)
+			mana, t, err = w.getMana(ID, updateAt)
 			if err != nil {
 				return err
 			}

--- a/plugins/mana/plugin.go
+++ b/plugins/mana/plugin.go
@@ -287,37 +287,37 @@ func GetHighestManaNodes(manaType mana.Type, n uint) ([]mana.Node, time.Time, er
 }
 
 // GetManaMap returns type mana perception of the node.
-func GetManaMap(manaType mana.Type, timestamp ...time.Time) (mana.NodeMap, time.Time, error) {
-	return baseManaVectors[manaType].GetManaMap(timestamp...)
+func GetManaMap(manaType mana.Type, optionalUpdateTime ...time.Time) (mana.NodeMap, time.Time, error) {
+	return baseManaVectors[manaType].GetManaMap(optionalUpdateTime...)
 }
 
 // GetAccessMana returns the access mana of the node specified.
-func GetAccessMana(nodeID identity.ID, t ...time.Time) (float64, time.Time, error) {
-	return baseManaVectors[mana.AccessMana].GetMana(nodeID, t...)
+func GetAccessMana(nodeID identity.ID, optionalUpdateTime ...time.Time) (float64, time.Time, error) {
+	return baseManaVectors[mana.AccessMana].GetMana(nodeID, optionalUpdateTime...)
 }
 
 // GetConsensusMana returns the consensus mana of the node specified.
-func GetConsensusMana(nodeID identity.ID, t ...time.Time) (float64, time.Time, error) {
-	return baseManaVectors[mana.ConsensusMana].GetMana(nodeID, t...)
+func GetConsensusMana(nodeID identity.ID, optionalUpdateTime ...time.Time) (float64, time.Time, error) {
+	return baseManaVectors[mana.ConsensusMana].GetMana(nodeID, optionalUpdateTime...)
 }
 
 // GetNeighborsMana returns the type mana of the nodes neighbors
-func GetNeighborsMana(manaType mana.Type, t ...time.Time) (mana.NodeMap, error) {
+func GetNeighborsMana(manaType mana.Type, optionalUpdateTime ...time.Time) (mana.NodeMap, error) {
 	neighbors := gossip.Manager().AllNeighbors()
 	res := make(mana.NodeMap)
 	for _, n := range neighbors {
 		// in case of error, value is 0.0
-		value, _, _ := baseManaVectors[manaType].GetMana(n.ID(), t...)
+		value, _, _ := baseManaVectors[manaType].GetMana(n.ID(), optionalUpdateTime...)
 		res[n.ID()] = value
 	}
 	return res, nil
 }
 
 // GetAllManaMaps returns the full mana maps for comparison with the perception of other nodes.
-func GetAllManaMaps(t ...time.Time) map[mana.Type]mana.NodeMap {
+func GetAllManaMaps(optionalUpdateTime ...time.Time) map[mana.Type]mana.NodeMap {
 	res := make(map[mana.Type]mana.NodeMap)
 	for manaType := range baseManaVectors {
-		res[manaType], _, _ = GetManaMap(manaType, t...)
+		res[manaType], _, _ = GetManaMap(manaType, optionalUpdateTime...)
 	}
 	return res
 }


### PR DESCRIPTION
Methods returning mana maps or lists should use the same timestamp to `getMana` for each node.
- GetManaMap
- GetHighestManaNodes