### PR TITLE
Make docker build faster

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,8 @@
 .git
 .gitignore
+.github/
+docs/
+.idea/
 
 LICENSE
 README.md

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -11,6 +11,7 @@ jobs:
     name: autopeering
     env:
       TEST_NAME: autopeering
+      DOCKER_BUILDKIT: 1
     runs-on: ubuntu-latest
     steps:
 
@@ -46,6 +47,7 @@ jobs:
     name: common
     env:
       TEST_NAME: common
+      DOCKER_BUILDKIT: 1
     runs-on: ubuntu-latest
     steps:
 
@@ -80,6 +82,7 @@ jobs:
     name: consensus
     env:
       TEST_NAME: consensus
+      DOCKER_BUILDKIT: 1
     runs-on: ubuntu-latest
     steps:
 
@@ -115,6 +118,7 @@ jobs:
     name: drng
     env:
       TEST_NAME: drng
+      DOCKER_BUILDKIT: 1
     runs-on: ubuntu-latest
     steps:
 
@@ -151,6 +155,7 @@ jobs:
     name: message
     env:
       TEST_NAME: message
+      DOCKER_BUILDKIT: 1
     runs-on: ubuntu-latest
     steps:
 
@@ -187,6 +192,7 @@ jobs:
     name: value
     env:
       TEST_NAME: value
+      DOCKER_BUILDKIT: 1
     runs-on: ubuntu-latest
     steps:
 
@@ -221,6 +227,7 @@ jobs:
     name: faucet
     env:
       TEST_NAME: faucet
+      DOCKER_BUILDKIT: 1
     runs-on: ubuntu-latest
     steps:
 
@@ -255,6 +262,7 @@ jobs:
     name: syncbeacon
     env:
       TEST_NAME: syncbeacon
+      DOCKER_BUILDKIT: 1
     runs-on: ubuntu-latest
     steps:
 
@@ -289,6 +297,7 @@ jobs:
     name: mana
     env:
       TEST_NAME: mana
+      DOCKER_BUILDKIT: 1
     runs-on: ubuntu-latest
     steps:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-# syntax = docker/dockerfile@sha256:6ce32b7af840de740a21ba297f7d1c31e0f1eb0d6b03c0efc03ae0cca9c8fd2a
-# Use Docker fronted docker/dockerfile:1.2.1 to enable BuildKit features.
+# syntax = docker/dockerfile:1.2.1
 
 ############################
 # Build

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,13 +20,12 @@ ENV GO111MODULE=on
 RUN go mod download
 RUN go mod verify
 
-COPY . .
-
 # 1. Mount everything from the current directory to the PWD(Present Working Directory) inside the container
 # 2. Mount the build cache volume
 # 3. Build the binary
 # 4. Verify that goshimmer binary is statically linked
-RUN --mount=type=cache,target=/root/.cache/go-build \
+RUN --mount=target=. \
+    --mount=type=cache,target=/root/.cache/go-build \
     CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
     -ldflags='-w -s -extldflags "-static"' \
     -o /go/bin/goshimmer; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-# syntax = docker/dockerfile:1.2
+# syntax = docker/dockerfile@sha256:6ce32b7af840de740a21ba297f7d1c31e0f1eb0d6b03c0efc03ae0cca9c8fd2a
+# Use Docker fronted docker/dockerfile:1.2.1 to enable BuildKit features.
+
 ############################
 # Build
 ############################

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,13 +19,19 @@ ENV GO111MODULE=on
 RUN go mod download
 RUN go mod verify
 
-# Copy everything from the current directory to the PWD(Present Working Directory) inside the container
-COPY . .
+# 1. Mount everything from the current directory to the PWD(Present Working Directory) inside the container
+# 2. Mount the build cache volume
+# 3. Build the binary
+# 4. Verify that goshimmer binary is statically linked
+RUN --mount=target=. \
 
-# Build the binary
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
-      -ldflags='-w -s -extldflags "-static"' -a \
-       -o /go/bin/goshimmer
+    --mount=type=cache,target=/root/.cache/go-build \
+
+    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+    -ldflags='-w -s -extldflags "-static"' \
+    -o /go/bin/goshimmer; \
+
+    ./check_static.sh
 
 ############################
 # Image

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,12 +20,13 @@ ENV GO111MODULE=on
 RUN go mod download
 RUN go mod verify
 
+COPY . .
+
 # 1. Mount everything from the current directory to the PWD(Present Working Directory) inside the container
 # 2. Mount the build cache volume
 # 3. Build the binary
 # 4. Verify that goshimmer binary is statically linked
-RUN --mount=target=. \
-    --mount=type=cache,target=/root/.cache/go-build \
+RUN --mount=type=cache,target=/root/.cache/go-build \
     CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
     -ldflags='-w -s -extldflags "-static"' \
     -o /go/bin/goshimmer; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax = docker/dockerfile:1.2
 ############################
 # Build
 ############################
@@ -24,13 +25,10 @@ RUN go mod verify
 # 3. Build the binary
 # 4. Verify that goshimmer binary is statically linked
 RUN --mount=target=. \
-
     --mount=type=cache,target=/root/.cache/go-build \
-
     CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
     -ldflags='-w -s -extldflags "-static"' \
     -o /go/bin/goshimmer; \
-
     ./check_static.sh
 
 ############################

--- a/check_static.sh
+++ b/check_static.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# This script uses ldd utility to verify that result goshimmer binary is statically linked
+
+ldd /go/bin/goshimmer &> /dev/null
+if [ $? -ne 0 ]; then
+  exit 0
+else
+  echo "/go/bin/goshimmer must be a statically linked binary"
+  exit 1
+fi

--- a/tools/docker-network/run.sh
+++ b/tools/docker-network/run.sh
@@ -8,6 +8,8 @@ fi
 REPLICAS=$1
 GRAFANA=${2:-0}
 
+DOCKER_BUILDKIT=1
+COMPOSE_DOCKER_CLI_BUILD=1
 echo "Build GoShimmer"
 docker-compose -f builder/docker-compose.builder.yml up --abort-on-container-exit --exit-code-from builder
 

--- a/tools/integration-tests/runTests.sh
+++ b/tools/integration-tests/runTests.sh
@@ -2,6 +2,8 @@
 
 TEST_NAMES='autopeering common drng message value consensus faucet syncbeacon mana'
 
+DOCKER_BUILDKIT=1
+COMPOSE_DOCKER_CLI_BUILD=1
 echo "Build GoShimmer image"
 docker build -t iotaledger/goshimmer ../../.
 


### PR DESCRIPTION
Docker build now mounts a volume for Go build-cache during the image build. Another small optimization is: mount the codebase instead of COPYing it.
As a result, the docker re-build time is 4.5s instead of the 50s before on my laptop