### PR TITLE
Fix ReviewDog to use go 1.16.2 or higher

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -12,6 +12,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "^1.16.2"
+
       - name: Run golangci-lint # reviewdog v1.19.0, golangci-lint v1.38.0
         uses: reviewdog/action-golangci-lint@93be4324306dcbba508544d891a7b0576bb28ddd
         with:


### PR DESCRIPTION
# Description of change

Reviewdog runs with an old go version by default which causes the linter to fail. This PR forces the environment to use go 1.16.2 or higher.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
