### PR TITLE
Release v0.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# v0.5.4 - 2021-03-29
+* Add new diagnostic APIs
+* Add new docs sections
+* Add branch inclusion state check before issuing new transactions
+* Refactor the Faucet plugin
+* Optimize transaction's past cone check
+* Make issued messages pass through the parser filters
+* Fix Faucet time usage
+* Fix markers issue
+* Fix max inputs count check
+* Fix nil pointer in diagnostic API
+* Update to latest hive.go 
+* Enhance golangci-lint
+* **Breaking**: bumps network and database versions
+
 # v0.5.3 - 2021-03-25
 * Added new API endpoints
 * Added models navigation through the Dashboard Explorer

--- a/plugins/autopeering/parameters.go
+++ b/plugins/autopeering/parameters.go
@@ -13,5 +13,5 @@ const (
 
 func init() {
 	flag.StringSlice(CfgEntryNodes, []string{"2PV5487xMw5rasGBXXWeqSi4hLz7r19YBt8Y1TGAsQbj@ressims.iota.cafe:15626", "5EDH4uY78EA6wrBkHHAVBWBMDt7EcksRq6pjzipoW15B@entryshimmer.tanglebay.com:14646"}, "list of trusted entry nodes for auto peering")
-	flag.Int(CfgNetworkVersion, 21, "autopeering network version")
+	flag.Int(CfgNetworkVersion, 22, "autopeering network version")
 }

--- a/plugins/banner/plugin.go
+++ b/plugins/banner/plugin.go
@@ -17,7 +17,7 @@ var (
 	once   sync.Once
 
 	// AppVersion version number
-	AppVersion = "v0.5.3"
+	AppVersion = "v0.5.4"
 	// SimplifiedAppVersion is the version number without commit hash
 	SimplifiedAppVersion = simplifiedVersion(AppVersion)
 )

--- a/plugins/database/versioning.go
+++ b/plugins/database/versioning.go
@@ -11,7 +11,7 @@ import (
 const (
 	// DBVersion defines the version of the database schema this version of GoShimmer supports.
 	// Every time there's a breaking change regarding the stored data, this version flag should be adjusted.
-	DBVersion = 23
+	DBVersion = 24
 )
 
 var (


### PR DESCRIPTION
# v0.5.4 - 2021-03-29
* Add new diagnostic APIs
* Add new docs sections
* Add branch inclusion state check before issuing new transactions
* Refactor the Faucet plugin
* Optimize transaction's past cone check
* Make issued messages pass through the parser filters
* Fix Faucet time usage
* Fix markers issue
* Fix max inputs count check
* Fix nil pointer in diagnostic API
* Update to latest hive.go 
* Enhance golangci-lint
* **Breaking**: bumps network and database versions