### PR TITLE
Restrict Genesis attachment

### DIFF
--- a/packages/tangle/storage.go
+++ b/packages/tangle/storage.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/iotaledger/goshimmer/packages/clock"
 	"github.com/iotaledger/goshimmer/packages/database"
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 	"github.com/iotaledger/goshimmer/packages/markers"
@@ -255,9 +256,10 @@ func (s *Storage) MarkerIndexBranchIDMapping(sequenceID markers.SequenceID, comp
 func (s *Storage) storeGenesis() {
 	s.MessageMetadata(EmptyMessageID, func() *MessageMetadata {
 		genesisMetadata := &MessageMetadata{
-			messageID: EmptyMessageID,
-			solid:     true,
-			branchID:  ledgerstate.MasterBranchID,
+			solidificationTime: clock.SyncedTime(),
+			messageID:          EmptyMessageID,
+			solid:              true,
+			branchID:           ledgerstate.MasterBranchID,
 			structureDetails: &markers.StructureDetails{
 				Rank:          0,
 				IsPastMarker:  false,
@@ -274,7 +276,6 @@ func (s *Storage) storeGenesis() {
 
 		return genesisMetadata
 	}).Release()
-
 }
 
 // deleteStrongApprover deletes an Approver from the object storage that was created by a strong parent.

--- a/packages/tangle/storage.go
+++ b/packages/tangle/storage.go
@@ -256,7 +256,7 @@ func (s *Storage) MarkerIndexBranchIDMapping(sequenceID markers.SequenceID, comp
 func (s *Storage) storeGenesis() {
 	s.MessageMetadata(EmptyMessageID, func() *MessageMetadata {
 		genesisMetadata := &MessageMetadata{
-			solidificationTime: clock.SyncedTime(),
+			solidificationTime: clock.SyncedTime().Add(time.Duration(-20) * time.Minute),
 			messageID:          EmptyMessageID,
 			solid:              true,
 			branchID:           ledgerstate.MasterBranchID,

--- a/packages/tangle/tangle.go
+++ b/packages/tangle/tangle.go
@@ -6,6 +6,7 @@ import (
 	"github.com/iotaledger/goshimmer/packages/markers"
 	"github.com/iotaledger/goshimmer/packages/tangle/payload"
 	"github.com/iotaledger/hive.go/autopeering/peer"
+	"github.com/iotaledger/hive.go/crypto/ed25519"
 	"github.com/iotaledger/hive.go/events"
 	"github.com/iotaledger/hive.go/identity"
 	"github.com/iotaledger/hive.go/kvstore"
@@ -191,6 +192,7 @@ type Options struct {
 	IncreaseMarkersIndexCallback markers.IncreaseIndexCallback
 	TangleWidth                  int
 	ConsensusMechanism           ConsensusMechanism
+	GenesisNode                  *ed25519.PublicKey
 }
 
 // Store is an Option for the Tangle that allows to specify which storage layer is supposed to be used to persist data.
@@ -222,10 +224,24 @@ func IncreaseMarkersIndexCallback(callback markers.IncreaseIndexCallback) Option
 	}
 }
 
-// TangleWidth is an Option for the Tangle that allows to change the strategy how Tips get removed.
-func TangleWidth(width int) Option {
+// Width is an Option for the Tangle that allows to change the strategy how Tips get removed.
+func Width(width int) Option {
 	return func(options *Options) {
 		options.TangleWidth = width
+	}
+}
+
+// GenesisNode is an Option for the Tangle that allows to set the GenesisNode, i.e., the node that is allowed to attach
+// to the Genesis Message.
+func GenesisNode(genesisNode string) Option {
+	var genesisPublicKey *ed25519.PublicKey
+	pk, _, err := ed25519.PublicKeyFromBytes([]byte(genesisNode))
+	if err == nil {
+		genesisPublicKey = &pk
+	}
+
+	return func(options *Options) {
+		options.GenesisNode = genesisPublicKey
 	}
 }
 

--- a/plugins/messagelayer/parameters.go
+++ b/plugins/messagelayer/parameters.go
@@ -10,7 +10,8 @@ var Parameters = struct {
 	// Snapshot contains snapshots related configuration parameters.
 	Snapshot struct {
 		// File is the path to the snapshot file.
-		File string `default:"./snapshot.bin" usage:"the path to the snapshot file"`
+		File        string `default:"./snapshot.bin" usage:"the path to the snapshot file"`
+		GenesisNode string `default:"Gm7W191NDnqyF7KJycZqK7V6ENLwqxTwoKQN4SmpkB24" usage:"the node that is allowed to attach to the genesis message"`
 	}
 
 	// FCOB contains parameters related to the fast consensus of barcelona.

--- a/plugins/messagelayer/plugin.go
+++ b/plugins/messagelayer/plugin.go
@@ -93,8 +93,9 @@ func Tangle() *tangle.Tangle {
 		tangleInstance = tangle.New(
 			tangle.Store(database.Store()),
 			tangle.Identity(local.GetInstance().LocalIdentity()),
-			tangle.TangleWidth(Parameters.TangleWidth),
+			tangle.Width(Parameters.TangleWidth),
 			tangle.Consensus(ConsensusMechanism()),
+			tangle.GenesisNode(Parameters.Snapshot.GenesisNode),
 		)
 
 		tangleInstance.Setup()

--- a/tools/docker-network/docker-compose.yml
+++ b/tools/docker-network/docker-compose.yml
@@ -45,6 +45,7 @@ services:
       --node.disablePlugins=syncbeaconfollower,clock
       --faucet.seed=7R1itJx5hVuo9w9hjg5cwKFmek4HMSoBDgJZN8hKGxih
       --messageLayer.snapshot.file=/tmp/assets/7R1itJx5hVuo9w9hjg5cwKFmek4HMSoBDgJZN8hKGxih.bin
+      --messageLayer.snapshot.genesisNode=
       --syncbeacon.broadcastInterval=5
       --syncbeacon.startSynced=true
       --metrics.manaResearch=true
@@ -71,6 +72,7 @@ services:
       --database.directory=/tmp/mainnetdb
       --node.enablePlugins=bootstrap,"webapi tools endpoint"
       --messageLayer.snapshot.file=/tmp/assets/7R1itJx5hVuo9w9hjg5cwKFmek4HMSoBDgJZN8hKGxih.bin
+      --messageLayer.snapshot.genesisNode=
       --node.disablePlugins=portcheck,clock
       --syncbeaconfollower.followNodes=EYsaGXnUVA9aTYL9FwYEvoQ8d1HCJveQVL7vogu6pqCP
       --webapi.exportPath=/tmp/

--- a/tools/integration-tests/tester/framework/docker.go
+++ b/tools/integration-tests/tester/framework/docker.go
@@ -113,6 +113,7 @@ func (d *DockerContainer) CreateGoShimmerPeer(config GoShimmerConfig) error {
 			}(),
 			fmt.Sprintf("--faucet.tokensPerRequest=%d", ParaFaucetTokensPerRequest),
 			fmt.Sprintf("--messageLayer.snapshot.file=%s", config.SnapshotFilePath),
+			"--messageLayer.snapshot.genesisNode=",
 			"--webapi.bindAddress=0.0.0.0:8080",
 			fmt.Sprintf("--autopeering.seed=base58:%s", config.Seed),
 			fmt.Sprintf("--autopeering.entryNodes=%s@%s:14626", config.EntryNodePublicKey, config.EntryNodeHost),


### PR DESCRIPTION
Restrict attachment to Genesis to a default node or enable time based verification if no node is given (useful for testing). This effectively prevents anyone from attaching to the Genesis except a special bootstrap node.