### PR TITLE
Fix: Moved special case of future markers being empty to end

### DIFF
--- a/packages/markers/manager.go
+++ b/packages/markers/manager.go
@@ -138,10 +138,6 @@ func (m *Manager) UpdateStructureDetails(structureDetailsToUpdate *StructureDeta
 
 // IsInPastCone checks if the earlier node is directly or indirectly referenced by the later node in the DAG.
 func (m *Manager) IsInPastCone(earlierStructureDetails, laterStructureDetails *StructureDetails) (isInPastCone types.TriBool) {
-	if earlierStructureDetails.FutureMarkers.Size() == 0 && laterStructureDetails.FutureMarkers.Size() == 0 {
-		return types.Maybe
-	}
-
 	if earlierStructureDetails.Rank >= laterStructureDetails.Rank {
 		return types.False
 	}
@@ -193,7 +189,7 @@ func (m *Manager) IsInPastCone(earlierStructureDetails, laterStructureDetails *S
 
 		// Iterate the future markers of laterStructureDetails and check if the earlier one has future markers in the same sequence,
 		// if yes, then make sure the index is smaller than the one of laterStructureDetails.
-		if !laterStructureDetails.FutureMarkers.ForEach(func(sequenceID SequenceID, laterIndex Index) bool {
+		if laterStructureDetails.FutureMarkers.Size() != 0 && !laterStructureDetails.FutureMarkers.ForEach(func(sequenceID SequenceID, laterIndex Index) bool {
 			earlierIndex, similarSequenceExists := earlierStructureDetails.FutureMarkers.Get(sequenceID)
 			return !similarSequenceExists || earlierIndex < laterIndex
 		}) {
@@ -219,7 +215,7 @@ func (m *Manager) IsInPastCone(earlierStructureDetails, laterStructureDetails *S
 		}
 	}
 
-	if m.markersReferenceMarkers(laterStructureDetails.PastMarkers, earlierStructureDetails.FutureMarkers, false) {
+	if earlierStructureDetails.FutureMarkers.Size() != 0 && m.markersReferenceMarkers(laterStructureDetails.PastMarkers, earlierStructureDetails.FutureMarkers, false) {
 		return types.True
 	}
 
@@ -227,7 +223,11 @@ func (m *Manager) IsInPastCone(earlierStructureDetails, laterStructureDetails *S
 		return types.False
 	}
 
-	if m.markersReferenceMarkers(earlierStructureDetails.FutureMarkers, laterStructureDetails.PastMarkers, true) {
+	if earlierStructureDetails.FutureMarkers.Size() != 0 && m.markersReferenceMarkers(earlierStructureDetails.FutureMarkers, laterStructureDetails.PastMarkers, true) {
+		return types.Maybe
+	}
+
+	if earlierStructureDetails.FutureMarkers.Size() == 0 && laterStructureDetails.FutureMarkers.Size() == 0 {
 		return types.Maybe
 	}
 


### PR DESCRIPTION
# Description of change

We recently added a special case to the markers.Manager that allowed the possibility of a past cone membership if the FutureMarkers of both Messages were empty. Since we added the check at the beginning of the method it erroneously also triggered when other conditions would allow us to either accept or reject a membership already.

This leads to false positives in the past cone check and unnecessary walks.

This PR moves the check to the end of the function to correctly consider the more strict rules of the other checks.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
