### PR TITLE
Make it possible to spam in intervals of random length (rand.ExpFloat64)

### DIFF
--- a/plugins/spammer/webapi.go
+++ b/plugins/spammer/webapi.go
@@ -19,9 +19,17 @@ func handleRequest(c echo.Context) error {
 			request.MPM = 1
 		}
 
+		// IMIF: Inter Message Issuing Function
+		switch request.IMIF {
+		case "exponential":
+			break
+		default:
+			request.IMIF = "uniform"
+		}
+
 		messageSpammer.Shutdown()
-		messageSpammer.Start(request.MPM, time.Minute)
-		log.Infof("Started spamming messages with %d MPM", request.MPM)
+		messageSpammer.Start(request.MPM, time.Minute, request.IMIF)
+		log.Infof("Started spamming messages with %d MPM and %s inter-message issuing function", request.MPM, request.IMIF)
 		return c.JSON(http.StatusOK, Response{Message: "started spamming messages"})
 	case "stop":
 		messageSpammer.Shutdown()
@@ -40,6 +48,7 @@ type Response struct {
 
 // Request contains the parameters of a spammer request.
 type Request struct {
-	Cmd string `json:"cmd"`
-	MPM int    `json:"mpm"`
+	Cmd  string `json:"cmd"`
+	IMIF string `json:"imif"`
+	MPM  int    `json:"mpm"`
 }


### PR DESCRIPTION
# Description of change

Makes it possible to send spam messages in intervals of time following an exponential function (Poisson distribution). This is a common assumption in literature, both for theoretical models or simulations.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Manual tests using tools/docker-network, and running the spammer with, e.g.:

`curl -X GET -H 'Content-Type:application/json' -H 'X-IOTA-API-Version:1' "http://${ip_node}:8080/spammer?cmd=start;mpm=60;imif=exponential"`
and:
`curl -X GET -H 'Content-Type:application/json' -H 'X-IOTA-API-Version:1' "http://${ip_node}:8080/spammer?cmd=start;mpm=60"`

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [ ] My code follows the contribution guidelines for this project (I didn't find any contribution guidelines. Please, point me to them, if they exist)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (I haven't found any spammer-related documentation in the code)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (I haven't found any existing spammer-related unit test. And too lazy to write one :-P)
