### PR TITLE
Fix markers persistence bug

### DIFF
--- a/packages/markers/sequence.go
+++ b/packages/markers/sequence.go
@@ -153,6 +153,16 @@ func (s *Sequence) IncreaseHighestIndex(referencedMarkers *Markers) (index Index
 	return
 }
 
+// String returns a human readable version of the Sequence.
+func (s *Sequence) String() string {
+	return stringify.Struct("Sequence",
+		stringify.StructField("ID", s.ID()),
+		stringify.StructField("ID", s.Rank()),
+		stringify.StructField("ID", s.LowestIndex()),
+		stringify.StructField("ID", s.HighestIndex()),
+	)
+}
+
 // Bytes returns a marshaled version of the Sequence.
 func (s *Sequence) Bytes() []byte {
 	return byteutils.ConcatBytes(s.ObjectStorageKey(), s.ObjectStorageValue())

--- a/plugins/spammer/plugin.go
+++ b/plugins/spammer/plugin.go
@@ -39,7 +39,7 @@ func configure(plugin *node.Plugin) {
 }
 
 func run(*node.Plugin) {
-	if err := daemon.BackgroundWorker("Tangle", func(shutdownSignal <-chan struct{}) {
+	if err := daemon.BackgroundWorker("spammer", func(shutdownSignal <-chan struct{}) {
 		<-shutdownSignal
 
 		messageSpammer.Shutdown()


### PR DESCRIPTION
Fix stupid shutdown and persistence issue of markers because of duplicate background worker name for messagelayer plugin and spammer if the spammer plugin is enabled.
