### PR TITLE
Golangci lint follow up patch

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,7 @@ issues:
     exclude-use-default: false
     max-issues-per-linter: 0
     max-same-issues: 0
+    new-from-rev: e79d2a0c90ae4c80aa56afebcd06d5540bbdc75f # Enhance golangci-lint (#1113)
     exclude:
         - 'Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv). is not checked' # errcheck
         - 'err113: do not define dynamic errors, use wrapped static errors instead:' # goerr113
@@ -17,23 +18,6 @@ issues:
         - 'ST1000: at least one file in a package should have a package comment' # stylecheck
         - 'ST1005: error strings should not be capitalized' # stylecheck
         - '`[0-9A-Za-z_.]+` - `[0-9A-Za-z_.]+` always receives `[0-9A-Za-z_.]+`' # unparam
-
-
-        # Temporary exclusions.
-        # They are needed until golangci-lint changes get merged into develop.
-        # After that they will be removed and golangci-lint start analyzing the codebase from the merge commit.
-        # Via new-from-rev config setting in .golangci.yml file.
-        - 'lines are duplicate of `*`' # dupl
-        - 'Error return value of (`[0-9A-Za-z_.]+`|``) is not checked' # errcheck
-        - 'cyclomatic complexity [0-9]+ of func `[0-9A-Za-z_.]+` is high' # gocyclo
-        - 'naked return in func `[0-9A-Za-z_.]+` with [0-9]+ lines of code' #nakedret
-        - 'string `init` has 3 occurrences, make it a constant' # goconst
-        - 'mnd: Magic number:' # gomnd
-        - "Function '[0-9A-Za-z_.]+' has too many statements" # funlen
-        - "Function '[0-9A-Za-z_.]+' is too long" # funlen
-        - 'is being imported more than once' # stylecheck
-        - 'ST1019' # stylecheck
-        - 'ST1003:' # stylecheck ST1003: var unixTsPRNG should be unixTSPRNG
     exclude-rules:
         -   path: (_test\.go|example_test\.go|example_[0-9A-Za-z_-]+_test\.go)
             linters:
@@ -66,16 +50,6 @@ linters-settings:
             - octalLiteral
             - whyNoLint
             - wrapperFunc
-
-            # Temporary exclusions.
-            # They are needed until golangci-lint changes get merged into develop.
-            # After that they will be removed and golangci-lint start analyzing the codebase from the merge commit.
-            # Via new-from-rev config setting in .golangci.yml file.
-            - importShadow
-            - typeUnparen
-            - paramTypeCombine
-            - exitAfterDefer
-            - elseif
     goimports:
         local-prefixes: github.com/iotaledger/goshimmer
     gomnd:

--- a/docs/teamresources/guidelines.md
+++ b/docs/teamresources/guidelines.md
@@ -1,4 +1,29 @@
 # Code guidelines
+## General guidelines
+
+- Don’t use `log.Fatal()` or `os.Exit()` outside of the main. It immediately terminates the program and all defers are ignored and no graceful shutdown is possible. It can lead to inconsistencies. Propagate the error up to the main and let the main function exit instead. Avoid panics as well, almost always use errors. [Example](https://github.com/iotaledger/goshimmer/blob/f75ce47eeaa3bf930b368754ac24b72f768a5964/plugins/autopeering/autopeering.go#L135).
+- Don’t duplicate code, reuse it. In tests too. Example: [duplicate1](https://github.com/iotaledger/goshimmer/blob/f75ce47eeaa3bf930b368754ac24b72f768a5964/packages/ledgerstate/branch_dag.go#L969) and [duplicate2](https://github.com/iotaledger/goshimmer/blob/f75ce47eeaa3bf930b368754ac24b72f768a5964/packages/ledgerstate/branch_dag.go#L1053)
+- Unhandled errors can cause bugs and make it harder to diagnose problems. Try to handle all errors: propagate them to the caller or log them. Even if the function call is used with a defer, and it’s inconvenient to handle the error it returns, still handle it. Wrap the function call in an anonymous function assign error to the upper error  like that:
+```go
+    defer func() {
+        cerr := f.Close()
+        if err == nil {
+            err = xerrors.Errorf("failed to close file: %w", cerr)
+        }
+    }()
+```
+- Wrap errors with `xerrors.Errorf()` when returning them to the caller. It adds the stack trace and a custom message to the error. Without that information investigating an issue is very hard.
+- Use `xerrors.Is()` instead of direct errors comparison. This function unwraps errors recursively. [Example](https://github.com/iotaledger/goshimmer/pull/1113/files#diff-05fdc081489a8d5a61224d812f9bbd7bc77edf9769ed00d95ea024d2a44a699aL62).
+- Propagate `ctx` and use APIs that accept `ctx`, start exposing APIs that accept `ctx`. Context is a native way for timeouts/cancellation in Go. It allows writing more resilient and fault tolerant code. [Example](https://github.com/iotaledger/goshimmer/pull/1113/files#diff-f2820ed0d3d4d9ea05b78b1dd3978dbcf9401c8caaa8cc40cc1c0342a55379fcL35).
+- Don’t shadow builtin functions like copy, len, new etc. [Example](https://github.com/iotaledger/goshimmer/pull/1113/files#diff-f07268750a44da26386469c1b1e93574a678c3d418fce9e1f186d5f1991a92eaL14).
+- Don’t shadow imported packages. [Example](https://github.com/iotaledger/goshimmer/blob/f75ce47eeaa3bf930b368754ac24b72f768a5964/plugins/webapi/value/sendtransactionbyjson.go#L172).
+- Don’t do `[:]` on a slice. It has no effect. [Example](https://github.com/iotaledger/goshimmer/pull/1113/files#diff-299a1ac5fa09739ea07b7c806ee2785d83eea110f8af143dbc853a25e4819116L133).
+- Avoid naked returns if the function isn’t very small. It makes the code more readable.
+- Define explicit constants for strings that are used 3 times or more. It makes the code more maintainable.
+- Define explicit constants for all numbers. It makes the code more readable.
+- Don’t write really long and complex functions. Split them into smaller ones.
+- Treat comments as regular text/documentation. Start with a capital letter, set space after `//` and end them with a dot. It’s a good habit since Go package docs are generated automatically from the comments and displayed on the godoc site.
+
 ## Error handling
 
 We use the new error wrapping API and behavior introduced with Go 1.13 but we use the "golang.org/x/xerrors" drop-in replacement which follows the Go 2 design draft and which enables us to have a stack trace for every "wrapping" of the error.


### PR DESCRIPTION
This is the quick patch that I was talking about in the https://github.com/iotaledger/goshimmer/pull/1113
It removes all temporary exclude rules from golangci-lint and sets the `new-from-rev` setting to the merge commit of the https://github.com/iotaledger/goshimmer/pull/1113: `e79d2a0c90ae4c80aa56afebcd06d5540bbdc75f`