### PR TITLE
Invalid Referenced Unlock Block in Transaction

### DIFF
--- a/packages/ledgerstate/transaction.go
+++ b/packages/ledgerstate/transaction.go
@@ -213,6 +213,16 @@ func TransactionFromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (transacti
 		return
 	}
 
+	maxReferencedUnlockIndex := len(transaction.essence.Inputs()) - 1
+	for i, unlockBlock := range transaction.unlockBlocks {
+		if unlockBlock.Type() == ReferenceUnlockBlockType {
+			if unlockBlock.(*ReferenceUnlockBlock).ReferencedIndex() > uint16(maxReferencedUnlockIndex) {
+				err = xerrors.Errorf("unlock block %d references non-existent unlock block at index %d", i, unlockBlock.(*ReferenceUnlockBlock).ReferencedIndex())
+				return
+			}
+		}
+	}
+
 	for i, output := range transaction.essence.Outputs() {
 		output.SetID(NewOutputID(transaction.ID(), uint16(i)))
 	}


### PR DESCRIPTION
# Description of change
As described in #1044, currently a reference unlock block in a transaction can reference any indices, which is problematic. A reference unlock block may only reference an existing unlock block, that is, an unlock block that is present in the transaction.
This PR adds this check to the syntactical validation of a transaction.
