### PR TITLE
Fix: Revoke Mana from EmptyNodeID

### DIFF
--- a/packages/mana/accessbasevector_test.go
+++ b/packages/mana/accessbasevector_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 	"github.com/iotaledger/hive.go/events"
 	"github.com/iotaledger/hive.go/identity"
 	"github.com/stretchr/testify/assert"
@@ -46,6 +47,7 @@ var (
 					AccessMana:    inputPledgeID1,
 					ConsensusMana: inputPledgeID1,
 				},
+				InputID: ledgerstate.OutputID{1},
 			},
 			{
 				// funds have been sitting here for couple days...
@@ -55,6 +57,7 @@ var (
 					AccessMana:    inputPledgeID2,
 					ConsensusMana: inputPledgeID2,
 				},
+				InputID: ledgerstate.OutputID{2},
 			},
 			{
 				// funds have been sitting here for couple days...
@@ -64,6 +67,7 @@ var (
 					AccessMana:    inputPledgeID3,
 					ConsensusMana: inputPledgeID3,
 				},
+				InputID: ledgerstate.OutputID{3},
 			},
 		},
 	}

--- a/packages/mana/consensusbasevector.go
+++ b/packages/mana/consensusbasevector.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 	"github.com/iotaledger/hive.go/identity"
 	"golang.org/x/xerrors"
 )
@@ -103,13 +104,12 @@ func (c *ConsensusBaseManaVector) Book(txInfo *TxInfo) {
 	defer c.Unlock()
 	// first, revoke mana from previous owners
 	for _, inputInfo := range txInfo.InputInfos {
-		// which node did the input pledge mana to?
-		pledgeNodeID := inputInfo.PledgeID[c.Type()]
-		// can't revoke from genesis
-		emptyID := identity.ID{}
-		if pledgeNodeID == emptyID {
+		// and there was the genesis once
+		if inputInfo.InputID == ledgerstate.NewOutputID(ledgerstate.GenesisTransactionID, 0) {
 			continue
 		}
+		// which node did the input pledge mana to?
+		pledgeNodeID := inputInfo.PledgeID[c.Type()]
 		if _, exist := c.vector[pledgeNodeID]; !exist {
 			// first time we see this node
 			c.vector[pledgeNodeID] = &ConsensusBaseMana{}

--- a/packages/mana/consensusbasevector_test.go
+++ b/packages/mana/consensusbasevector_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 	"github.com/iotaledger/hive.go/events"
 	"github.com/iotaledger/hive.go/identity"
 	"github.com/stretchr/testify/assert"
@@ -670,6 +671,8 @@ func TestConsensusBaseManaVector_BuildPastBaseVector(t *testing.T) {
 				TimeStamp: inputTime,
 				Amount:    10,
 				PledgeID:  map[Type]identity.ID{ConsensusMana: emptyID},
+				// imitate spending the genesis
+				InputID: ledgerstate.NewOutputID(ledgerstate.GenesisTransactionID, 0),
 			},
 		},
 	}
@@ -684,6 +687,7 @@ func TestConsensusBaseManaVector_BuildPastBaseVector(t *testing.T) {
 				TimeStamp: txTime,
 				Amount:    5,
 				PledgeID:  map[Type]identity.ID{ConsensusMana: inputPledgeID1},
+				InputID:   ledgerstate.OutputID{2},
 			},
 		},
 	}
@@ -698,11 +702,13 @@ func TestConsensusBaseManaVector_BuildPastBaseVector(t *testing.T) {
 				TimeStamp: txTime,
 				Amount:    5,
 				PledgeID:  map[Type]identity.ID{ConsensusMana: inputPledgeID1},
+				InputID:   ledgerstate.OutputID{3},
 			},
 			{
 				TimeStamp: txTime.Add(1 * time.Hour),
 				Amount:    5,
 				PledgeID:  map[Type]identity.ID{ConsensusMana: inputPledgeID2},
+				InputID:   ledgerstate.OutputID{4},
 			},
 		},
 	}


### PR DESCRIPTION
# Description of change
Identify the genesis transaction by its `OutputID` rather than by the fact that it "pledged" consensus mana to `EmptyNodeID`.
With the previous implementation, `EmptyNodeID` was never revoked consensus mana from. 
