### PR TITLE
Fix Docker Compose shutdown too early

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
   goshimmer:
     network_mode: host
     image: iotaledger/goshimmer
+    stop_grace_period: 1m
     build:
       context: ./
       dockerfile: Dockerfile


### PR DESCRIPTION
Add 1 minute grace period to docker compose to wait for GoShimmer to gracefully shut down instead of Docker's default, sending SIGKILL after the 10s which leads to GoShimmer not properly shutting down.

Fixes #1063 