### PR TITLE
Mana Sync Behavior

### DIFF
--- a/plugins/dashboard/frontend/src/app/components/Mana.tsx
+++ b/plugins/dashboard/frontend/src/app/components/Mana.tsx
@@ -28,6 +28,10 @@ export class Mana extends React.Component<Props, any> {
         const {searchNode, searchTxID} = this.props.manaStore;
         return (
             <Container>
+                {
+                    !nodeStore.status.synced &&
+                    <Badge variant="danger">WARNING: Node not in sync, displayed mana values might be outdated!</Badge>
+                }
                 <Row className={"mb-3"}>
                     <Col>
                         <ManaGauge

--- a/plugins/dashboard/manafeed.go
+++ b/plugins/dashboard/manafeed.go
@@ -78,12 +78,12 @@ func sendManaValue() {
 	ownID := local.GetInstance().ID()
 	access, _, err := manaPlugin.GetAccessMana(ownID)
 	// if node not found, returned value is 0.0
-	if err != nil && err != mana.ErrNodeNotFoundInBaseManaVector {
+	if err != nil && err != mana.ErrNodeNotFoundInBaseManaVector && err != manaPlugin.ErrQueryNotAllowed {
 		log.Errorf("failed to get own access mana: %s ", err.Error())
 	}
 	consensus, _, err := manaPlugin.GetConsensusMana(ownID)
 	// if node not found, returned value is 0.0
-	if err != nil && err != mana.ErrNodeNotFoundInBaseManaVector {
+	if err != nil && err != mana.ErrNodeNotFoundInBaseManaVector && err != manaPlugin.ErrQueryNotAllowed {
 		log.Errorf("failed to get own consensus mana: %s ", err.Error())
 	}
 	msgData := &ManaValueMsgData{
@@ -101,7 +101,7 @@ func sendManaValue() {
 
 func sendManaMapOverall() {
 	accessManaList, _, err := manaPlugin.GetHighestManaNodes(mana.AccessMana, 0)
-	if err != nil {
+	if err != nil && err != manaPlugin.ErrQueryNotAllowed {
 		log.Errorf("failed to get list of n highest access mana nodes: %s ", err.Error())
 	}
 	accessPayload := &ManaNetworkListMsgData{ManaType: mana.AccessMana.String()}
@@ -116,7 +116,7 @@ func sendManaMapOverall() {
 		Data: accessPayload,
 	})
 	consensusManaList, _, err := manaPlugin.GetHighestManaNodes(mana.ConsensusMana, 0)
-	if err != nil {
+	if err != nil && err != manaPlugin.ErrQueryNotAllowed {
 		log.Errorf("failed to get list of n highest consensus mana nodes: %s ", err.Error())
 	}
 	consensusPayload := &ManaNetworkListMsgData{ManaType: mana.ConsensusMana.String()}
@@ -135,7 +135,7 @@ func sendManaMapOverall() {
 
 func sendManaMapOnline() {
 	accessManaList, _, err := manaPlugin.GetOnlineNodes(mana.AccessMana)
-	if err != nil {
+	if err != nil && err != manaPlugin.ErrQueryNotAllowed {
 		log.Errorf("failed to get list of online access mana nodes: %s", err.Error())
 	}
 	accessPayload := &ManaNetworkListMsgData{ManaType: mana.AccessMana.String()}
@@ -150,7 +150,7 @@ func sendManaMapOnline() {
 		Data: accessPayload,
 	})
 	consensusManaList, _, err := manaPlugin.GetOnlineNodes(mana.ConsensusMana)
-	if err != nil {
+	if err != nil && err != manaPlugin.ErrQueryNotAllowed {
 		log.Errorf("failed to get list of online consensus mana nodes: %s ", err.Error())
 	}
 	consensusPayload := &ManaNetworkListMsgData{ManaType: mana.ConsensusMana.String()}

--- a/plugins/mana/errors.go
+++ b/plugins/mana/errors.go
@@ -1,0 +1,8 @@
+package mana
+
+import "golang.org/x/xerrors"
+
+var (
+	// ErrQueryNotAllowed is returned when the node is not synced and mana debug mode is disabled.
+	ErrQueryNotAllowed = xerrors.New("mana query not allowed, node is not synced, debug mode disabled")
+)

--- a/plugins/mana/parameters.go
+++ b/plugins/mana/parameters.go
@@ -26,6 +26,8 @@ const (
 	CfgManaEnableResearchVectors = "mana.enableResearchVectors"
 	// CfgPruneConsensusEventLogsInterval defines the interval to check and prune consensus event logs storage.
 	CfgPruneConsensusEventLogsInterval = "mana.pruneConsensusEventLogsInterval"
+	// CfgDebuggingEnabled defines if the mana plugin responds to queries while not being in sync or not.
+	CfgDebuggingEnabled = "mana.debuggingEnabled"
 )
 
 func init() {
@@ -38,4 +40,5 @@ func init() {
 	flag.Bool(CfgAllowedConsensusFilterEnabled, false, "if filtering on consensus mana pledge nodes is enabled")
 	flag.Bool(CfgManaEnableResearchVectors, false, "enable mana research vectors")
 	flag.Duration(CfgPruneConsensusEventLogsInterval, 5*time.Minute, "interval to check and prune consensus event storage")
+	flag.Bool(CfgDebuggingEnabled, false, "if mana plugin responds to queries while not in sync")
 }

--- a/plugins/mana/plugin.go
+++ b/plugins/mana/plugin.go
@@ -18,6 +18,7 @@ import (
 	"github.com/iotaledger/goshimmer/plugins/database"
 	"github.com/iotaledger/goshimmer/plugins/gossip"
 	"github.com/iotaledger/goshimmer/plugins/messagelayer"
+	"github.com/iotaledger/goshimmer/plugins/syncbeaconfollower"
 	"github.com/iotaledger/hive.go/daemon"
 	"github.com/iotaledger/hive.go/datastructure/set"
 	"github.com/iotaledger/hive.go/events"
@@ -52,6 +53,7 @@ var (
 	onTransactionConfirmedClosure              *events.Closure
 	onPledgeEventClosure                       *events.Closure
 	onRevokeEventClosure                       *events.Closure
+	debuggingEnabled                           bool
 )
 
 // Plugin gets the plugin instance.
@@ -97,6 +99,8 @@ func configure(*node.Plugin) {
 	if err != nil {
 		log.Panic(err.Error())
 	}
+
+	debuggingEnabled = config.Node().Bool(CfgDebuggingEnabled)
 
 	configureEvents()
 }
@@ -281,27 +285,42 @@ func shutdownStorages() {
 // It also updates the mana values for each node.
 // If n is zero, it returns all nodes.
 func GetHighestManaNodes(manaType mana.Type, n uint) ([]mana.Node, time.Time, error) {
+	if !QueryAllowed() {
+		return []mana.Node{}, time.Now(), ErrQueryNotAllowed
+	}
 	bmv := baseManaVectors[manaType]
 	return bmv.GetHighestManaNodes(n)
 }
 
 // GetManaMap returns type mana perception of the node.
 func GetManaMap(manaType mana.Type, optionalUpdateTime ...time.Time) (mana.NodeMap, time.Time, error) {
+	if !QueryAllowed() {
+		return mana.NodeMap{}, time.Now(), ErrQueryNotAllowed
+	}
 	return baseManaVectors[manaType].GetManaMap(optionalUpdateTime...)
 }
 
 // GetAccessMana returns the access mana of the node specified.
 func GetAccessMana(nodeID identity.ID, optionalUpdateTime ...time.Time) (float64, time.Time, error) {
+	if !QueryAllowed() {
+		return 0, time.Now(), ErrQueryNotAllowed
+	}
 	return baseManaVectors[mana.AccessMana].GetMana(nodeID, optionalUpdateTime...)
 }
 
 // GetConsensusMana returns the consensus mana of the node specified.
 func GetConsensusMana(nodeID identity.ID, optionalUpdateTime ...time.Time) (float64, time.Time, error) {
+	if !QueryAllowed() {
+		return 0, time.Now(), ErrQueryNotAllowed
+	}
 	return baseManaVectors[mana.ConsensusMana].GetMana(nodeID, optionalUpdateTime...)
 }
 
 // GetNeighborsMana returns the type mana of the nodes neighbors
 func GetNeighborsMana(manaType mana.Type, optionalUpdateTime ...time.Time) (mana.NodeMap, error) {
+	if !QueryAllowed() {
+		return mana.NodeMap{}, ErrQueryNotAllowed
+	}
 	neighbors := gossip.Manager().AllNeighbors()
 	res := make(mana.NodeMap)
 	for _, n := range neighbors {
@@ -313,12 +332,15 @@ func GetNeighborsMana(manaType mana.Type, optionalUpdateTime ...time.Time) (mana
 }
 
 // GetAllManaMaps returns the full mana maps for comparison with the perception of other nodes.
-func GetAllManaMaps(optionalUpdateTime ...time.Time) map[mana.Type]mana.NodeMap {
+func GetAllManaMaps(optionalUpdateTime ...time.Time) (map[mana.Type]mana.NodeMap, error) {
+	if !QueryAllowed() {
+		return make(map[mana.Type]mana.NodeMap), ErrQueryNotAllowed
+	}
 	res := make(map[mana.Type]mana.NodeMap)
 	for manaType := range baseManaVectors {
 		res[manaType], _, _ = GetManaMap(manaType, optionalUpdateTime...)
 	}
-	return res
+	return res, nil
 }
 
 // OverrideMana sets the nodes mana to a specific value.
@@ -328,7 +350,10 @@ func OverrideMana(manaType mana.Type, nodeID identity.ID, bm *mana.AccessBaseMan
 }
 
 //GetWeightedRandomNodes returns a weighted random selection of n nodes.
-func GetWeightedRandomNodes(n uint, manaType mana.Type) mana.NodeMap {
+func GetWeightedRandomNodes(n uint, manaType mana.Type) (mana.NodeMap, error) {
+	if !QueryAllowed() {
+		return mana.NodeMap{}, ErrQueryNotAllowed
+	}
 	rand.Seed(time.Now().UTC().UnixNano())
 	manaMap, _, _ := GetManaMap(manaType)
 	var choices []mana.RandChoice
@@ -345,7 +370,7 @@ func GetWeightedRandomNodes(n uint, manaType mana.Type) mana.NodeMap {
 		ID := nodeID.(identity.ID)
 		res[ID] = manaMap[ID]
 	}
-	return res
+	return res, nil
 }
 
 // GetAllowedPledgeNodes returns the list of nodes that type mana is allowed to be pledged to.
@@ -356,6 +381,9 @@ func GetAllowedPledgeNodes(manaType mana.Type) AllowedPledge {
 // GetOnlineNodes gets the list of currently known (and verified) peers in the network, and their respective mana values.
 // Sorted in descending order based on mana. Zero mana nodes are excluded.
 func GetOnlineNodes(manaType mana.Type) (onlineNodesMana []mana.Node, t time.Time, err error) {
+	if !QueryAllowed() {
+		return []mana.Node{}, time.Now(), ErrQueryNotAllowed
+	}
 	knownPeers := autopeering.Discovery().GetVerifiedPeers()
 	// consider ourselves as a peer in the network too
 	knownPeers = append(knownPeers, local.GetInstance().Peer)
@@ -708,4 +736,11 @@ type AllowedPledge struct {
 type EventsLogs struct {
 	Pledge []*mana.PledgedEvent `json:"pledge"`
 	Revoke []*mana.RevokedEvent `json:"revoke"`
+}
+
+// QueryAllowed returns if the mana plugin answers queries or not.
+func QueryAllowed() (allowed bool) {
+	// if debugging enabled, reply to the query
+	// if debugging is not allowed, only reply when in sync
+	return syncbeaconfollower.Synced() || debuggingEnabled
 }

--- a/plugins/metrics/mana.go
+++ b/plugins/metrics/mana.go
@@ -162,7 +162,7 @@ func addPledge(event *mana.PledgedEvent) {
 }
 
 func measureMana() {
-	tmp := manaPlugin.GetAllManaMaps()
+	tmp, _ := manaPlugin.GetAllManaMaps()
 	accessLock.Lock()
 	defer accessLock.Unlock()
 	accessMap = tmp[mana.AccessMana]


### PR DESCRIPTION
Fixes #906
# Description
 Define mana plugin behavior while syncing:

 - Unless `mana.debuggingEnabled` is explicitly enabled in config, the mana plugin replies to all queries with zero value response and `ErrQueryNotAllowed` if the node is not in sync according to the syncbeacon.
 - This does not effect updating the mana vectors, only signals to the caller, that mana values don't make sense until the node is in synced state.
 - Display warning message on the mana page of the dashboard if node is not synced.