### PR TITLE
Add more strict integration test for fpc with mana 

### DIFF
--- a/packages/consensus/fcob/consensusmechanism.go
+++ b/packages/consensus/fcob/consensusmechanism.go
@@ -308,6 +308,13 @@ func (f *ConsensusMechanism) createMessageOpinion(messageID tangle.MessageID, wa
 	// trigger TransactionOpinionFormed if the message contains a transaction
 	f.tangle.Utils.ComputeIfTransaction(messageID, func(transactionID ledgerstate.TransactionID) {
 		if f.tangle.LedgerState.BranchInclusionState(f.tangle.LedgerState.BranchID(transactionID)) == ledgerstate.Confirmed {
+			// skip reattachments
+			for _, attachmentID := range f.tangle.Storage.AttachmentMessageIDs(transactionID) {
+				if f.messageOpinionTriggered(attachmentID) {
+					return
+				}
+			}
+
 			f.tangle.ConsensusManager.Events.TransactionConfirmed.Trigger(messageID)
 		}
 	})

--- a/packages/vote/fpc/parameters.go
+++ b/packages/vote/fpc/parameters.go
@@ -42,15 +42,13 @@ func DefaultParameters() *Parameters {
 		EndingRoundsFixedThreshold:          0.50,
 		QuerySampleSize:                     21,
 		MaxQuerySampleSize:                  100,
+		MinOpinionsReceived:                 1,
 		TotalRoundsFinalization:             10,
 		TotalRoundsFixedThreshold:           3,
 		TotalRoundsCoolingOffPeriod:         0,
 		MaxRoundsPerVoteContext:             100,
 		QueryTimeout:                        1500 * time.Millisecond,
 	}
-
-	// Setting the minimum amount of received opinions as the half of the quorum size.
-	p.MinOpinionsReceived = p.QuerySampleSize / 2
 
 	return p
 }

--- a/tools/integration-tests/tester/tests/consensus/consensus_conflicts_test.go
+++ b/tools/integration-tests/tester/tests/consensus/consensus_conflicts_test.go
@@ -2,21 +2,21 @@ package consensus
 
 import (
 	"fmt"
-	"github.com/iotaledger/goshimmer/plugins/webapi/value"
-	"github.com/iotaledger/hive.go/crypto/ed25519"
 	"log"
 	"testing"
 	"time"
 
+	"github.com/iotaledger/hive.go/crypto/ed25519"
+	"github.com/iotaledger/hive.go/identity"
 	"github.com/mr-tron/base58/base58"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/iotaledger/goshimmer/client/wallet/packages/seed"
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
+	"github.com/iotaledger/goshimmer/plugins/webapi/value"
 	"github.com/iotaledger/goshimmer/tools/integration-tests/tester/framework"
 	"github.com/iotaledger/goshimmer/tools/integration-tests/tester/tests"
-	"github.com/iotaledger/hive.go/identity"
 )
 
 // TestConsensusFiftyFiftyOpinionSplit spawns two network partitions with their own peers,
@@ -129,8 +129,7 @@ func TestConsensusFiftyFiftyOpinionSplit(t *testing.T) {
 	}
 
 	// sleep the avg. network delay so both partitions prefer their own first seen transaction
-	log.Printf("waiting %d seconds, 1/4th of avg. network delay to make the transactions "+
-		"preferred in their corresponding partition", framework.ParaFCoBAverageNetworkDelay/4)
+	log.Printf("waiting %d seconds, 1/4th of avg. network delay before merging the partitions", framework.ParaFCoBAverageNetworkDelay/4)
 	time.Sleep(time.Duration(framework.ParaFCoBAverageNetworkDelay) / 4 * time.Second)
 	premergeTimestamp := time.Now()
 	// merge back the partitions


### PR DESCRIPTION
# Description of change

More strict test for fpc mana. We give one of the nodes 90% of the mana. Then the partition with that node will win. Then we would have one like and one disliked conflict transaction.
## Type of change

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [ ] My code follows the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
