### PR TITLE
Deprecation of io/ioutil

### DIFF
--- a/client/lib.go
+++ b/client/lib.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 )
 
@@ -91,7 +90,7 @@ type errorresponse struct {
 }
 
 func interpretBody(res *http.Response, decodeTo interface{}) error {
-	resBody, err := ioutil.ReadAll(res.Body)
+	resBody, err := io.ReadAll(res.Body)
 	if err != nil {
 		return fmt.Errorf("unable to read response body: %w", err)
 	}

--- a/plugins/analysis/dashboard/routes.go
+++ b/plugins/analysis/dashboard/routes.go
@@ -3,7 +3,7 @@ package dashboard
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 
@@ -36,7 +36,7 @@ func indexRoute(e echo.Context) error {
 		if err != nil {
 			return err
 		}
-		devIndexHTML, err := ioutil.ReadAll(res.Body)
+		devIndexHTML, err := io.ReadAll(res.Body)
 		if err != nil {
 			return err
 		}
@@ -48,7 +48,7 @@ func indexRoute(e echo.Context) error {
 	}
 	defer index.Close()
 
-	indexHTML, err := ioutil.ReadAll(index)
+	indexHTML, err := io.ReadAll(index)
 	if err != nil {
 		return err
 	}

--- a/plugins/dashboard/routes.go
+++ b/plugins/dashboard/routes.go
@@ -3,7 +3,7 @@ package dashboard
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 
@@ -35,7 +35,7 @@ func indexRoute(e echo.Context) error {
 		if err != nil {
 			return err
 		}
-		devIndexHTML, err := ioutil.ReadAll(res.Body)
+		devIndexHTML, err := io.ReadAll(res.Body)
 		if err != nil {
 			return err
 		}
@@ -48,7 +48,7 @@ func indexRoute(e echo.Context) error {
 	}
 	defer index.Close()
 
-	indexHTML, err := ioutil.ReadAll(index)
+	indexHTML, err := io.ReadAll(index)
 	if err != nil {
 		return err
 	}

--- a/tools/cli-wallet/config.go
+++ b/tools/cli-wallet/config.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 
 	"github.com/iotaledger/goshimmer/client"
@@ -35,7 +34,7 @@ func loadConfig() {
 			panic(err)
 		}
 
-		if err = ioutil.WriteFile("config.json", []byte(configJSON), 0644); err != nil {
+		if err = os.WriteFile("config.json", []byte(configJSON), 0644); err != nil {
 			panic(err)
 		}
 		if file, err = os.Open("config.json"); err != nil {

--- a/tools/cli-wallet/lib.go
+++ b/tools/cli-wallet/lib.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"unsafe"
@@ -40,7 +39,7 @@ func loadWallet() *wallet.Wallet {
 }
 
 func importWalletStateFile(filename string) (seed *walletseed.Seed, lastAddressIndex uint64, spentAddresses []bitmask.BitMask, assetRegistry *wallet.AssetRegistry, err error) {
-	walletStateBytes, err := ioutil.ReadFile(filename)
+	walletStateBytes, err := os.ReadFile(filename)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			return
@@ -114,7 +113,7 @@ func writeWalletStateFile(wallet *wallet.Wallet, filename string) {
 		}
 	}
 
-	err = ioutil.WriteFile(filename, wallet.ExportState(), 0644)
+	err = os.WriteFile(filename, wallet.ExportState(), 0644)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
# Description of change

Uses the new locations for the names exported by `io/ioutil` that got deprecated with Go 1.16.
