### PR TITLE
Explorer model navigation

### DIFF
--- a/plugins/dashboard/explorer_routes.go
+++ b/plugins/dashboard/explorer_routes.go
@@ -142,6 +142,15 @@ func setupExplorerRoutes(routeGroup *echo.Group) {
 	routeGroup.GET("/mana/pending", func(c echo.Context) error {
 		return manaAPI.GetPendingMana(c)
 	})
+	routeGroup.GET("/branch/:branchID", func(c echo.Context) error {
+		return ledgerstateAPI.GetBranch(c)
+	})
+	routeGroup.GET("/branch/:branchID/children", func(c echo.Context) error {
+		return ledgerstateAPI.GetBranchChildren(c)
+	})
+	routeGroup.GET("/branch/:branchID/conflicts", func(c echo.Context) error {
+		return ledgerstateAPI.GetBranchConflicts(c)
+	})
 
 	routeGroup.GET("/search/:search", func(c echo.Context) error {
 		search := c.Param("search")

--- a/plugins/dashboard/explorer_routes.go
+++ b/plugins/dashboard/explorer_routes.go
@@ -139,6 +139,12 @@ func setupExplorerRoutes(routeGroup *echo.Group) {
 	routeGroup.GET("/output/:outputID", func(c echo.Context) error {
 		return ledgerstateAPI.GetOutput(c)
 	})
+	routeGroup.GET("/output/:outputID/metadata", func(c echo.Context) error {
+		return ledgerstateAPI.GetOutputMetadata(c)
+	})
+	routeGroup.GET("/output/:outputID/consumers", func(c echo.Context) error {
+		return ledgerstateAPI.GetOutputConsumers(c)
+	})
 	routeGroup.GET("/mana/pending", func(c echo.Context) error {
 		return manaAPI.GetPendingMana(c)
 	})

--- a/plugins/dashboard/explorer_routes.go
+++ b/plugins/dashboard/explorer_routes.go
@@ -9,6 +9,7 @@ import (
 	"github.com/iotaledger/goshimmer/plugins/mana"
 	"github.com/iotaledger/goshimmer/plugins/messagelayer"
 	ledgerstateAPI "github.com/iotaledger/goshimmer/plugins/webapi/ledgerstate"
+	manaAPI "github.com/iotaledger/goshimmer/plugins/webapi/mana"
 	valueutils "github.com/iotaledger/goshimmer/plugins/webapi/value"
 	"github.com/labstack/echo"
 	"github.com/mr-tron/base58/base58"
@@ -87,6 +88,7 @@ type ExplorerAddress struct {
 // ExplorerOutput defines the struct of the ExplorerOutput.
 type ExplorerOutput struct {
 	ID                 string                    `json:"id"`
+	TransactionID      string                    `json:"transaction_id"`
 	Balances           []valueutils.Balance      `json:"balances"`
 	InclusionState     valueutils.InclusionState `json:"inclusion_state"`
 	SolidificationTime int64                     `json:"solidification_time"`
@@ -136,6 +138,9 @@ func setupExplorerRoutes(routeGroup *echo.Group) {
 	})
 	routeGroup.GET("/output/:outputID", func(c echo.Context) error {
 		return ledgerstateAPI.GetOutput(c)
+	})
+	routeGroup.GET("/mana/pending", func(c echo.Context) error {
+		return manaAPI.GetPendingMana(c)
 	})
 
 	routeGroup.GET("/search/:search", func(c echo.Context) error {
@@ -227,7 +232,8 @@ func findAddress(strAddress string) (*ExplorerAddress, error) {
 
 		pendingMana, _ := mana.PendingManaOnOutput(output.ID())
 		outputids = append(outputids, ExplorerOutput{
-			ID:                 output.ID().String(),
+			ID:                 output.ID().Base58(),
+			TransactionID:      output.ID().TransactionID().Base58(),
 			Balances:           b,
 			InclusionState:     inclusionState,
 			ConsumerCount:      consumerCount,

--- a/plugins/dashboard/frontend/src/app/components/Explorer.tsx
+++ b/plugins/dashboard/frontend/src/app/components/Explorer.tsx
@@ -6,6 +6,9 @@ import NodeStore from "app/stores/NodeStore";
 import {inject, observer} from "mobx-react";
 import {ExplorerSearchbar} from "app/components/ExplorerSearchbar";
 import {ExplorerLiveFeed} from "app/components/ExplorerLiveFeed";
+import {ExplorerTransactionSearchbar} from "app/components/ExplorerTransactionSearchbar";
+import {ExplorerOutputSearchbar} from "app/components/ExplorerOutputSearchbar";
+import {ExplorerBranchSearchbar} from "app/components/ExplorerBranchSearchbar";
 
 interface Props {
     nodeStore?: NodeStore;
@@ -21,11 +24,26 @@ export class Explorer extends React.Component<Props, any> {
                 <Row className={"mb-3"}>
                     <Col>
                         <p>
-                            Search for addresses or messages.
+                            Search for addresses, messages, transactions, outputs and branches.
                         </p>
                     </Col>
                 </Row>
-                <ExplorerSearchbar/>
+                <Row>
+                    <Col>
+                        <ExplorerSearchbar/>
+                    </Col>
+                    <Col>
+                        <ExplorerTransactionSearchbar/>
+                    </Col>
+                </Row>
+                <Row>
+                    <Col>
+                        <ExplorerOutputSearchbar/>
+                    </Col>
+                    <Col>
+                        <ExplorerBranchSearchbar/>
+                    </Col>
+                </Row>
                 <ExplorerLiveFeed/>
                 <small>
                     This explorer implementation is heavily inspired by <a

--- a/plugins/dashboard/frontend/src/app/components/ExplorerAddressResult.tsx
+++ b/plugins/dashboard/frontend/src/app/components/ExplorerAddressResult.tsx
@@ -8,7 +8,6 @@ import ExplorerStore from "app/stores/ExplorerStore";
 import Spinner from "react-bootstrap/Spinner";
 import ListGroup from "react-bootstrap/ListGroup";
 import Alert from "react-bootstrap/Alert";
-import * as dateformat from 'dateformat';
 import {displayManaUnit} from "app/utils";
 
 interface Props {
@@ -111,9 +110,12 @@ export class ExplorerAddressQueryResult extends React.Component<Props, any> {
                 outputs.push(
                     <ListGroup.Item key={output.id}>
                         <small>
-                            <div>{'Output ID:'} {output.id} {' '}</div>
+                            <div>Output ID: <a href={`/explorer/output/${output.id}`}>{output.id}</a></div>
+                            <div>Transaction ID:  <a href={`/explorer/transaction/${output.transaction_id}`}>{output.transaction_id}</a></div>
+                            <div>Index: {output.index}</div>
+                            <div>Type: {output.type}</div>
                             {output.solidification_time != 0 &&
-                                <div>Solidification Time: {dateformat(new Date(output.solidification_time * 1000), "dd.mm.yyyy HH:MM:ss")}</div>
+                                <div>Solidification Time: {new Date(output.solidification_time * 1000).toLocaleString()}</div>
                             }
                             <div>{status}</div>
                             <div>{consumed}</div>

--- a/plugins/dashboard/frontend/src/app/components/ExplorerBranchQueryResult.tsx
+++ b/plugins/dashboard/frontend/src/app/components/ExplorerBranchQueryResult.tsx
@@ -1,0 +1,104 @@
+import * as React from 'react';
+import Container from "react-bootstrap/Container";
+import NodeStore from "app/stores/NodeStore";
+import { inject, observer } from "mobx-react";
+import ExplorerStore from "app/stores/ExplorerStore";
+import ListGroup from "react-bootstrap/ListGroup";
+import Badge from "react-bootstrap/Badge";
+
+
+interface Props {
+    nodeStore?: NodeStore;
+    explorerStore?: ExplorerStore;
+    match?: {
+        params: {
+            id: string,
+        }
+    }
+}
+
+@inject("nodeStore")
+@inject("explorerStore")
+@observer
+export class ExplorerBranchQueryResult extends React.Component<Props, any> {
+    componentDidMount() {
+        this.props.explorerStore.getBranch(this.props.match.params.id);
+        this.props.explorerStore.getBranchChildren(this.props.match.params.id);
+        this.props.explorerStore.getBranchConflicts(this.props.match.params.id);
+    }
+
+    componentWillUnmount() {
+        this.props.explorerStore.reset();
+    }
+    render() {
+        let {id} = this.props.match.params;
+        let { query_err, branch, branchChildren, branchConflicts } = this.props.explorerStore;
+
+        if (query_err) {
+            return (
+                <Container>
+                    <h4>Branch not found - 404</h4>
+                    <span>{id}</span>
+                </Container>
+            );
+        }
+        let renderInclusionState = (inclusionState: string) => {
+            let variant = "secondary";
+            let value = ""
+            switch(inclusionState) {
+                case "InclusionState(Confirmed)":
+                    variant = "success";
+                    value = "confirmed"
+                    break;
+                case "InclusionState(Rejected)":
+                    variant = "danger";
+                    value = "rejected"
+                    break;
+                case "InclusionState(Pending)":
+                    variant = "warning";
+                    value = "pending"
+                    break;
+            }
+            return <Badge variant={variant}>{value}</Badge>
+        }
+        return (
+            <Container>
+                <h4>Branch</h4>
+                {branch && <ListGroup>
+                    <ListGroup.Item>ID: {branch.id}</ListGroup.Item>
+                    <ListGroup.Item>Type: {branch.type}</ListGroup.Item>
+                    <ListGroup.Item>Parents:
+                        <ListGroup>
+                        {branch.parents.map((p,i) => <ListGroup.Item key={i}>{p}</ListGroup.Item>)}
+                        </ListGroup>
+                    </ListGroup.Item>
+                    <ListGroup.Item>Conflicts:
+                        {branch.conflictIDs && <ListGroup>
+                            {branch.conflictIDs.map((c,i) => <ListGroup.Item key={i}>{c}</ListGroup.Item>)}
+                        </ListGroup>}
+                    </ListGroup.Item>
+                    <ListGroup.Item>Finalized: {branch.finalized.toString()}</ListGroup.Item>
+                    <ListGroup.Item>Monotonically Liked: {branch.monotonicallyLiked.toString()}</ListGroup.Item>
+                    <ListGroup.Item>Inclusion State: {renderInclusionState(branch.inclusionState)}</ListGroup.Item>
+                    <ListGroup.Item> Children:
+                        {branchChildren && <ListGroup>
+                            {branchChildren.childBranches.map((c,i) => <ListGroup.Item key={i}><a href={`/explorer/branch/${c}`}>{c}</a></ListGroup.Item>)}
+                        </ListGroup> }
+                    </ListGroup.Item>
+                    <ListGroup.Item> Conflicts:
+                        {branchConflicts && <ListGroup>
+                            {branchConflicts.conflicts.map((c,i) => <div key={i}>
+                                OutputID: <a href={`/explorer/output/${c.outputID}`}>{c.outputID}</a>
+                                <ListGroup className={"mb-2"}>
+                                    {c.branchIDs.map((b,j) => <ListGroup.Item key={j}>
+                                        <a href={`/explorer/branch/${b}`}>{b}</a>
+                                    </ListGroup.Item>)}
+                                </ListGroup>
+                            </div>)}
+                        </ListGroup> }
+                    </ListGroup.Item>
+                </ListGroup>}
+            </Container>
+        )
+    }
+}

--- a/plugins/dashboard/frontend/src/app/components/ExplorerBranchQueryResult.tsx
+++ b/plugins/dashboard/frontend/src/app/components/ExplorerBranchQueryResult.tsx
@@ -88,7 +88,7 @@ export class ExplorerBranchQueryResult extends React.Component<Props, any> {
                     <ListGroup.Item> Conflicts:
                         {branchConflicts && <ListGroup>
                             {branchConflicts.conflicts.map((c,i) => <div key={i}>
-                                OutputID: <a href={`/explorer/output/${c.outputID}`}>{c.outputID}</a>
+                                OutputID: <a href={`/explorer/output/${c.outputID.base58}`}>{c.outputID.base58}</a>
                                 <ListGroup className={"mb-2"}>
                                     {c.branchIDs.map((b,j) => <ListGroup.Item key={j}>
                                         <a href={`/explorer/branch/${b}`}>{b}</a>

--- a/plugins/dashboard/frontend/src/app/components/ExplorerBranchSearchbar.tsx
+++ b/plugins/dashboard/frontend/src/app/components/ExplorerBranchSearchbar.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import {KeyboardEvent} from 'react';
+import NodeStore from "app/stores/NodeStore";
+import {inject, observer} from "mobx-react";
+import FormControl from "react-bootstrap/FormControl";
+import ExplorerStore from "app/stores/ExplorerStore";
+import Row from "react-bootstrap/Row";
+import Col from "react-bootstrap/Col";
+import InputGroup from "react-bootstrap/InputGroup";
+
+interface Props {
+    nodeStore?: NodeStore;
+    explorerStore?: ExplorerStore;
+}
+
+@inject("nodeStore")
+@inject("explorerStore")
+@observer
+export class ExplorerBranchSearchbar extends React.Component<Props, any> {
+    branchID: string;
+
+    updateSearch = (e) => {
+        this.branchID =e.target.value;
+    };
+
+    executeSearch = (e: KeyboardEvent) => {
+        if (e.key !== 'Enter') return;
+        this.props.explorerStore.routerStore.push(`/explorer/branch/${this.branchID}`);
+    };
+
+    render() {
+        let {searching} = this.props.explorerStore;
+
+        return (
+            <React.Fragment>
+                <Row className={"mb-3"}>
+                    <Col>
+                        <InputGroup className="mb-3">
+                            <FormControl
+                                placeholder="Branch ID"
+                                aria-label="Branch ID"
+                                aria-describedby="basic-addon1"
+                                value={this.branchID} onChange={this.updateSearch}
+                                onKeyUp={this.executeSearch}
+                                disabled={searching}
+                            />
+                        </InputGroup>
+                    </Col>
+                </Row>
+            </React.Fragment>
+        );
+    }
+}

--- a/plugins/dashboard/frontend/src/app/components/ExplorerOutputQueryResult.tsx
+++ b/plugins/dashboard/frontend/src/app/components/ExplorerOutputQueryResult.tsx
@@ -24,6 +24,8 @@ export class ExplorerOutputQueryResult extends React.Component<Props, any> {
     componentDidMount() {
         this.props.explorerStore.getOutput(this.props.match.params.id);
         this.props.explorerStore.getPendingMana(this.props.match.params.id);
+        this.props.explorerStore.getOutputMetadata(this.props.match.params.id);
+        this.props.explorerStore.getOutputConsumers(this.props.match.params.id);
     }
 
     componentWillUnmount() {
@@ -31,7 +33,17 @@ export class ExplorerOutputQueryResult extends React.Component<Props, any> {
     }
     render() {
         let {id} = this.props.match.params;
-        let { query_err, output, pendingMana } = this.props.explorerStore;
+        let { query_err, output, pendingMana, outputMetadata, outputConsumers } = this.props.explorerStore;
+
+        let renderTriBool = (val: string) => {
+            if (val === "true"){
+                return <Badge variant={"success"}>True</Badge>
+            }
+            if (val === "false"){
+                return <Badge variant={"danger"}>False</Badge>
+            }
+            return <Badge variant={"warning"}>Maybe</Badge>
+        }
 
         if (query_err) {
             return (
@@ -44,7 +56,7 @@ export class ExplorerOutputQueryResult extends React.Component<Props, any> {
         return (
             <Container>
                 <h4>Output</h4>
-                {output && <div>
+                {output && <div className={"mb-2"}>
                     <ListGroup>
                         <ListGroup.Item>Output ID: {output.outputID.base58}</ListGroup.Item>
                         <ListGroup.Item>Transaction ID: <a href={`/explorer/transaction/${output.outputID.transactionID}`}>{output.outputID.transactionID}</a> </ListGroup.Item>
@@ -62,6 +74,29 @@ export class ExplorerOutputQueryResult extends React.Component<Props, any> {
                             <div>Value: {displayManaUnit(pendingMana.mana)}</div>
                             <div>Timestamp: {new Date(pendingMana.timestamp * 1000).toLocaleString()}</div>
                         </ListGroup.Item>}
+                    </ListGroup>
+                </div>}
+
+                <h4>Metadata</h4>
+                {outputMetadata && <div className={"mb-2"}>
+                    <ListGroup>
+                        <ListGroup.Item>Transaction ID: <a href={`/explorer/transaction/${outputMetadata.outputID.transactionID}`}>{outputMetadata.outputID.transactionID}</a> </ListGroup.Item>
+                        <ListGroup.Item>Branch ID: <a href={`/explorer/branch/${outputMetadata.branchID}`}>{outputMetadata.branchID}</a> </ListGroup.Item>
+                        <ListGroup.Item>Solid: {outputMetadata.solid.toString()}</ListGroup.Item>
+                        <ListGroup.Item>Solidification Time: {new Date(outputMetadata.solidificationTime * 1000).toLocaleString()}</ListGroup.Item>
+                        <ListGroup.Item>Consumer Count: {outputMetadata.consumerCount}</ListGroup.Item>
+                        <ListGroup.Item>First Consumer: <a href={`/explorer/transaction/${outputMetadata.firstConsumer}`}>{outputMetadata.firstConsumer}</a> </ListGroup.Item>
+                        <ListGroup.Item>Finalized: {outputMetadata.finalized.toString()}</ListGroup.Item>
+                    </ListGroup>
+                </div>}
+
+                <h4>Consumers</h4>
+                {outputConsumers && <div>
+                    <ListGroup>
+                        {outputConsumers.consumers.map((c,i) => <ListGroup.Item key={i}>
+                            <div>Transaction ID:  <a href={`/explorer/transaction/${c.transactionID}`}>{c.transactionID}</a></div>
+                            <div>Valid: {renderTriBool(c.valid)} </div>
+                        </ListGroup.Item>)}
                     </ListGroup>
                 </div>}
             </Container>

--- a/plugins/dashboard/frontend/src/app/components/ExplorerOutputQueryResult.tsx
+++ b/plugins/dashboard/frontend/src/app/components/ExplorerOutputQueryResult.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react';
+import Container from "react-bootstrap/Container";
+import ListGroup from "react-bootstrap/ListGroup";
+import NodeStore from "app/stores/NodeStore";
+import { inject, observer } from "mobx-react";
+import ExplorerStore from "app/stores/ExplorerStore";
+import Badge from "react-bootstrap/Badge";
+import {displayManaUnit} from "app/utils";
+
+interface Props {
+    nodeStore?: NodeStore;
+    explorerStore?: ExplorerStore;
+    match?: {
+        params: {
+            id: string,
+        }
+    }
+}
+
+@inject("nodeStore")
+@inject("explorerStore")
+@observer
+export class ExplorerOutputQueryResult extends React.Component<Props, any> {
+    componentDidMount() {
+        this.props.explorerStore.getOutput(this.props.match.params.id);
+        this.props.explorerStore.getPendingMana(this.props.match.params.id);
+    }
+
+    componentWillUnmount() {
+        this.props.explorerStore.reset();
+    }
+    render() {
+        let {id} = this.props.match.params;
+        let { query_err, output, pendingMana } = this.props.explorerStore;
+
+        if (query_err) {
+            return (
+                <Container>
+                    <h4>Output not found - 404</h4>
+                    <span>{id}</span>
+                </Container>
+            );
+        }
+        return (
+            <Container>
+                <h4>Output</h4>
+                {output && <div>
+                    <ListGroup>
+                        <ListGroup.Item>Output ID: {output.outputID.base58}</ListGroup.Item>
+                        <ListGroup.Item>Transaction ID: <a href={`/explorer/transaction/${output.outputID.transactionID}`}>{output.outputID.transactionID}</a> </ListGroup.Item>
+                        <ListGroup.Item>Index: {output.outputID.outputIndex}</ListGroup.Item>
+                        <ListGroup.Item>Type: {output.type}</ListGroup.Item>
+                        <ListGroup.Item>
+                            Balances:
+                            <span>
+                                {Object.entries(output.balances).map((entry, i) => (<div className={"mr-2"} key={i}><Badge variant="secondary">{entry[1]} {entry[0]}</Badge></div>))}
+                            </span>
+                        </ListGroup.Item>
+                        {pendingMana && <ListGroup.Item>
+                            Pending Mana
+                            <hr/>
+                            <div>Value: {displayManaUnit(pendingMana.mana)}</div>
+                            <div>Timestamp: {new Date(pendingMana.timestamp * 1000).toLocaleString()}</div>
+                        </ListGroup.Item>}
+                    </ListGroup>
+                </div>}
+            </Container>
+        )
+    }
+}

--- a/plugins/dashboard/frontend/src/app/components/ExplorerOutputSearchbar.tsx
+++ b/plugins/dashboard/frontend/src/app/components/ExplorerOutputSearchbar.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import {KeyboardEvent} from 'react';
+import NodeStore from "app/stores/NodeStore";
+import {inject, observer} from "mobx-react";
+import FormControl from "react-bootstrap/FormControl";
+import ExplorerStore from "app/stores/ExplorerStore";
+import Row from "react-bootstrap/Row";
+import Col from "react-bootstrap/Col";
+import InputGroup from "react-bootstrap/InputGroup";
+
+interface Props {
+    nodeStore?: NodeStore;
+    explorerStore?: ExplorerStore;
+}
+
+@inject("nodeStore")
+@inject("explorerStore")
+@observer
+export class ExplorerOutputSearchbar extends React.Component<Props, any> {
+    outputID: string;
+
+    updateSearch = (e) => {
+        this.outputID =e.target.value;
+    };
+
+    executeSearch = (e: KeyboardEvent) => {
+        if (e.key !== 'Enter') return;
+        this.props.explorerStore.routerStore.push(`/explorer/output/${this.outputID}`);
+    };
+
+    render() {
+        let {searching} = this.props.explorerStore;
+
+        return (
+            <React.Fragment>
+                <Row className={"mb-3"}>
+                    <Col>
+                        <InputGroup className="mb-3">
+                            <FormControl
+                                placeholder="Output ID"
+                                aria-label="Output ID"
+                                aria-describedby="basic-addon1"
+                                value={this.outputID} onChange={this.updateSearch}
+                                onKeyUp={this.executeSearch}
+                                disabled={searching}
+                            />
+                        </InputGroup>
+                    </Col>
+                </Row>
+            </React.Fragment>
+        );
+    }
+}

--- a/plugins/dashboard/frontend/src/app/components/ExplorerSearchbar.tsx
+++ b/plugins/dashboard/frontend/src/app/components/ExplorerSearchbar.tsx
@@ -36,8 +36,8 @@ export class ExplorerSearchbar extends React.Component<Props, any> {
                     <Col>
                         <InputGroup className="mb-3">
                             <FormControl
-                                placeholder="Address or message id"
-                                aria-label="Address message id"
+                                placeholder="Address or Message ID"
+                                aria-label="Address or Message ID"
                                 aria-describedby="basic-addon1"
                                 value={search} onChange={this.updateSearch}
                                 onKeyUp={this.executeSearch}

--- a/plugins/dashboard/frontend/src/app/components/ExplorerTransaction.tsx
+++ b/plugins/dashboard/frontend/src/app/components/ExplorerTransaction.tsx
@@ -75,8 +75,8 @@ export class ExplorerTransaction extends React.Component<Props, any> {
                                                           {
                                                               input.referencedOutputID ?
                                                                   <React.Fragment>
-                                                                      <ListGroup.Item>Transaction ID: <a className={"font-sm"} href={`/explorer/transaction/${input.referencedOutputID.transactionID}`}>{input.referencedOutputID.transactionID}</a></ListGroup.Item>
-                                                                      <ListGroup.Item>Referenced OutputID: <a href={"#"}>{input.referencedOutputID.base58}</a></ListGroup.Item>
+                                                                      <ListGroup.Item>Transaction ID: <a href={`/explorer/transaction/${input.referencedOutputID.transactionID}`}>{input.referencedOutputID.transactionID}</a></ListGroup.Item>
+                                                                      <ListGroup.Item>Referenced OutputID: <a href={`/explorer/output/${input.referencedOutputID.base58}`}>{input.referencedOutputID.base58}</a></ListGroup.Item>
                                                                       <ListGroup.Item>Output Index: {input.referencedOutputID.outputIndex}</ListGroup.Item>
                                                                   </React.Fragment>
                                                               :
@@ -112,7 +112,7 @@ export class ExplorerTransaction extends React.Component<Props, any> {
                                                     <div className={"mb-2"} key={i}>
                                                         <span className={"mb-2"}>Index: <Badge variant={"primary"}>{i}</Badge></span>
                                                         <ListGroup>
-                                                            <ListGroup.Item>ID: <a href={"#"}>{output.outputID.base58}</a></ListGroup.Item>
+                                                            <ListGroup.Item>ID: <a href={`/explorer/output/${output.outputID.base58}`}>{output.outputID.base58}</a></ListGroup.Item>
                                                             <ListGroup.Item>Address: <a href={`/explorer/address/${output.address}`}> {output.address}</a></ListGroup.Item>
                                                             <ListGroup.Item>Type: {output.type}</ListGroup.Item>
                                                             <ListGroup.Item>Output Index: {output.outputID.outputIndex}</ListGroup.Item>

--- a/plugins/dashboard/frontend/src/app/components/ExplorerTransactionMetadata.tsx
+++ b/plugins/dashboard/frontend/src/app/components/ExplorerTransactionMetadata.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
 import Container from "react-bootstrap/Container";
-import Row from "react-bootstrap/Row";
-import Col from "react-bootstrap/Col";
 import NodeStore from "app/stores/NodeStore";
 import { inject, observer } from "mobx-react";
-import ExplorerStore, { GenesisTransactionID } from "app/stores/ExplorerStore";
+import ExplorerStore from "app/stores/ExplorerStore";
+import ListGroup from "react-bootstrap/ListGroup";
 
 interface Props {
     nodeStore?: NodeStore;
@@ -27,14 +26,6 @@ export class ExplorerTransactionMetadata extends React.Component<Props, any> {
         let { txId } = this.props;
         let { query_err, txMetadata } = this.props.explorerStore;
 
-        if (txId === GenesisTransactionID) {
-            return (
-                <Container>
-                <h4>Metadata</h4>
-                    <p>No metadata for genesis transaction</p>
-                </Container>
-            )
-        }
         if (query_err) {
             return (
                 <Container>
@@ -45,35 +36,14 @@ export class ExplorerTransactionMetadata extends React.Component<Props, any> {
         }
         return (
             <Container>
-            <h4>Metadata</h4>
-                {txMetadata && <Row className={"mb-3"}>
-                    <Col>
-                        <table className={"table table-bordered table-condensed table-sm"}>
-                            <tbody>
-                                <tr>
-                                    <td>Branch ID</td>
-                                    <td><a href="#">{txMetadata.branchID}</a></td>
-                                </tr>
-                                <tr>
-                                    <td>Solid</td>
-                                    <td>{txMetadata.solid.toString()}</td>
-                                </tr>
-                                <tr>
-                                    <td>Solidification time</td>
-                                    <td>{new Date(txMetadata.solidificationTime * 1000).toLocaleString()}</td>
-                                </tr>
-                                <tr>
-                                    <td>Finalized</td>
-                                    <td>{txMetadata.finalized.toString()}</td>
-                                </tr>
-                                <tr>
-                                    <td>Lazy booked</td>
-                                    <td>{txMetadata.lazyBooked.toString()}</td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </Col>
-                </Row>}
+                <h4>Metadata</h4>
+                {txMetadata && <ListGroup>
+                    <ListGroup.Item>Branch ID: <a href={`/explorer/branch/${txMetadata.branchID}`}>{txMetadata.branchID}</a></ListGroup.Item>
+                    <ListGroup.Item>Solid: {txMetadata.solid.toString()}</ListGroup.Item>
+                    <ListGroup.Item>Solidification time: {new Date(txMetadata.solidificationTime * 1000).toLocaleString()}</ListGroup.Item>
+                    <ListGroup.Item>Finalized: {txMetadata.finalized.toString()}</ListGroup.Item>
+                    <ListGroup.Item>Lazy booked: {txMetadata.lazyBooked.toString()}</ListGroup.Item>
+                </ListGroup>}
             </Container>
         )
     }

--- a/plugins/dashboard/frontend/src/app/components/ExplorerTransactionSearchbar.tsx
+++ b/plugins/dashboard/frontend/src/app/components/ExplorerTransactionSearchbar.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import {KeyboardEvent} from 'react';
+import NodeStore from "app/stores/NodeStore";
+import {inject, observer} from "mobx-react";
+import FormControl from "react-bootstrap/FormControl";
+import ExplorerStore from "app/stores/ExplorerStore";
+import Row from "react-bootstrap/Row";
+import Col from "react-bootstrap/Col";
+import InputGroup from "react-bootstrap/InputGroup";
+
+interface Props {
+    nodeStore?: NodeStore;
+    explorerStore?: ExplorerStore;
+}
+
+@inject("nodeStore")
+@inject("explorerStore")
+@observer
+export class ExplorerTransactionSearchbar extends React.Component<Props, any> {
+    txID: string;
+
+    updateSearch = (e) => {
+        this.txID =e.target.value;
+    };
+
+    executeSearch = (e: KeyboardEvent) => {
+        if (e.key !== 'Enter') return;
+        this.props.explorerStore.routerStore.push(`/explorer/transaction/${this.txID}`);
+    };
+
+    render() {
+        let {searching} = this.props.explorerStore;
+
+        return (
+            <React.Fragment>
+                <Row className={"mb-3"}>
+                    <Col>
+                        <InputGroup className="mb-3">
+                            <FormControl
+                                placeholder="Transaction ID"
+                                aria-label="Transaction ID"
+                                aria-describedby="basic-addon1"
+                                value={this.txID} onChange={this.updateSearch}
+                                onKeyUp={this.executeSearch}
+                                disabled={searching}
+                            />
+                        </InputGroup>
+                    </Col>
+                </Row>
+            </React.Fragment>
+        );
+    }
+}

--- a/plugins/dashboard/frontend/src/app/components/Root.tsx
+++ b/plugins/dashboard/frontend/src/app/components/Root.tsx
@@ -20,6 +20,7 @@ import {Drng} from "app/components/Drng";
 import {Mana} from "app/components/Mana";
 import {ExplorerTransactionQueryResult} from "app/components/ExplorerTransactionQueryResult";
 import {ExplorerOutputQueryResult} from "app/components/ExplorerOutputQueryResult";
+import {ExplorerBranchQueryResult} from "app/components/ExplorerBranchQueryResult";
 
 interface Props {
     history: any;
@@ -96,6 +97,7 @@ export class Root extends React.Component<Props, any> {
                     <Route exact path="/explorer/address/:id" component={ExplorerAddressQueryResult}/>
                     <Route exact path="/explorer/transaction/:id" component={ExplorerTransactionQueryResult}/>
                     <Route exact path="/explorer/output/:id" component={ExplorerOutputQueryResult}/>
+                    <Route exact path="/explorer/branch/:id" component={ExplorerBranchQueryResult}/>
                     <Route exact path="/explorer/404/:search" component={Explorer404}/>
                     <Route exact path="/drng" component={Drng}/>
                     <Route exact path="/explorer" component={Explorer}/>

--- a/plugins/dashboard/frontend/src/app/components/Root.tsx
+++ b/plugins/dashboard/frontend/src/app/components/Root.tsx
@@ -19,6 +19,7 @@ import {Visualizer} from "app/components/Visualizer";
 import {Drng} from "app/components/Drng";
 import {Mana} from "app/components/Mana";
 import {ExplorerTransactionQueryResult} from "app/components/ExplorerTransactionQueryResult";
+import {ExplorerOutputQueryResult} from "app/components/ExplorerOutputQueryResult";
 
 interface Props {
     history: any;
@@ -94,6 +95,7 @@ export class Root extends React.Component<Props, any> {
                     <Route exact path="/explorer/message/:id" component={ExplorerMessageQueryResult}/>
                     <Route exact path="/explorer/address/:id" component={ExplorerAddressQueryResult}/>
                     <Route exact path="/explorer/transaction/:id" component={ExplorerTransactionQueryResult}/>
+                    <Route exact path="/explorer/output/:id" component={ExplorerOutputQueryResult}/>
                     <Route exact path="/explorer/404/:search" component={Explorer404}/>
                     <Route exact path="/drng" component={Drng}/>
                     <Route exact path="/explorer" component={Explorer}/>

--- a/plugins/dashboard/frontend/src/app/components/TransactionPayload.tsx
+++ b/plugins/dashboard/frontend/src/app/components/TransactionPayload.tsx
@@ -142,7 +142,7 @@ class Inputs extends React.Component<OutputProps> {
                 <Col>
                     Index: <Badge variant={"primary"}>{this.props.index}</Badge>
                     <ListGroup>
-                        <ListGroup.Item key={this.props.outputID}>OutputID: {this.props.outputID} </ListGroup.Item>
+                        <ListGroup.Item key={this.props.outputID}>OutputID: <a href={`/explorer/output/${this.props.outputID}`}>{this.props.outputID}</a> </ListGroup.Item>
                         <ListGroup.Item key={this.props.address}>Address: <Link to={`/explorer/address/${this.props.address}`}>{this.props.address}</Link>
                         </ListGroup.Item>
                         <ListGroup.Item key={'balances'}>
@@ -165,7 +165,7 @@ class Outputs extends React.Component<OutputProps> {
                 <Col>
                     Index: <Badge variant={"primary"}>{this.props.index}</Badge>
                     <ListGroup>
-                        <ListGroup.Item key={this.props.outputID}>OutputID: {this.props.outputID} </ListGroup.Item>
+                        <ListGroup.Item key={this.props.outputID}>OutputID: <a href={`/explorer/output/${this.props.outputID}`}>{this.props.outputID}</a></ListGroup.Item>
                         <ListGroup.Item key={this.props.address}>Address: <Link to={`/explorer/address/${this.props.address}`}>{this.props.address}</Link>
                         </ListGroup.Item>
                         <ListGroup.Item key={'balances'}>

--- a/plugins/dashboard/frontend/src/app/stores/ExplorerStore.tsx
+++ b/plugins/dashboard/frontend/src/app/stores/ExplorerStore.tsx
@@ -54,6 +54,32 @@ class Output {
     pending_mana: number;
 }
 
+class OutputID {
+    base58:  string;
+    transactionID: string;
+    outputIndex: number;
+}
+
+class OutputMetadata {
+    outputID: OutputID;
+    branchID: string;
+    solid: boolean;
+    solidificationTime: number;
+    consumerCount: number;
+    firstConsumer: string; //tx id
+    finalized: boolean;
+}
+
+class OutputConsumer {
+    transactionID: string;
+    valid: string;
+}
+
+class OutputConsumers {
+    outputID: OutputID;
+    consumers: Array<OutputConsumer>
+}
+
 class PendingMana {
     mana: number;
     outputID: string;
@@ -132,6 +158,8 @@ export class ExplorerStore {
     @observable txMetadata: any = null;
     @observable txAttachments: any = [];
     @observable output: any = null;
+    @observable outputMetadata: OutputMetadata = null;
+    @observable outputConsumers: OutputConsumers = null;
     @observable pendingMana: PendingMana = null;
     @observable branch: Branch = null;
     @observable branchChildren: BranchChildren = null;
@@ -298,6 +326,32 @@ export class ExplorerStore {
         }
     }
 
+    getOutputMetadata = async (id: string) => {
+        try {
+            let res = await fetch(`/api/output/${id}/metadata`)
+            if (res.status === 404) {
+                return;
+            }
+            let metadata: OutputMetadata = await res.json()
+            this.updateOutputMetadata(metadata)
+        } catch (err) {
+            //ignore
+        }
+    }
+
+    getOutputConsumers = async (id: string) => {
+        try {
+            let res = await fetch(`/api/output/${id}/consumers`)
+            if (res.status === 404) {
+                return;
+            }
+            let consumers: OutputConsumers = await res.json()
+            this.updateOutputConsumers(consumers)
+        } catch (err) {
+            //ignore
+        }
+    }
+
     getPendingMana = async (outputID: string) => {
         try {
             let res = await fetch(`/api/mana/pending?OutputID=${outputID}`)
@@ -382,6 +436,16 @@ export class ExplorerStore {
     @action
     updateOutput = (output: any) => {
         this.output = output;
+    }
+
+    @action
+    updateOutputMetadata = (metadata: OutputMetadata) => {
+        this.outputMetadata = metadata;
+    }
+
+    @action
+    updateOutputConsumers = (consumers: OutputConsumers) => {
+        this.outputConsumers = consumers;
     }
 
     @action

--- a/plugins/dashboard/frontend/src/app/stores/ExplorerStore.tsx
+++ b/plugins/dashboard/frontend/src/app/stores/ExplorerStore.tsx
@@ -144,7 +144,8 @@ class MessageRef {
 const liveFeedSize = 50;
 
 enum QueryError {
-    NotFound = 1
+    NotFound = 1,
+    BadRequest = 2
 }
 
 export class ExplorerStore {
@@ -315,6 +316,10 @@ export class ExplorerStore {
                 this.updateQueryError(QueryError.NotFound);
                 return;
             }
+            if (res.status === 400) {
+                this.updateQueryError(QueryError.BadRequest);
+                return;
+            }
             let output: any = await res.json()
             if (output.error) {
                 this.updateQueryError(output.error)
@@ -332,6 +337,9 @@ export class ExplorerStore {
             if (res.status === 404) {
                 return;
             }
+            if (res.status === 400) {
+                return;
+            }
             let metadata: OutputMetadata = await res.json()
             this.updateOutputMetadata(metadata)
         } catch (err) {
@@ -343,6 +351,9 @@ export class ExplorerStore {
         try {
             let res = await fetch(`/api/output/${id}/consumers`)
             if (res.status === 404) {
+                return;
+            }
+            if (res.status === 400) {
                 return;
             }
             let consumers: OutputConsumers = await res.json()
@@ -358,6 +369,9 @@ export class ExplorerStore {
             if (res.status === 404) {
                 return;
             }
+            if (res.status === 400) {
+                return;
+            }
             let pendingMana: PendingMana = await res.json()
             this.updatePendingMana(pendingMana)
         } catch (err) {
@@ -370,6 +384,10 @@ export class ExplorerStore {
             let res = await fetch(`/api/branch/${id}`)
             if (res.status === 404) {
                 this.updateQueryError(QueryError.NotFound);
+                return;
+            }
+            if (res.status === 400) {
+                this.updateQueryError(QueryError.BadRequest);
                 return;
             }
             let branch: Branch = await res.json()
@@ -409,6 +427,17 @@ export class ExplorerStore {
     reset = () => {
         this.msg = null;
         this.query_err = null;
+        // reset all variables
+        this.tx = null;
+        this.txMetadata = null;
+        this.txAttachments = [];
+        this.output = null;
+        this.outputMetadata = null;
+        this.outputConsumers = null;
+        this.pendingMana = null;
+        this.branch = null;
+        this.branchChildren = null;
+        this.branchConflicts = null;
     };
 
     @action

--- a/plugins/dashboard/frontend/src/app/stores/ExplorerStore.tsx
+++ b/plugins/dashboard/frontend/src/app/stores/ExplorerStore.tsx
@@ -15,7 +15,6 @@ import {Link} from 'react-router-dom';
 import {RouterStore} from "mobx-react-router";
 
 export const GenesisMessageID = "1111111111111111111111111111111111111111111111111111111111111111";
-export const GenesisTransactionID = "1111111111111111111111111111111111111111111111111111111111111111"
 
 export class Message {
     id: string;

--- a/plugins/dashboard/frontend/src/app/stores/ExplorerStore.tsx
+++ b/plugins/dashboard/frontend/src/app/stores/ExplorerStore.tsx
@@ -109,7 +109,7 @@ class BranchChild {
 }
 
 class BranchConflict {
-    outputID: string;
+    outputID: OutputID;
     branchIDs: Array<string>;
 }
 

--- a/plugins/dashboard/frontend/src/app/stores/ExplorerStore.tsx
+++ b/plugins/dashboard/frontend/src/app/stores/ExplorerStore.tsx
@@ -61,6 +61,37 @@ class PendingMana {
     timestamp: number;
 }
 
+class Branch {
+    id: string;
+    type: string;
+    parents: Array<string>;
+    conflictIDs: Array<string>;
+    liked: boolean;
+    monotonicallyLiked: boolean;
+    finalized: boolean;
+    inclusionState: string;
+}
+
+class BranchChildren {
+    branchID: string;
+    childBranches: Array<BranchChild>
+}
+
+class BranchChild {
+    branchID: string;
+    type: string;
+}
+
+class BranchConflict {
+    outputID: string;
+    branchIDs: Array<string>;
+}
+
+class BranchConflicts {
+    branchID: string;
+    conflicts: Array<BranchConflict>
+}
+
 class Balance {
     value: number;
     color: string;
@@ -102,6 +133,9 @@ export class ExplorerStore {
     @observable txAttachments: any = [];
     @observable output: any = null;
     @observable pendingMana: PendingMana = null;
+    @observable branch: Branch = null;
+    @observable branchChildren: BranchChildren = null;
+    @observable branchConflicts: BranchConflicts = null;
 
     // loading
     @observable query_loading: boolean = false;
@@ -277,6 +311,46 @@ export class ExplorerStore {
         }
     }
 
+    getBranch = async (id: string) => {
+        try {
+            let res = await fetch(`/api/branch/${id}`)
+            if (res.status === 404) {
+                this.updateQueryError(QueryError.NotFound);
+                return;
+            }
+            let branch: Branch = await res.json()
+            this.updateBranch(branch)
+        } catch (err) {
+            this.updateQueryError(err);
+        }
+    }
+
+    getBranchChildren = async (id: string) => {
+        try {
+            let res = await fetch(`/api/branch/${id}/children`)
+            if (res.status === 404) {
+                return;
+            }
+            let children: BranchChildren = await res.json()
+            this.updateBranchChildren(children)
+        } catch (err) {
+            // ignore
+        }
+    }
+
+    getBranchConflicts = async (id: string) => {
+        try {
+            let res = await fetch(`/api/branch/${id}/conflicts`)
+            if (res.status === 404) {
+                return;
+            }
+            let conflicts: BranchConflicts = await res.json()
+            this.updateBranchConflicts(conflicts)
+        } catch (err) {
+            // ignore
+        }
+    }
+
     @action
     reset = () => {
         this.msg = null;
@@ -313,6 +387,21 @@ export class ExplorerStore {
     @action
     updatePendingMana = (pendingMana: PendingMana) => {
         this.pendingMana = pendingMana;
+    }
+
+    @action
+    updateBranch = (branch: Branch) => {
+        this.branch = branch;
+    }
+
+    @action
+    updateBranchChildren = (children: BranchChildren) => {
+        this.branchChildren = children;
+    }
+
+    @action
+    updateBranchConflicts = (conflicts: BranchConflicts) => {
+        this.branchConflicts = conflicts;
     }
 
     @action

--- a/plugins/mana/plugin.go
+++ b/plugins/mana/plugin.go
@@ -455,7 +455,7 @@ func PendingManaOnOutput(outputID ledgerstate.OutputID) (float64, time.Time) {
 	outputMetadata := cachedOutputMetadata.Unwrap()
 
 	// spent output has 0 pending mana.
-	if outputMetadata.ConsumerCount() > 0 {
+	if outputMetadata == nil || outputMetadata.ConsumerCount() > 0 {
 		return 0, time.Time{}
 	}
 

--- a/plugins/webapi/mana/pending.go
+++ b/plugins/webapi/mana/pending.go
@@ -8,8 +8,8 @@ import (
 	"github.com/labstack/echo"
 )
 
-// getPendingHandler handles the request.
-func getPendingHandler(c echo.Context) error {
+// GetPendingMana handles the request.
+func GetPendingMana(c echo.Context) error {
 	var req PendingRequest
 	if err := c.Bind(&req); err != nil {
 		return c.JSON(http.StatusBadRequest, PendingResponse{Error: err.Error()})

--- a/plugins/webapi/mana/plugin.go
+++ b/plugins/webapi/mana/plugin.go
@@ -32,7 +32,7 @@ func configure(_ *node.Plugin) {
 	webapi.Server().GET("/mana/percentile", getPercentileHandler)
 	webapi.Server().GET("/mana/access/online", getOnlineAccessHandler)
 	webapi.Server().GET("/mana/consensus/online", getOnlineConsensusHandler)
-	webapi.Server().GET("/mana/pending", getPendingHandler)
+	webapi.Server().GET("/mana/pending", GetPendingMana)
 	webapi.Server().GET("/mana/consensus/past", getPastConsensusManaVectorHandler)
 	webapi.Server().GET("/mana/consensus/logs", getEventLogsHandler)
 	webapi.Server().GET("/mana/consensus/metadata", getPastConsensusVectorMetadataHandler)


### PR DESCRIPTION
# Description
- [x] Transaction `http://localhost:8081/explorer/transaction/<id>`
- [x] Output `http://localhost:8081/explorer/output/<id>`
- [x] Branch `http://localhost:8081/explorer/branch/<id>`
- [x] Added searchbars for transactions, outputs and branches:

<img width="1143" alt="Screenshot 2021-03-23 at 15 49 40" src="https://user-images.githubusercontent.com/57879913/112166079-9cdb6280-8bef-11eb-9e3a-d601e0c9727f.png">

![image](https://user-images.githubusercontent.com/32927267/112200621-b2f91b00-8c0f-11eb-9dd0-36fbfc7b6cda.png)
