### PR TITLE
Update to v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v0.5.2 - 2021-03-17
+* Fix markers past cone check
+* Add more information to explorer and message API
+* Restrict Genesis attachment
+* Fix parsing of GenesisNode public key
+* Display mana histogram in log scale on dashboards
+* **Breaking**: bumps network and database versions
+
 # v0.5.1 - 2021-03-15
 * Implement FCoB*
 * Fix markers persistence bug

--- a/plugins/autopeering/parameters.go
+++ b/plugins/autopeering/parameters.go
@@ -13,5 +13,5 @@ const (
 
 func init() {
 	flag.StringSlice(CfgEntryNodes, []string{"2PV5487xMw5rasGBXXWeqSi4hLz7r19YBt8Y1TGAsQbj@ressims.iota.cafe:15626", "5EDH4uY78EA6wrBkHHAVBWBMDt7EcksRq6pjzipoW15B@entryshimmer.tanglebay.com:14646"}, "list of trusted entry nodes for auto peering")
-	flag.Int(CfgNetworkVersion, 19, "autopeering network version")
+	flag.Int(CfgNetworkVersion, 20, "autopeering network version")
 }

--- a/plugins/banner/plugin.go
+++ b/plugins/banner/plugin.go
@@ -17,7 +17,7 @@ var (
 	once   sync.Once
 
 	// AppVersion version number
-	AppVersion = "v0.5.1"
+	AppVersion = "v0.5.2"
 	// SimplifiedAppVersion is the version number without commit hash
 	SimplifiedAppVersion = simplifiedVersion(AppVersion)
 )

--- a/plugins/database/versioning.go
+++ b/plugins/database/versioning.go
@@ -10,7 +10,7 @@ import (
 const (
 	// DBVersion defines the version of the database schema this version of GoShimmer supports.
 	// Every time there's a breaking change regarding the stored data, this version flag should be adjusted.
-	DBVersion = 21
+	DBVersion = 22
 )
 
 var (


### PR DESCRIPTION
# v0.5.2 - 2021-03-17
* Fix markers past cone check
* Add more information to explorer and message API
* Restrict Genesis attachment
* Fix parsing of GenesisNode public key
* Display mana histogram in log scale on dashboards
* **Breaking**: bumps network and database versions