### PR TITLE
feat: Visualizer tweaks

### DIFF
--- a/plugins/dashboard/frontend/src/app/components/Visualizer.tsx
+++ b/plugins/dashboard/frontend/src/app/components/Visualizer.tsx
@@ -60,7 +60,7 @@ export class Visualizer extends React.Component<Props, any> {
 
     render() {
         let {
-            vertices, solid_count, selected,
+            vertices, confirmed_count, selected,
             selected_approvers_count, selected_approvees_count,
             verticesLimit, tips_count, paused, search
         } = this.props.visualizerStore;
@@ -127,13 +127,17 @@ export class Visualizer extends React.Component<Props, any> {
                         </InputGroup>
                     </Col>
                     <Col xs={{span: 5, offset: 2}}>
-                        <p>
-                            <Badge pill style={{background: "#6c71c4", color: "white"}}>
-                                Solid
+                        <p>                            
+                            <Badge pill style={{background: "#b9b7bd", color: "white"}}>
+                                Pending
                             </Badge>
                             {' '}
-                            <Badge pill style={{background: "#2aa198", color: "white"}}>
-                                Unsolid
+                            <Badge pill style={{background: "#6c71c4", color: "white"}}>
+                                Non-TX Confirmed
+                            </Badge>
+                            {' '}
+                            <Badge pill style={{background: "#fad02c", color: "white"}}>
+                                TX Confirmed
                             </Badge>
                             {' '}
                             <Badge pill style={{background: "#cb4b16", color: "white"}}>
@@ -145,7 +149,7 @@ export class Visualizer extends React.Component<Props, any> {
                             </Badge>
                             <br/>
                             Vertices: {vertices.size}, Tips: {tips_count},
-                            Solid/Unsolid: {solid_count}/{vertices.size - solid_count},{' '}
+                            Confirmed/UnConfirmed: {confirmed_count}/{vertices.size - confirmed_count},{' '}
                             MPS: {last_mps_metric.mps}
                             <br/>
                             Selected: {selected ?

--- a/plugins/dashboard/frontend/src/app/stores/VisualizerStore.ts
+++ b/plugins/dashboard/frontend/src/app/stores/VisualizerStore.ts
@@ -7,8 +7,9 @@ export class Vertex {
     id: string;
     strongParentIDs: Array<string>;
     weakParentIDs: Array<string>;
-    is_solid: boolean;
     is_tip: boolean;
+    is_confirmed: boolean;
+    is_tx: boolean;
 }
 
 export class TipInfo {
@@ -25,7 +26,7 @@ const vertexSize = 20;
 export class VisualizerStore {
     @observable vertices = new ObservableMap<string, Vertex>();
     @observable verticesLimit = 1500;
-    @observable solid_count = 0;
+    @observable confirmed_count = 0;
     @observable tips_count = 0;
     verticesIncomingOrder = [];
     draw: boolean = false;
@@ -51,7 +52,7 @@ export class VisualizerStore {
         this.routerStore = routerStore;
         this.fetchHistory();
         registerHandler(WSMsgType.Vertex, this.addVertex);
-        registerHandler(WSMsgType.TipInfo, this.addTipInfo);     
+        registerHandler(WSMsgType.TipInfo, this.addTipInfo); 
     }
 
     fetchHistory = async () => {
@@ -108,19 +109,18 @@ export class VisualizerStore {
     addVertex = (vert: Vertex) => {        
         let existing = this.vertices.get(vert.id);
         if (existing) {
-            // can only go from unsolid to solid
-            if (!existing.is_solid && vert.is_solid) {
-                existing.is_solid = true;
-                this.solid_count++;
+            if (!existing.is_confirmed && vert.is_confirmed) {
+                existing.is_confirmed = true;
+                this.confirmed_count++;
             }
             // update parent1 and parent2 ids since we might be dealing
             // with a vertex obj only created from a tip info
             existing.strongParentIDs = vert.strongParentIDs;
             existing.weakParentIDs = vert.weakParentIDs;
-            vert = existing
+            vert = existing;
         } else {
-            if (vert.is_solid) {
-                this.solid_count++;
+            if (vert.is_confirmed) {
+                this.confirmed_count++;
             }
             this.verticesIncomingOrder.push(vert.id);
             this.checkLimit();
@@ -166,8 +166,8 @@ export class VisualizerStore {
             if (!vert) {
                 continue;
             }
-            if (vert.is_solid) {
-                this.solid_count--;
+            if (vert.is_confirmed) {
+                this.confirmed_count--;
             }
             if (vert.is_tip) {
                 this.tips_count--;
@@ -191,8 +191,8 @@ export class VisualizerStore {
             if (this.selected && approveeId === this.selected.id) {
                 this.clearSelected();
             }
-            if (approvee.is_solid) {
-                this.solid_count--;
+            if (approvee.is_confirmed) {
+                this.confirmed_count--;
             }
             if (approvee.is_tip) {
                 this.tips_count--;
@@ -247,10 +247,14 @@ export class VisualizerStore {
         if (vert.is_tip) {
             return "#cb4b16";
         }
-        if (vert.is_solid) {
-            return "#6c71c4";
+        if (vert.is_tx && vert.is_confirmed) {
+            return "#fad02c";
         }
-        return "#2aa198";
+        // non-tx message confirmed
+        if (vert.is_confirmed) {
+            return "#6c71c4"
+        }
+        return "#b9b7bd";
     }
 
     start = () => {
@@ -361,7 +365,7 @@ export class VisualizerStore {
         if (!this.selected || (this.selected_via_click && !force_clear)) {
             return;
         }
-        
+
         this.selected_approvers_count = 0;
         this.selected_approvees_count = 0;
 

--- a/plugins/dashboard/frontend/src/app/stores/VisualizerStore.ts
+++ b/plugins/dashboard/frontend/src/app/stores/VisualizerStore.ts
@@ -284,11 +284,17 @@ export class VisualizerStore {
         let events = Viva.Graph.webglInputEvents(graphics, this.graph);
 
         events.mouseEnter((node) => {
-            this.clearSelected();
+            this.clearSelected(true);
             this.updateSelected(node.data);
         }).mouseLeave((node) => {
-            this.clearSelected();
+            this.clearSelected(false);
         });
+
+        events.click((node) => {
+            this.clearSelected(true);
+            this.updateSelected(node.data, true);
+        });
+
         this.graphics = graphics;
         this.renderer.run();
 
@@ -351,12 +357,13 @@ export class VisualizerStore {
     }
 
     @action
-    clearSelected = () => {
-        this.selected_approvers_count = 0;
-        this.selected_approvees_count = 0;
-        if (this.selected_via_click || !this.selected) {
+    clearSelected = (force_clear?: boolean) => {
+        if (!this.selected || (this.selected_via_click && !force_clear)) {
             return;
         }
+        
+        this.selected_approvers_count = 0;
+        this.selected_approvees_count = 0;
 
         // clear link highlight
         let node = this.graph.getNode(this.selected.id);
@@ -390,6 +397,7 @@ export class VisualizerStore {
         );
 
         this.selected = null;
+        this.selected_via_click = false;
     }
 
 }

--- a/plugins/dashboard/plugin.go
+++ b/plugins/dashboard/plugin.go
@@ -152,6 +152,8 @@ const (
 	MsgTypeVertex
 	// MsgTypeTipInfo defines a tip info message.
 	MsgTypeTipInfo
+	// MsgTypeMsgOpinionFormed defines a tip info message.
+	MsgTypeMsgOpinionFormed
 )
 
 type wsmsg struct {

--- a/plugins/dashboard/visualizer.go
+++ b/plugins/dashboard/visualizer.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"sync"
 
+	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 	"github.com/iotaledger/goshimmer/packages/shutdown"
 	"github.com/iotaledger/goshimmer/packages/tangle"
 	"github.com/iotaledger/goshimmer/plugins/messagelayer"
@@ -20,7 +21,7 @@ var (
 	visualizerWorkerPool      *workerpool.WorkerPool
 
 	msgHistoryMutex    sync.RWMutex
-	msgSolid           map[string]bool
+	msgOpinionFormed   map[string]bool
 	msgHistory         []*tangle.Message
 	maxMsgHistorySize  = 1000
 	numHistoryToRemove = 100
@@ -31,7 +32,8 @@ type vertex struct {
 	ID              string   `json:"id"`
 	StrongParentIDs []string `json:"strongParentIDs"`
 	WeakParentIDs   []string `json:"weakParentIDs"`
-	IsSolid         bool     `json:"is_solid"`
+	IsOpinionFormed bool     `json:"is_confirmed"`
+	IsTx            bool     `json:"is_tx"`
 }
 
 // tipinfo holds information about whether a given message is a tip or not.
@@ -49,25 +51,26 @@ func configureVisualizer() {
 	visualizerWorkerPool = workerpool.New(func(task workerpool.Task) {
 		switch x := task.Param(0).(type) {
 		case *tangle.Message:
-			sendVertex(x, task.Param(1).(*tangle.MessageMetadata))
-		case tangle.MessageID:
-			sendTipInfo(x, task.Param(1).(bool))
+			sendVertex(x, task.Param(1).(bool))
+		case tangle.TipType:
+			sendTipInfo(task.Param(1).(tangle.MessageID), task.Param(2).(bool))
 		}
 
 		task.Return(nil)
 	}, workerpool.WorkerCount(visualizerWorkerCount), workerpool.QueueSize(visualizerWorkerQueueSize))
 
 	// configure msgHistory, msgSolid
-	msgSolid = make(map[string]bool, maxMsgHistorySize)
+	msgOpinionFormed = make(map[string]bool, maxMsgHistorySize)
 	msgHistory = make([]*tangle.Message, 0, maxMsgHistorySize)
 }
 
-func sendVertex(msg *tangle.Message, messageMetadata *tangle.MessageMetadata) {
+func sendVertex(msg *tangle.Message, confirmed bool) {
 	broadcastWsMessage(&wsmsg{MsgTypeVertex, &vertex{
 		ID:              msg.ID().String(),
 		StrongParentIDs: msg.StrongParents().ToStrings(),
 		WeakParentIDs:   msg.WeakParents().ToStrings(),
-		IsSolid:         messageMetadata.IsSolid(),
+		IsOpinionFormed: confirmed,
+		IsTx:            msg.Payload().Type() == ledgerstate.TransactionType,
 	}}, true)
 }
 
@@ -82,9 +85,20 @@ func runVisualizer() {
 	notifyNewMsg := events.NewClosure(func(messageID tangle.MessageID) {
 		messagelayer.Tangle().Storage.Message(messageID).Consume(func(message *tangle.Message) {
 			messagelayer.Tangle().Storage.MessageMetadata(messageID).Consume(func(messageMetadata *tangle.MessageMetadata) {
-				addToHistory(message, messageMetadata.IsSolid())
+				confirmed := false
 
-				visualizerWorkerPool.TrySubmit(message, messageMetadata)
+				p := message.Payload()
+				if p.Type() == ledgerstate.TransactionType {
+					txID := p.(*ledgerstate.Transaction).ID()
+					txInclusionState, _ := messagelayer.Tangle().LedgerState.TransactionInclusionState(txID)
+					confirmed = txInclusionState == ledgerstate.Confirmed
+				} else {
+					confirmed = messageMetadata.IsEligible()
+				}
+
+				addToHistory(message, confirmed)
+
+				visualizerWorkerPool.TrySubmit(message, confirmed)
 			})
 		})
 	})
@@ -92,22 +106,22 @@ func runVisualizer() {
 	notifyNewTip := events.NewClosure(func(tipEvent *tangle.TipEvent) {
 		// TODO: handle weak tips
 		if tipEvent.TipType == tangle.StrongTip {
-			visualizerWorkerPool.TrySubmit(tipEvent.MessageID, true)
+			visualizerWorkerPool.TrySubmit(tipEvent.TipType, tipEvent.MessageID, true)
 		}
 	})
 
 	notifyDeletedTip := events.NewClosure(func(tipEvent *tangle.TipEvent) {
 		// TODO: handle weak tips
 		if tipEvent.TipType == tangle.StrongTip {
-			visualizerWorkerPool.TrySubmit(tipEvent.MessageID, false)
+			visualizerWorkerPool.TrySubmit(tipEvent.TipType, tipEvent.MessageID, false)
 		}
 	})
 
 	if err := daemon.BackgroundWorker("Dashboard[Visualizer]", func(shutdownSignal <-chan struct{}) {
 		messagelayer.Tangle().Storage.Events.MessageStored.Attach(notifyNewMsg)
 		defer messagelayer.Tangle().Storage.Events.MessageStored.Detach(notifyNewMsg)
-		messagelayer.Tangle().Solidifier.Events.MessageSolid.Attach(notifyNewMsg)
-		defer messagelayer.Tangle().Solidifier.Events.MessageSolid.Detach(notifyNewMsg)
+		messagelayer.Tangle().OpinionFormer.Events.MessageOpinionFormed.Attach(notifyNewMsg)
+		defer messagelayer.Tangle().OpinionFormer.Events.MessageOpinionFormed.Detach(notifyNewMsg)
 		messagelayer.Tangle().TipManager.Events.TipAdded.Attach(notifyNewTip)
 		defer messagelayer.Tangle().TipManager.Events.TipAdded.Detach(notifyNewTip)
 		messagelayer.Tangle().TipManager.Events.TipRemoved.Attach(notifyDeletedTip)
@@ -136,7 +150,8 @@ func setupVisualizerRoutes(routeGroup *echo.Group) {
 				ID:              msg.ID().String(),
 				StrongParentIDs: msg.StrongParents().ToStrings(),
 				WeakParentIDs:   msg.WeakParents().ToStrings(),
-				IsSolid:         msgSolid[msg.ID().String()],
+				IsOpinionFormed: msgOpinionFormed[msg.ID().String()],
+				IsTx:            msg.Payload().Type() == ledgerstate.TransactionType,
 			})
 		}
 
@@ -144,22 +159,22 @@ func setupVisualizerRoutes(routeGroup *echo.Group) {
 	})
 }
 
-func addToHistory(msg *tangle.Message, solid bool) {
+func addToHistory(msg *tangle.Message, opinionFormed bool) {
 	msgHistoryMutex.Lock()
 	defer msgHistoryMutex.Unlock()
-	if _, exist := msgSolid[msg.ID().String()]; exist {
-		msgSolid[msg.ID().String()] = solid
+	if _, exist := msgOpinionFormed[msg.ID().String()]; exist {
+		msgOpinionFormed[msg.ID().String()] = opinionFormed
 		return
 	}
 
 	// remove 100 old msgs if the slice is full
 	if len(msgHistory) >= maxMsgHistorySize {
 		for i := 0; i < numHistoryToRemove; i++ {
-			delete(msgSolid, msgHistory[i].ID().String())
+			delete(msgOpinionFormed, msgHistory[i].ID().String())
 		}
 		msgHistory = append(msgHistory[:0], msgHistory[numHistoryToRemove:maxMsgHistorySize]...)
 	}
 	// add new msg
 	msgHistory = append(msgHistory, msg)
-	msgSolid[msg.ID().String()] = solid
+	msgOpinionFormed[msg.ID().String()] = opinionFormed
 }


### PR DESCRIPTION
# Description of change

* Preserve the information of clicked msg on the visualizer
* Update the color of messages when it's confirmed (listen to `MessageOpinionFormed` event)
   * tx confirmed -> yellow
   * non-tx confirmed -> purple
   * pending / tx not confirmed -> gray 

![image](https://user-images.githubusercontent.com/11289354/109920969-00abf300-7cf6-11eb-9ae5-7c82f68f31c0.png)

## Type of change

Enhancement

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
