### PR TITLE
add mana pledge nodeIDs option to cli wallet sendFunds

### DIFF
--- a/client/wallet/sendfunds_options.go
+++ b/client/wallet/sendfunds_options.go
@@ -62,10 +62,28 @@ func Remainder(addr address.Address) SendFundsOption {
 	}
 }
 
+// AccessManaPledgeID is an option for SendFunds call that defines the nodeID to pledge access mana to.
+func AccessManaPledgeID(nodeID string) SendFundsOption {
+	return func(options *sendFundsOptions) error {
+		options.AccessManaPledgeID = nodeID
+		return nil
+	}
+}
+
+// ConsensusManaPledgeID is an option for SendFunds call that defines the nodeID to pledge consensus mana to.
+func ConsensusManaPledgeID(nodeID string) SendFundsOption {
+	return func(options *sendFundsOptions) error {
+		options.ConsensusManaPledgeID = nodeID
+		return nil
+	}
+}
+
 // sendFundsOptions is a struct that is used to aggregate the optional parameters provided in the SendFunds call.
 type sendFundsOptions struct {
-	Destinations     map[address.Address]map[ledgerstate.Color]uint64
-	RemainderAddress address.Address
+	Destinations          map[address.Address]map[ledgerstate.Color]uint64
+	RemainderAddress      address.Address
+	AccessManaPledgeID    string
+	ConsensusManaPledgeID string
 }
 
 // buildSendFundsOptions is a utility function that constructs the sendFundsOptions.

--- a/client/wallet/wallet.go
+++ b/client/wallet/wallet.go
@@ -11,6 +11,7 @@ import (
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 	"github.com/iotaledger/goshimmer/packages/mana"
 	"github.com/iotaledger/hive.go/bitmask"
+	"github.com/iotaledger/hive.go/identity"
 	"github.com/iotaledger/hive.go/marshalutil"
 	"golang.org/x/crypto/blake2b"
 )
@@ -94,13 +95,22 @@ func (wallet *Wallet) SendFunds(options ...SendFundsOption) (tx *ledgerstate.Tra
 	if err != nil {
 		return
 	}
-	// take the first in the list (node's own ID is always returned)
-	// TODO: extend this to choose from the list
-	accessPledgeNodeID, err := mana.IDFromStr(allowedPledgeNodeIDs[mana.AccessMana][0])
+	var accessPledgeNodeID identity.ID
+	if sendFundsOptions.AccessManaPledgeID == "" {
+		accessPledgeNodeID, err = mana.IDFromStr(allowedPledgeNodeIDs[mana.AccessMana][0])
+	} else {
+		accessPledgeNodeID, err = mana.IDFromStr(sendFundsOptions.AccessManaPledgeID)
+	}
 	if err != nil {
 		return
 	}
-	consensusPledgeNodeID, err := mana.IDFromStr(allowedPledgeNodeIDs[mana.ConsensusMana][0])
+
+	var consensusPledgeNodeID identity.ID
+	if sendFundsOptions.ConsensusManaPledgeID == "" {
+		consensusPledgeNodeID, err = mana.IDFromStr(allowedPledgeNodeIDs[mana.AccessMana][0])
+	} else {
+		consensusPledgeNodeID, err = mana.IDFromStr(sendFundsOptions.ConsensusManaPledgeID)
+	}
 	if err != nil {
 		return
 	}

--- a/tools/cli-wallet/sendfunds.go
+++ b/tools/cli-wallet/sendfunds.go
@@ -5,10 +5,9 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/iotaledger/goshimmer/client/wallet"
 	"github.com/iotaledger/goshimmer/client/wallet/packages/address"
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
-
-	"github.com/iotaledger/goshimmer/client/wallet"
 	"github.com/mr-tron/base58"
 )
 
@@ -17,6 +16,8 @@ func execSendFundsCommand(command *flag.FlagSet, cliWallet *wallet.Wallet) {
 	addressPtr := command.String("dest-addr", "", "destination address for the transfer")
 	amountPtr := command.Int64("amount", 0, "the amount of tokens that are supposed to be sent")
 	colorPtr := command.String("color", "IOTA", "color of the tokens to transfer (optional)")
+	accessManaPledgeIDPtr := command.String("access-mana-id", "", "node ID to pledge access mana to")
+	consensusManaPledgeIDPtr := command.String("consensus-mana-id", "", "node ID to pledge consensus mana to")
 
 	err := command.Parse(os.Args[2:])
 	if err != nil {
@@ -65,6 +66,8 @@ func execSendFundsCommand(command *flag.FlagSet, cliWallet *wallet.Wallet) {
 		wallet.Destination(address.Address{
 			AddressBytes: destinationAddress.Array(),
 		}, uint64(*amountPtr), color),
+		wallet.AccessManaPledgeID(*accessManaPledgeIDPtr),
+		wallet.ConsensusManaPledgeID(*consensusManaPledgeIDPtr),
 	)
 	if err != nil {
 		printUsage(command, err.Error())


### PR DESCRIPTION
Added 2 new options that define the node ID to which mana is pledged to.

`access-mana-id` , `consensus-mana-id`