### PR TITLE
Fix: Added missing checks to UnlockBlock parsing

### DIFF
--- a/packages/ledgerstate/unlockblock_test.go
+++ b/packages/ledgerstate/unlockblock_test.go
@@ -1,0 +1,36 @@
+package ledgerstate
+
+import (
+	"testing"
+
+	"github.com/iotaledger/hive.go/crypto/ed25519"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnlockBlockFromMarshalUtil(t *testing.T) {
+	keyPair := ed25519.GenerateKeyPair()
+
+	// test a valid set of UnlockBlocks
+	{
+		unlockBlocks := UnlockBlocks{
+			NewSignatureUnlockBlock(NewED25519Signature(keyPair.PublicKey, keyPair.PrivateKey.Sign([]byte("testdata")))),
+			NewReferenceUnlockBlock(0),
+		}
+		marshaledUnlockBlocks := unlockBlocks.Bytes()
+		parsedUnlockBlocks, consumedBytes, err := UnlockBlocksFromBytes(marshaledUnlockBlocks)
+
+		assert.NoError(t, err)
+		assert.Equal(t, len(marshaledUnlockBlocks), consumedBytes)
+		assert.Equal(t, unlockBlocks, parsedUnlockBlocks)
+	}
+
+	// test an invalid set of UnlockBlocks
+	{
+		unlockBlocks := UnlockBlocks{
+			NewSignatureUnlockBlock(NewED25519Signature(keyPair.PublicKey, keyPair.PrivateKey.Sign([]byte("testdata")))),
+			NewSignatureUnlockBlock(NewED25519Signature(keyPair.PublicKey, keyPair.PrivateKey.Sign([]byte("testdata")))),
+		}
+		_, _, err := UnlockBlocksFromBytes(unlockBlocks.Bytes())
+		assert.Error(t, err)
+	}
+}


### PR DESCRIPTION
# Description of change

This PR fixes the missing duplicates check in the parsing of the UnlockBlocks.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
