### PR TITLE
Fix: TransactionLiked did not consider monotonicity

### DIFF
--- a/packages/consensus/fcob/consensusmechanism.go
+++ b/packages/consensus/fcob/consensusmechanism.go
@@ -61,8 +61,16 @@ func (f *ConsensusMechanism) Setup() {
 
 // TransactionLiked returns a boolean value indicating whether the given Transaction is liked.
 func (f *ConsensusMechanism) TransactionLiked(transactionID ledgerstate.TransactionID) (liked bool) {
-	f.storage.Opinion(transactionID).Consume(func(opinion *Opinion) {
-		liked = opinion.OpinionEssence.liked
+	f.tangle.LedgerState.TransactionMetadata(transactionID).Consume(func(transactionMetadata *ledgerstate.TransactionMetadata) {
+		f.tangle.LedgerState.BranchDAG.Branch(transactionMetadata.BranchID()).Consume(func(branch ledgerstate.Branch) {
+			if !branch.MonotonicallyLiked() {
+				return
+			}
+
+			f.storage.Opinion(transactionID).Consume(func(opinion *Opinion) {
+				liked = opinion.OpinionEssence.liked
+			})
+		})
 	})
 
 	return


### PR DESCRIPTION
# Description of change

The TransactionLiked function in FCOB consensus did only consider the individual liked status of a Transaction and not its MonotonicallyLiked status. This caused nodes to pick up rejected Transactions via weak Parents which completely fucked up the perception of the ledger state.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
