### PR TITLE
feat: Add a space between badges in mana dashboard

### DIFF
--- a/plugins/analysis/dashboard/frontend/src/app/components/Mana/Mana.tsx
+++ b/plugins/analysis/dashboard/frontend/src/app/components/Mana/Mana.tsx
@@ -51,6 +51,7 @@ export default class Mana extends React.Component<Props, any> {
                                             }}>
                                                 Events
                                             </Badge>
+                                            {' '}
                                             <Badge pill style={{
                                                 backgroundColor: '#a6f6f1',
                                                 color: 'white'

--- a/plugins/dashboard/frontend/src/app/components/Mana.tsx
+++ b/plugins/dashboard/frontend/src/app/components/Mana.tsx
@@ -110,6 +110,7 @@ export class Mana extends React.Component<Props, any> {
                                             }}>
                                                 Events
                                             </Badge>
+                                            {' '}
                                             <Badge pill style={{
                                                 backgroundColor: '#a6f6f1',
                                                 color: 'white'

--- a/plugins/dashboard/frontend/src/app/components/ManaAllowedPledgeID.tsx
+++ b/plugins/dashboard/frontend/src/app/components/ManaAllowedPledgeID.tsx
@@ -59,6 +59,7 @@ export default class ManaAllowedPledgeID extends React.Component<Props, any> {
                     <Card.Body>
                         <Card.Title>
                             Access Pledge Filter
+                            {' '}
                             {allowedPledgeIDs.accessFilter.enabled ?
                                 <Badge variant="success">Enabled</Badge>:
                                 <Badge variant="danger">Disabled</Badge>
@@ -80,6 +81,7 @@ export default class ManaAllowedPledgeID extends React.Component<Props, any> {
                     <Card.Body>
                         <Card.Title>
                             Consensus Pledge Filter
+                            {' '}
                             {allowedPledgeIDs.consensusFilter.enabled ?
                                 <Badge variant="success">Enabled</Badge>:
                                 <Badge variant="danger">Disabled</Badge>


### PR DESCRIPTION
# Description of change

Add a space between badges in mana dashboard.

Filter section:
![image](https://user-images.githubusercontent.com/11289354/110415862-a8963780-80cd-11eb-844e-d3fc43d820f8.png)

Pledge filter section:
![image](https://user-images.githubusercontent.com/11289354/110415901-bb107100-80cd-11eb-9a51-99179e2dc180.png)

## Type of change

- Enhancement

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
