### PR TITLE
Make issued messages pass through normal flow on issuing node

### DIFF
--- a/packages/tangle/storage.go
+++ b/packages/tangle/storage.go
@@ -91,7 +91,6 @@ func (s *Storage) Setup() {
 	s.tangle.Parser.Events.MessageParsed.Attach(events.NewClosure(func(msgParsedEvent *MessageParsedEvent) {
 		s.tangle.Storage.StoreMessage(msgParsedEvent.Message)
 	}))
-	s.tangle.MessageFactory.Events.MessageConstructed.Attach(events.NewClosure(s.StoreMessage))
 }
 
 // StoreMessage stores a new message to the message store.

--- a/plugins/messagelayer/plugin.go
+++ b/plugins/messagelayer/plugin.go
@@ -55,6 +55,11 @@ func configure(plugin *node.Plugin) {
 		plugin.LogError(rejectedEvent.Message)
 	}))
 
+	// Messages created by the node need to pass through the normal flow.
+	Tangle().MessageFactory.Events.MessageConstructed.Attach(events.NewClosure(func(message *tangle.Message) {
+		Tangle().ProcessGossipMessage(message.Bytes(), local.GetInstance().Peer)
+	}))
+
 	// read snapshot file
 	if Parameters.Snapshot.File != "" {
 		snapshot := ledgerstate.Snapshot{}


### PR DESCRIPTION
Messages created by the node should pass through the normal flow as every other messages received via gossip. This should avoid differences in perception if there is e.g. something wrong with a message vs transaction timestamp like the recent faucet issue. 