### PR TITLE
Release v0.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# v0.5.5 - 2021-04-01
+* Integrate Mana with FPC
+* Integrate Mana with the Autopeering
+* Add several FPC optimizations
+* Add dRNG diagnostic API
+* Simplify memory usage of dashboard and align to Grafana
+* Add a chart for stored, solidifier, scheduler and booker MPS
+* Update to latest hive.go
+* **Breaking**: bumps network and database versions
+
 # v0.5.4 - 2021-03-29
 * Add new diagnostic APIs
 * Add new docs sections

--- a/plugins/autopeering/discovery/parameters.go
+++ b/plugins/autopeering/discovery/parameters.go
@@ -5,7 +5,7 @@ import "github.com/iotaledger/hive.go/configuration"
 // Parameters contains the configuration parameters used by the message layer.
 var Parameters = struct {
 	// NetworkVersion defines the config flag of the network version.
-	NetworkVersion int `default:"22" usage:"autopeering network version"`
+	NetworkVersion int `default:"23" usage:"autopeering network version"`
 
 	// EntryNodes defines the config flag of the entry nodes.
 	EntryNodes []string `default:"2PV5487xMw5rasGBXXWeqSi4hLz7r19YBt8Y1TGAsQbj@ressims.iota.cafe:15626,5EDH4uY78EA6wrBkHHAVBWBMDt7EcksRq6pjzipoW15B@entryshimmer.tanglebay.com:14646" usage:"list of trusted entry nodes for auto peering"`

--- a/plugins/banner/plugin.go
+++ b/plugins/banner/plugin.go
@@ -17,7 +17,7 @@ var (
 	once   sync.Once
 
 	// AppVersion version number
-	AppVersion = "v0.5.4"
+	AppVersion = "v0.5.5"
 	// SimplifiedAppVersion is the version number without commit hash
 	SimplifiedAppVersion = simplifiedVersion(AppVersion)
 )

--- a/plugins/database/versioning.go
+++ b/plugins/database/versioning.go
@@ -11,7 +11,7 @@ import (
 const (
 	// DBVersion defines the version of the database schema this version of GoShimmer supports.
 	// Every time there's a breaking change regarding the stored data, this version flag should be adjusted.
-	DBVersion = 24
+	DBVersion = 25
 )
 
 var (


### PR DESCRIPTION
# v0.5.5 - 2021-04-01
* Integrate Mana with FPC
* Integrate Mana with the Autopeering
* Add several FPC optimizations
* Add dRNG diagnostic API
* Simplify memory usage of dashboard and align to Grafana
* Add a chart for stored, solidifier, scheduler and booker MPS
* Update to latest hive.go
* **Breaking**: bumps network and database versions