### PR TITLE
Resolve base58 encoded branchIDs in frontend

### DIFF
--- a/plugins/dashboard/explorer_routes.go
+++ b/plugins/dashboard/explorer_routes.go
@@ -68,7 +68,7 @@ func createExplorerMessage(msg *tangle.Message) *ExplorerMessage {
 		StrongApprovers:         messagelayer.Tangle().Utils.ApprovingMessageIDs(messageID, tangle.StrongApprover).ToStrings(),
 		WeakApprovers:           messagelayer.Tangle().Utils.ApprovingMessageIDs(messageID, tangle.WeakApprover).ToStrings(),
 		Solid:                   messageMetadata.IsSolid(),
-		BranchID:                messageMetadata.BranchID().String(),
+		BranchID:                messageMetadata.BranchID().Base58(),
 		Scheduled:               messageMetadata.Scheduled(),
 		Booked:                  messageMetadata.IsBooked(),
 		Eligible:                messageMetadata.IsEligible(),

--- a/plugins/dashboard/frontend/src/app/components/ExplorerBranchQueryResult.tsx
+++ b/plugins/dashboard/frontend/src/app/components/ExplorerBranchQueryResult.tsx
@@ -5,6 +5,7 @@ import { inject, observer } from "mobx-react";
 import ExplorerStore from "app/stores/ExplorerStore";
 import ListGroup from "react-bootstrap/ListGroup";
 import Badge from "react-bootstrap/Badge";
+import {resolveBase58BranchID} from "app/utils/branch";
 
 
 interface Props {
@@ -65,16 +66,16 @@ export class ExplorerBranchQueryResult extends React.Component<Props, any> {
             <Container>
                 <h4>Branch</h4>
                 {branch && <ListGroup>
-                    <ListGroup.Item>ID: {branch.id}</ListGroup.Item>
+                    <ListGroup.Item>ID: {resolveBase58BranchID(branch.id)}</ListGroup.Item>
                     <ListGroup.Item>Type: {branch.type}</ListGroup.Item>
                     <ListGroup.Item>Parents:
                         <ListGroup>
-                        {branch.parents.map((p,i) => <ListGroup.Item key={i}>{p}</ListGroup.Item>)}
+                        {branch.parents.map((p,i) => <ListGroup.Item key={i}><a href={`/explorer/branch/${p}`}>{resolveBase58BranchID(p)}</a></ListGroup.Item>)}
                         </ListGroup>
                     </ListGroup.Item>
                     <ListGroup.Item>Conflicts:
                         {branch.conflictIDs && <ListGroup>
-                            {branch.conflictIDs.map((c,i) => <ListGroup.Item key={i}>{c}</ListGroup.Item>)}
+                            {branch.conflictIDs.map((c,i) => <ListGroup.Item key={i}>{resolveBase58BranchID(c)}</ListGroup.Item>)}
                         </ListGroup>}
                     </ListGroup.Item>
                     <ListGroup.Item>Finalized: {branch.finalized.toString()}</ListGroup.Item>
@@ -82,7 +83,7 @@ export class ExplorerBranchQueryResult extends React.Component<Props, any> {
                     <ListGroup.Item>Inclusion State: {renderInclusionState(branch.inclusionState)}</ListGroup.Item>
                     <ListGroup.Item> Children:
                         {branchChildren && <ListGroup>
-                            {branchChildren.childBranches.map((c,i) => <ListGroup.Item key={i}><a href={`/explorer/branch/${c}`}>{c}</a></ListGroup.Item>)}
+                            {branchChildren.childBranches.map((c,i) => <ListGroup.Item key={i}><a href={`/explorer/branch/${c.branchID}`}>{resolveBase58BranchID(c.branchID)}</a></ListGroup.Item>)}
                         </ListGroup> }
                     </ListGroup.Item>
                     <ListGroup.Item> Conflicts:
@@ -91,7 +92,7 @@ export class ExplorerBranchQueryResult extends React.Component<Props, any> {
                                 OutputID: <a href={`/explorer/output/${c.outputID.base58}`}>{c.outputID.base58}</a>
                                 <ListGroup className={"mb-2"}>
                                     {c.branchIDs.map((b,j) => <ListGroup.Item key={j}>
-                                        <a href={`/explorer/branch/${b}`}>{b}</a>
+                                        <a href={`/explorer/branch/${b}`}>{resolveBase58BranchID(b)}</a>
                                     </ListGroup.Item>)}
                                 </ListGroup>
                             </div>)}

--- a/plugins/dashboard/frontend/src/app/components/ExplorerBranchQueryResult.tsx
+++ b/plugins/dashboard/frontend/src/app/components/ExplorerBranchQueryResult.tsx
@@ -75,7 +75,7 @@ export class ExplorerBranchQueryResult extends React.Component<Props, any> {
                     </ListGroup.Item>
                     <ListGroup.Item>Conflicts:
                         {branch.conflictIDs && <ListGroup>
-                            {branch.conflictIDs.map((c,i) => <ListGroup.Item key={i}>{resolveBase58BranchID(c)}</ListGroup.Item>)}
+                            {branch.conflictIDs.map((c,i) => <ListGroup.Item key={i}><a href={`/explorer/output/${c}`}>{c}</a></ListGroup.Item>)}
                         </ListGroup>}
                     </ListGroup.Item>
                     <ListGroup.Item>Finalized: {branch.finalized.toString()}</ListGroup.Item>

--- a/plugins/dashboard/frontend/src/app/components/ExplorerMessageQueryResult.tsx
+++ b/plugins/dashboard/frontend/src/app/components/ExplorerMessageQueryResult.tsx
@@ -16,6 +16,7 @@ import {TransactionPayload} from 'app/components/TransactionPayload'
 import {SyncBeaconPayload} from 'app/components/SyncBeaconPayload'
 import {getPayloadType, PayloadType} from 'app/misc/Payload'
 import {StatementPayload} from "app/components/StatemenetPayload";
+import {resolveBase58BranchID} from "app/utils/branch";
 
 interface Props {
     nodeStore?: NodeStore;
@@ -127,7 +128,7 @@ export class ExplorerMessageQueryResult extends React.Component<Props, any> {
                                         Sequence Number: {msg.sequence_number}
                                     </ListGroup.Item>
                                     <ListGroup.Item>
-                                        BranchID: {msg.branchID}
+                                        BranchID: <Link to={`/explorer/branch/${msg.branchID}`}>{resolveBase58BranchID(msg.branchID)}</Link>
                                     </ListGroup.Item>
                                     <ListGroup.Item>
                                         Solid: {msg.solid ? 'Yes' : 'No'}

--- a/plugins/dashboard/frontend/src/app/components/ExplorerOutputQueryResult.tsx
+++ b/plugins/dashboard/frontend/src/app/components/ExplorerOutputQueryResult.tsx
@@ -6,6 +6,7 @@ import { inject, observer } from "mobx-react";
 import ExplorerStore from "app/stores/ExplorerStore";
 import Badge from "react-bootstrap/Badge";
 import {displayManaUnit} from "app/utils";
+import {resolveBase58BranchID} from "app/utils/branch";
 
 interface Props {
     nodeStore?: NodeStore;
@@ -81,7 +82,7 @@ export class ExplorerOutputQueryResult extends React.Component<Props, any> {
                 {outputMetadata && <div className={"mb-2"}>
                     <ListGroup>
                         <ListGroup.Item>Transaction ID: <a href={`/explorer/transaction/${outputMetadata.outputID.transactionID}`}>{outputMetadata.outputID.transactionID}</a> </ListGroup.Item>
-                        <ListGroup.Item>Branch ID: <a href={`/explorer/branch/${outputMetadata.branchID}`}>{outputMetadata.branchID}</a> </ListGroup.Item>
+                        <ListGroup.Item>Branch ID: <a href={`/explorer/branch/${outputMetadata.branchID}`}>{resolveBase58BranchID(outputMetadata.branchID)}</a> </ListGroup.Item>
                         <ListGroup.Item>Solid: {outputMetadata.solid.toString()}</ListGroup.Item>
                         <ListGroup.Item>Solidification Time: {new Date(outputMetadata.solidificationTime * 1000).toLocaleString()}</ListGroup.Item>
                         <ListGroup.Item>Consumer Count: {outputMetadata.consumerCount}</ListGroup.Item>

--- a/plugins/dashboard/frontend/src/app/components/ExplorerTransactionMetadata.tsx
+++ b/plugins/dashboard/frontend/src/app/components/ExplorerTransactionMetadata.tsx
@@ -4,6 +4,7 @@ import NodeStore from "app/stores/NodeStore";
 import { inject, observer } from "mobx-react";
 import ExplorerStore from "app/stores/ExplorerStore";
 import ListGroup from "react-bootstrap/ListGroup";
+import {resolveBase58BranchID} from "app/utils/branch";
 
 interface Props {
     nodeStore?: NodeStore;
@@ -38,7 +39,7 @@ export class ExplorerTransactionMetadata extends React.Component<Props, any> {
             <Container>
                 <h4>Metadata</h4>
                 {txMetadata && <ListGroup>
-                    <ListGroup.Item>Branch ID: <a href={`/explorer/branch/${txMetadata.branchID}`}>{txMetadata.branchID}</a></ListGroup.Item>
+                    <ListGroup.Item>Branch ID: <a href={`/explorer/branch/${txMetadata.branchID}`}>{resolveBase58BranchID(txMetadata.branchID)}</a></ListGroup.Item>
                     <ListGroup.Item>Solid: {txMetadata.solid.toString()}</ListGroup.Item>
                     <ListGroup.Item>Solidification time: {new Date(txMetadata.solidificationTime * 1000).toLocaleString()}</ListGroup.Item>
                     <ListGroup.Item>Finalized: {txMetadata.finalized.toString()}</ListGroup.Item>

--- a/plugins/dashboard/frontend/src/app/utils/branch.ts
+++ b/plugins/dashboard/frontend/src/app/utils/branch.ts
@@ -2,11 +2,11 @@ export function resolveBase58BranchID(base58Branch: string): string {
     switch (base58Branch) {
         case MasterBranchInBase58:
             return "MasterBranchID";
-        case UndefinedBranchID:
+        case UndefinedBranchInBase58:
             return "UndefinedBranchID";
-        case LazyBookedConflictsBranchID:
+        case LazyBookedConflictsBranchInBase58:
             return "LazyBookedConflictsBranchID";
-        case InvalidBranchID:
+        case InvalidBranchInBase58:
             return "InvalidBranchID";
         default:
             // otherwise it is a "regular" branchID that doesn't have a distinct name
@@ -14,7 +14,8 @@ export function resolveBase58BranchID(base58Branch: string): string {
     }
 }
 
+// base58 branchIDs that have distinct names
 const MasterBranchInBase58 = "4uQeVj5tqViQh7yWWGStvkEG1Zmhx6uasJtWCJziofM"
-const UndefinedBranchID = "11111111111111111111111111111111"
-const LazyBookedConflictsBranchID = "JEKNVnkbo3jma5nREBBJCDoXFVeKkD56V3xKrvRmWxFF"
-const InvalidBranchID = "JEKNVnkbo3jma5nREBBJCDoXFVeKkD56V3xKrvRmWxFG"
+const UndefinedBranchInBase58 = "11111111111111111111111111111111"
+const LazyBookedConflictsBranchInBase58 = "JEKNVnkbo3jma5nREBBJCDoXFVeKkD56V3xKrvRmWxFF"
+const InvalidBranchInBase58 = "JEKNVnkbo3jma5nREBBJCDoXFVeKkD56V3xKrvRmWxFG"

--- a/plugins/dashboard/frontend/src/app/utils/branch.ts
+++ b/plugins/dashboard/frontend/src/app/utils/branch.ts
@@ -1,0 +1,20 @@
+export function resolveBase58BranchID(base58Branch: string): string {
+    switch (base58Branch) {
+        case MasterBranchInBase58:
+            return "MasterBranchID";
+        case UndefinedBranchID:
+            return "UndefinedBranchID";
+        case LazyBookedConflictsBranchID:
+            return "LazyBookedConflictsBranchID";
+        case InvalidBranchID:
+            return "InvalidBranchID";
+        default:
+            // otherwise it is a "regular" branchID that doesn't have a distinct name
+            return base58Branch
+    }
+}
+
+const MasterBranchInBase58 = "4uQeVj5tqViQh7yWWGStvkEG1Zmhx6uasJtWCJziofM"
+const UndefinedBranchID = "11111111111111111111111111111111"
+const LazyBookedConflictsBranchID = "JEKNVnkbo3jma5nREBBJCDoXFVeKkD56V3xKrvRmWxFF"
+const InvalidBranchID = "JEKNVnkbo3jma5nREBBJCDoXFVeKkD56V3xKrvRmWxFG"


### PR DESCRIPTION
# Description of change

BranchIDs are encoded in base58, but some of them has a distinct meaning:
 - MasterBranch,
 - InvalidBranch,
 - LazyBookedBranch,
 - UndefinedBranch

The base58 encoded branchIDs are resolved in the frontend to show human readable versions for the branches above.

![image](https://user-images.githubusercontent.com/32927267/112323231-e096a080-8cb1-11eb-83ae-930001f1befc.png)

