### PR TITLE
Consensus debug possibilities

### DIFF
--- a/packages/consensus/fcob/consensusmechanism.go
+++ b/packages/consensus/fcob/consensusmechanism.go
@@ -1,6 +1,7 @@
 package fcob
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/iotaledger/hive.go/datastructure/walker"
@@ -30,7 +31,7 @@ type ConsensusMechanism struct {
 	Events *ConsensusMechanismEvents
 
 	tangle                   *tangle.Tangle
-	storage                  *Storage
+	Storage                  *Storage
 	likedThresholdExecutor   *timedexecutor.TimedExecutor
 	locallyFinalizedExecutor *timedexecutor.TimedExecutor
 }
@@ -50,7 +51,7 @@ func NewConsensusMechanism() *ConsensusMechanism {
 // Init initializes the ConsensusMechanism by making the Tangle object available that is using it.
 func (f *ConsensusMechanism) Init(tangle *tangle.Tangle) {
 	f.tangle = tangle
-	f.storage = NewStorage(tangle.Options.Store)
+	f.Storage = NewStorage(tangle.Options.Store)
 }
 
 // Setup sets up the behavior of the ConsensusMechanism by making it attach to the relevant events in the Tangle.
@@ -67,7 +68,7 @@ func (f *ConsensusMechanism) TransactionLiked(transactionID ledgerstate.Transact
 				return
 			}
 
-			f.storage.Opinion(transactionID).Consume(func(opinion *Opinion) {
+			f.Storage.Opinion(transactionID).Consume(func(opinion *Opinion) {
 				liked = opinion.OpinionEssence.liked
 			})
 		})
@@ -80,12 +81,12 @@ func (f *ConsensusMechanism) TransactionLiked(transactionID ledgerstate.Transact
 func (f *ConsensusMechanism) Shutdown() {
 	f.likedThresholdExecutor.Shutdown(timedqueue.CancelPendingElements)
 	f.locallyFinalizedExecutor.Shutdown(timedqueue.CancelPendingElements)
-	f.storage.Shutdown()
+	f.Storage.Shutdown()
 }
 
 // Evaluate evaluates the opinion of the given messageID.
 func (f *ConsensusMechanism) Evaluate(messageID tangle.MessageID) {
-	f.storage.StoreMessageMetadata(NewMessageMetadata(messageID))
+	f.Storage.StoreMessageMetadata(NewMessageMetadata(messageID))
 	if f.tangle.Utils.ComputeIfTransaction(messageID, func(transactionID ledgerstate.TransactionID) {
 		f.onTransactionBooked(transactionID, messageID)
 	}) {
@@ -98,8 +99,8 @@ func (f *ConsensusMechanism) Evaluate(messageID tangle.MessageID) {
 
 // EvaluateTimestamp evaluates the honesty of the timestamp of the given Message.
 func (f *ConsensusMechanism) EvaluateTimestamp(messageID tangle.MessageID) {
-	f.storage.StoreMessageMetadata(NewMessageMetadata(messageID))
-	f.storage.StoreTimestampOpinion(&TimestampOpinion{
+	f.Storage.StoreMessageMetadata(NewMessageMetadata(messageID))
+	f.Storage.StoreTimestampOpinion(&TimestampOpinion{
 		MessageID: messageID,
 		Value:     voter.Like,
 		LoK:       Two,
@@ -123,7 +124,7 @@ func (f *ConsensusMechanism) ProcessVote(ev *vote.OpinionEvent) {
 			return
 		}
 
-		f.storage.Opinion(transactionID).Consume(func(opinion *Opinion) {
+		f.Storage.Opinion(transactionID).Consume(func(opinion *Opinion) {
 			opinion.SetLiked(ev.Opinion == voter.Like)
 			opinion.SetLevelOfKnowledge(Two)
 			// trigger PayloadOpinionFormed event
@@ -137,7 +138,7 @@ func (f *ConsensusMechanism) ProcessVote(ev *vote.OpinionEvent) {
 
 // TransactionOpinionEssence returns the opinion essence of a given transactionID.
 func (f *ConsensusMechanism) TransactionOpinionEssence(transactionID ledgerstate.TransactionID) (opinion OpinionEssence) {
-	opinion = f.storage.OpinionEssence(transactionID)
+	opinion = f.Storage.OpinionEssence(transactionID)
 
 	return
 }
@@ -150,7 +151,7 @@ func (f *ConsensusMechanism) OpinionsEssence(targetID ledgerstate.TransactionID,
 		if conflictID == targetID {
 			continue
 		}
-		opinions = append(opinions, f.storage.OpinionEssence(conflictID))
+		opinions = append(opinions, f.Storage.OpinionEssence(conflictID))
 	}
 	return
 }
@@ -159,7 +160,7 @@ func (f *ConsensusMechanism) onTransactionBooked(transactionID ledgerstate.Trans
 	// if the opinion for this transactionID is already present,
 	// it's a reattachment and thus, we re-use the same opinion.
 	isReattachment := false
-	f.storage.Opinion(transactionID).Consume(func(opinion *Opinion) {
+	f.Storage.Opinion(transactionID).Consume(func(opinion *Opinion) {
 		// if the opinion has been already set by the opinion provider, re-use it
 		if opinion.LevelOfKnowledge() > One {
 			// trigger PayloadOpinionFormed event
@@ -189,7 +190,7 @@ func (f *ConsensusMechanism) onTransactionBooked(transactionID ledgerstate.Trans
 			liked:            false,
 			levelOfKnowledge: Two,
 		}
-		f.storage.opinionStorage.Store(newOpinion).Release()
+		f.Storage.opinionStorage.Store(newOpinion).Release()
 		f.onPayloadOpinionFormed(messageID, newOpinion.liked)
 		return
 	}
@@ -197,7 +198,7 @@ func (f *ConsensusMechanism) onTransactionBooked(transactionID ledgerstate.Trans
 	if f.tangle.LedgerState.TransactionConflicting(transactionID) {
 		newOpinion.OpinionEssence = deriveOpinion(timestamp, f.OpinionsEssence(transactionID, f.tangle.LedgerState.ConflictSet(transactionID)))
 
-		f.storage.opinionStorage.Store(newOpinion).Release()
+		f.Storage.opinionStorage.Store(newOpinion).Release()
 
 		switch newOpinion.LevelOfKnowledge() {
 		case Pending:
@@ -222,7 +223,7 @@ func (f *ConsensusMechanism) onTransactionBooked(transactionID ledgerstate.Trans
 		timestamp:        timestamp,
 		levelOfKnowledge: Pending,
 	}
-	o, stored := f.storage.opinionStorage.StoreIfAbsent(newOpinion)
+	o, stored := f.Storage.opinionStorage.StoreIfAbsent(newOpinion)
 	if stored {
 		o.Release()
 	}
@@ -230,7 +231,9 @@ func (f *ConsensusMechanism) onTransactionBooked(transactionID ledgerstate.Trans
 	// Wait LikedThreshold
 	f.likedThresholdExecutor.ExecuteAt(func() {
 		runLocallyFinalizedExecutor := true
-		f.storage.Opinion(transactionID).Consume(func(opinion *Opinion) {
+		if !f.Storage.Opinion(transactionID).Consume(func(opinion *Opinion) {
+			opinion.SetFCOBTime1(time.Now())
+
 			if f.tangle.LedgerState.TransactionConflicting(transactionID) {
 				runLocallyFinalizedExecutor = false
 				// if the previous conflicts have been finalized with all dislikes,
@@ -252,12 +255,16 @@ func (f *ConsensusMechanism) onTransactionBooked(transactionID ledgerstate.Trans
 			}
 			opinion.SetLevelOfKnowledge(One)
 			opinion.SetLiked(true)
-		})
+		}) {
+			panic(fmt.Sprintf("could not load opinion of transaction %s", transactionID))
+		}
 
 		if runLocallyFinalizedExecutor {
 			// Wait LocallyFinalizedThreshold
 			f.locallyFinalizedExecutor.ExecuteAt(func() {
-				f.storage.Opinion(transactionID).Consume(func(opinion *Opinion) {
+				if !f.Storage.Opinion(transactionID).Consume(func(opinion *Opinion) {
+					opinion.SetFCOBTime2(time.Now())
+
 					opinion.SetLiked(true)
 					if f.tangle.LedgerState.TransactionConflicting(transactionID) {
 						// trigger voting for this transactionID
@@ -270,7 +277,9 @@ func (f *ConsensusMechanism) onTransactionBooked(transactionID ledgerstate.Trans
 					for _, messageID := range messageIDs {
 						f.onPayloadOpinionFormed(messageID, opinion.liked)
 					}
-				})
+				}) {
+					panic(fmt.Sprintf("could not load opinion of transaction %s", transactionID))
+				}
 			}, timestamp.Add(LocallyFinalizedThreshold))
 		}
 	}, timestamp.Add(LikedThreshold))
@@ -332,7 +341,7 @@ func (f *ConsensusMechanism) createMessageOpinion(messageID tangle.MessageID, wa
 
 func (f *ConsensusMechanism) setEligibility(messageID tangle.MessageID) {
 	f.tangle.Storage.MessageMetadata(messageID).Consume(func(messageMetadata *tangle.MessageMetadata) {
-		f.storage.TimestampOpinion(messageID).Consume(func(timestampOpinion *TimestampOpinion) {
+		f.Storage.TimestampOpinion(messageID).Consume(func(timestampOpinion *TimestampOpinion) {
 			messageMetadata.SetEligible(
 				timestampOpinion != nil && timestampOpinion.Value == opinion.Like && timestampOpinion.LoK > One && f.parentsEligibility(messageID),
 			)
@@ -342,7 +351,7 @@ func (f *ConsensusMechanism) setEligibility(messageID tangle.MessageID) {
 
 // OpinionFormedTime returns the time when the opinion for the given message was formed.
 func (f *ConsensusMechanism) OpinionFormedTime(messageID tangle.MessageID) (t time.Time) {
-	f.storage.MessageMetadata(messageID).Consume(func(messageMetadata *MessageMetadata) {
+	f.Storage.MessageMetadata(messageID).Consume(func(messageMetadata *MessageMetadata) {
 		t = messageMetadata.OpinionFormedTime()
 	})
 	return
@@ -364,7 +373,7 @@ func (f *ConsensusMechanism) parentsEligibility(messageID tangle.MessageID) (eli
 
 // setPayloadOpinionDone set the payload opinion as formed.
 func (f *ConsensusMechanism) setPayloadOpinionDone(messageID tangle.MessageID) (modified bool) {
-	f.storage.MessageMetadata(messageID).Consume(func(messageMetadata *MessageMetadata) {
+	f.Storage.MessageMetadata(messageID).Consume(func(messageMetadata *MessageMetadata) {
 		modified = messageMetadata.SetPayloadOpinionFormed(true)
 	})
 	return
@@ -372,7 +381,7 @@ func (f *ConsensusMechanism) setPayloadOpinionDone(messageID tangle.MessageID) (
 
 // setTimestampOpinionDone set the timestamp opinion as formed.
 func (f *ConsensusMechanism) setTimestampOpinionDone(messageID tangle.MessageID) (modified bool) {
-	f.storage.MessageMetadata(messageID).Consume(func(messageMetadata *MessageMetadata) {
+	f.Storage.MessageMetadata(messageID).Consume(func(messageMetadata *MessageMetadata) {
 		modified = messageMetadata.SetTimestampOpinionFormed(true)
 	})
 	return
@@ -380,7 +389,7 @@ func (f *ConsensusMechanism) setTimestampOpinionDone(messageID tangle.MessageID)
 
 // setMessageOpinionFormed set the message opinion as formed.
 func (f *ConsensusMechanism) setMessageOpinionFormed(messageID tangle.MessageID) (modified bool) {
-	f.storage.MessageMetadata(messageID).Consume(func(messageMetadata *MessageMetadata) {
+	f.Storage.MessageMetadata(messageID).Consume(func(messageMetadata *MessageMetadata) {
 		modified = messageMetadata.SetMessageOpinionFormed(true)
 	})
 	return
@@ -388,7 +397,7 @@ func (f *ConsensusMechanism) setMessageOpinionFormed(messageID tangle.MessageID)
 
 // messageDone checks if the both timestamp opinion and payload opinion are formed.
 func (f *ConsensusMechanism) messageDone(messageID tangle.MessageID) (done bool) {
-	f.storage.MessageMetadata(messageID).Consume(func(messageMetadata *MessageMetadata) {
+	f.Storage.MessageMetadata(messageID).Consume(func(messageMetadata *MessageMetadata) {
 		done = messageMetadata.TimestampOpinionFormed() && messageMetadata.PayloadOpinionFormed()
 	})
 	return
@@ -396,7 +405,7 @@ func (f *ConsensusMechanism) messageDone(messageID tangle.MessageID) (done bool)
 
 // setMessageOpinionTriggered set the message opinion as triggered.
 func (f *ConsensusMechanism) setMessageOpinionTriggered(messageID tangle.MessageID) (modified bool) {
-	f.storage.MessageMetadata(messageID).Consume(func(messageMetadata *MessageMetadata) {
+	f.Storage.MessageMetadata(messageID).Consume(func(messageMetadata *MessageMetadata) {
 		modified = messageMetadata.SetMessageOpinionTriggered(true)
 	})
 	return
@@ -404,7 +413,7 @@ func (f *ConsensusMechanism) setMessageOpinionTriggered(messageID tangle.Message
 
 // messageOpinionTriggered checks if the message opinion has been triggered.
 func (f *ConsensusMechanism) messageOpinionTriggered(messageID tangle.MessageID) (messageOpinionTriggered bool) {
-	f.storage.MessageMetadata(messageID).Consume(func(messageMetadata *MessageMetadata) {
+	f.Storage.MessageMetadata(messageID).Consume(func(messageMetadata *MessageMetadata) {
 		messageOpinionTriggered = messageMetadata.MessageOpinionTriggered()
 	})
 	return

--- a/packages/consensus/fcob/storage.go
+++ b/packages/consensus/fcob/storage.go
@@ -21,7 +21,7 @@ import (
 
 // region Storage //////////////////////////////////////////////////////////////////////////////////////////////////////
 
-// Storage is a component of the ConsensusMechanism that encapsulates the storage related methods.
+// Storage is a component of the ConsensusMechanism that encapsulates the Storage related methods.
 type Storage struct {
 	store                   kvstore.KVStore
 	opinionStorage          *objectstorage.ObjectStorage
@@ -75,7 +75,7 @@ func (s *Storage) MessageMetadata(messageID tangle.MessageID) (cachedMessageMeta
 	return &CachedMessageMetadata{CachedObject: s.messageMetadataStorage.Load(messageID.Bytes())}
 }
 
-// StoreTimestampOpinion stores the TimestampOpinion in the object storage. It returns true if it was stored or updated.
+// StoreTimestampOpinion stores the TimestampOpinion in the object Storage. It returns true if it was stored or updated.
 func (s *Storage) StoreTimestampOpinion(timestampOpinion *TimestampOpinion) (modified bool) {
 	cachedTimestampOpinion := &CachedTimestampOpinion{CachedObject: s.timestampOpinionStorage.ComputeIfAbsent(timestampOpinion.MessageID.Bytes(), func(key []byte) objectstorage.StorableObject {
 		timestampOpinion.SetModified()
@@ -106,7 +106,7 @@ func (s *Storage) StoreTimestampOpinion(timestampOpinion *TimestampOpinion) (mod
 	return
 }
 
-// StoreMessageMetadata stores the MessageMetadata in the object storage. It returns true if it was stored or updated.
+// StoreMessageMetadata stores the MessageMetadata in the object Storage. It returns true if it was stored or updated.
 func (s *Storage) StoreMessageMetadata(messageMetadata *MessageMetadata) (modified bool) {
 	cachedMessageMetadata := &CachedMessageMetadata{CachedObject: s.messageMetadataStorage.ComputeIfAbsent(messageMetadata.id.Bytes(), func(key []byte) objectstorage.StorableObject {
 		messageMetadata.SetModified()
@@ -151,17 +151,17 @@ func (s *Storage) Shutdown() {
 // region Object Storage Parameters ////////////////////////////////////////////////////////////////////////////////////
 
 const (
-	// PrefixOpinion defines the storage prefix for the opinion storage.
+	// PrefixOpinion defines the Storage prefix for the opinion Storage.
 	PrefixOpinion byte = iota
 
-	// PrefixTimestampOpinion defines the storage prefix for the timestamp opinion storage.
+	// PrefixTimestampOpinion defines the Storage prefix for the timestamp opinion Storage.
 	PrefixTimestampOpinion
 
-	// PrefixMessageMetadata defines the storage prefix for the MessageMetadata storage.
+	// PrefixMessageMetadata defines the Storage prefix for the MessageMetadata Storage.
 	PrefixMessageMetadata
 
-	// cacheTime defines the duration that the object storage caches objects.
-	cacheTime = 2 * time.Second
+	// cacheTime defines the duration that the object Storage caches objects.
+	cacheTime = 0 * time.Second
 )
 
 // endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -228,7 +228,7 @@ func MessageMetadataFromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (messa
 	return
 }
 
-// MessageMetadataFromObjectStorage restores a MessageMetadata object from the object storage.
+// MessageMetadataFromObjectStorage restores a MessageMetadata object from the object Storage.
 func MessageMetadataFromObjectStorage(key []byte, data []byte) (result objectstorage.StorableObject, err error) {
 	if result, _, err = MessageMetadataFromBytes(byteutils.ConcatBytes(key, data)); err != nil {
 		err = xerrors.Errorf("failed to parse MessageMetadata from bytes: %w", err)
@@ -398,7 +398,7 @@ func (m *MessageMetadata) ObjectStorageKey() []byte {
 }
 
 // ObjectStorageValue marshals the MessageMetadata into a sequence of bytes that are used as the value part in the
-// object storage.
+// object Storage.
 func (m *MessageMetadata) ObjectStorageValue() []byte {
 	return marshalutil.New(3 * marshalutil.BoolSize).
 		WriteBool(m.PayloadOpinionFormed()).
@@ -416,7 +416,7 @@ var _ objectstorage.StorableObject = &MessageMetadata{}
 
 // region CachedMessageMetadata ////////////////////////////////////////////////////////////////////////////////////////
 
-// CachedMessageMetadata is a wrapper for the generic CachedObject returned by the object storage that overrides the
+// CachedMessageMetadata is a wrapper for the generic CachedObject returned by the object Storage that overrides the
 // accessor methods with a type-casted one.
 type CachedMessageMetadata struct {
 	objectstorage.CachedObject
@@ -531,7 +531,7 @@ func TimestampOpinionFromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (resu
 	return
 }
 
-// TimestampOpinionFromObjectStorage restores a TimestampOpinion from the object storage.
+// TimestampOpinionFromObjectStorage restores a TimestampOpinion from the object Storage.
 func TimestampOpinionFromObjectStorage(key []byte, data []byte) (result objectstorage.StorableObject, err error) {
 	if result, _, err = TimestampOpinionFromBytes(byteutils.ConcatBytes(key, data)); err != nil {
 		err = xerrors.Errorf("failed to parse TimestampOpinion from bytes: %w", err)
@@ -572,7 +572,7 @@ func (t *TimestampOpinion) ObjectStorageKey() []byte {
 }
 
 // ObjectStorageValue marshals the TimestampOpinion into a sequence of bytes that are used as the value part in the
-// object storage.
+// object Storage.
 func (t *TimestampOpinion) ObjectStorageValue() []byte {
 	return marshalutil.New(2).
 		WriteByte(byte(t.Value)).
@@ -584,7 +584,7 @@ func (t *TimestampOpinion) ObjectStorageValue() []byte {
 
 // region CachedTimestampOpinion ///////////////////////////////////////////////////////////////////////////////////////
 
-// CachedTimestampOpinion is a wrapper for the generic CachedObject returned by the object storage that overrides the accessor
+// CachedTimestampOpinion is a wrapper for the generic CachedObject returned by the object Storage that overrides the accessor
 // methods with a type-casted one.
 type CachedTimestampOpinion struct {
 	objectstorage.CachedObject

--- a/plugins/spammer/webapi.go
+++ b/plugins/spammer/webapi.go
@@ -4,8 +4,9 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/iotaledger/goshimmer/plugins/webapi/jsonmodels"
 	"github.com/labstack/echo"
+
+	"github.com/iotaledger/goshimmer/plugins/webapi/jsonmodels"
 )
 
 func handleRequest(c echo.Context) error {

--- a/plugins/webapi/jsonmodels/ledgerstate.go
+++ b/plugins/webapi/jsonmodels/ledgerstate.go
@@ -3,6 +3,7 @@ package jsonmodels
 import (
 	"github.com/mr-tron/base58"
 
+	"github.com/iotaledger/goshimmer/packages/consensus/fcob"
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 )
 
@@ -353,6 +354,32 @@ func NewTransactionMetadata(transactionMetadata *ledgerstate.TransactionMetadata
 		SolidificationTime: transactionMetadata.SolidificationTime().Unix(),
 		Finalized:          transactionMetadata.Finalized(),
 		LazyBooked:         transactionMetadata.LazyBooked(),
+	}
+}
+
+// endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// region TransactionConsensusMetadata /////////////////////////////////////////////////////////////////////////////////
+
+// TransactionConsensusMetadata represents the JSON model of the transaction's consensus metadata.
+type TransactionConsensusMetadata struct {
+	TransactionID string `json:"transactionID"`
+	Timestamp     int64  `json:"timestamp"`
+	Liked         bool   `json:"liked"`
+	LoK           string `json:"lok"`
+	FCOBTime1     int64  `json:"fcobTime1"`
+	FCOBTime2     int64  `json:"fcobTime2"`
+}
+
+// NewTransactionConsensusMetadata returns the TransactionConsensusMetadata from the given transaction ID.
+func NewTransactionConsensusMetadata(transactionID ledgerstate.TransactionID, opinion *fcob.Opinion) *TransactionConsensusMetadata {
+	return &TransactionConsensusMetadata{
+		TransactionID: transactionID.Base58(),
+		Timestamp:     opinion.Timestamp().Unix(),
+		Liked:         opinion.Liked(),
+		LoK:           opinion.LevelOfKnowledge().String(),
+		FCOBTime1:     opinion.FCOBTime1().Unix(),
+		FCOBTime2:     opinion.FCOBTime2().Unix(),
 	}
 }
 

--- a/plugins/webapi/jsonmodels/tangle.go
+++ b/plugins/webapi/jsonmodels/tangle.go
@@ -1,6 +1,7 @@
 package jsonmodels
 
 import (
+	"github.com/iotaledger/goshimmer/packages/consensus/fcob"
 	"github.com/iotaledger/goshimmer/packages/tangle"
 )
 
@@ -53,6 +54,36 @@ func NewMessageMetadata(metadata *tangle.MessageMetadata) MessageMetadata {
 		Booked:             metadata.IsBooked(),
 		Eligible:           metadata.IsEligible(),
 		Invalid:            metadata.IsInvalid(),
+	}
+}
+
+// endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// region MessageConsensusMetadata /////////////////////////////////////////////////////////////////////////////////////
+
+// MessageConsensusMetadata represents the JSON model of a tangle.Message's consensus metadata.
+type MessageConsensusMetadata struct {
+	ID                      string `json:"id"`
+	OpinionFormedTime       int64  `json:"opinionFormedTime"`
+	PayloadOpinionFormed    bool   `json:"payloadOpinionFormed"`
+	TimestampOpinionFormed  bool   `json:"timestampOpinionFormed"`
+	MessageOpinionFormed    bool   `json:"messageOpinionFormed"`
+	MessageOpinionTriggered bool   `json:"messageOpinionTriggered"`
+	TimestampOpinion        string `json:"timestampOpinion"`
+	TimestampLoK            string `json:"timestampLoK"`
+}
+
+// NewMessageConsensusMetadata returns MessageConsensusMetadata from the given tangle.MessageMetadata.
+func NewMessageConsensusMetadata(metadata *fcob.MessageMetadata, timestampOpinion *fcob.TimestampOpinion) MessageConsensusMetadata {
+	return MessageConsensusMetadata{
+		ID:                      metadata.ID().String(),
+		OpinionFormedTime:       metadata.OpinionFormedTime().Unix(),
+		PayloadOpinionFormed:    metadata.PayloadOpinionFormed(),
+		TimestampOpinionFormed:  metadata.TimestampOpinionFormed(),
+		MessageOpinionFormed:    metadata.MessageOpinionFormed(),
+		MessageOpinionTriggered: metadata.MessageOpinionTriggered(),
+		TimestampOpinion:        timestampOpinion.Value.String(),
+		TimestampLoK:            timestampOpinion.LoK.String(),
 	}
 }
 

--- a/plugins/webapi/ledgerstate/plugin.go
+++ b/plugins/webapi/ledgerstate/plugin.go
@@ -9,6 +9,7 @@ import (
 	"github.com/labstack/echo"
 	"golang.org/x/xerrors"
 
+	"github.com/iotaledger/goshimmer/packages/consensus/fcob"
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 	"github.com/iotaledger/goshimmer/packages/tangle"
 	"github.com/iotaledger/goshimmer/plugins/messagelayer"
@@ -40,6 +41,7 @@ func Plugin() *node.Plugin {
 			webapi.Server().GET("ledgerstate/outputs/:outputID/metadata", GetOutputMetadata)
 			webapi.Server().GET("ledgerstate/transactions/:transactionID", GetTransaction)
 			webapi.Server().GET("ledgerstate/transactions/:transactionID/metadata", GetTransactionMetadata)
+			webapi.Server().GET("ledgerstate/transactions/:transactionID/consensus", GetTransactionConsensusMetadata)
 			webapi.Server().GET("ledgerstate/transactions/:transactionID/attachments", GetTransactionAttachments)
 		})
 	})
@@ -252,6 +254,27 @@ func GetTransactionMetadata(c echo.Context) (err error) {
 	}
 
 	return
+}
+
+// endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// GetTransactionConsensusMetadata is the handler for the ledgerstate/transactions/:transactionID/consensus endpoint.
+func GetTransactionConsensusMetadata(c echo.Context) (err error) {
+	transactionID, err := ledgerstate.TransactionIDFromBase58(c.Param("transactionID"))
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, jsonmodels.NewErrorResponse(err))
+	}
+
+	consensusMechanism := messagelayer.Tangle().Options.ConsensusMechanism.(*fcob.ConsensusMechanism)
+	if consensusMechanism != nil {
+		if consensusMechanism.Storage.Opinion(transactionID).Consume(func(opinion *fcob.Opinion) {
+			err = c.JSON(http.StatusOK, jsonmodels.NewTransactionConsensusMetadata(transactionID, opinion))
+		}) {
+			return
+		}
+	}
+
+	return c.JSON(http.StatusNotFound, jsonmodels.NewErrorResponse(xerrors.Errorf("failed to load TransactionConsensusMetadata of Transaction with %s", transactionID)))
 }
 
 // endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/plugins/webapi/tools/message/diagnostic_branches.go
+++ b/plugins/webapi/tools/message/diagnostic_branches.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/iotaledger/goshimmer/packages/tangle"
 	"github.com/labstack/echo"
 
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
+	"github.com/iotaledger/goshimmer/packages/tangle"
 	"github.com/iotaledger/goshimmer/plugins/messagelayer"
 )
 

--- a/plugins/webapi/tools/message/diagnostic_messages.go
+++ b/plugins/webapi/tools/message/diagnostic_messages.go
@@ -14,6 +14,7 @@ import (
 	"github.com/iotaledger/hive.go/identity"
 	"github.com/labstack/echo"
 
+	"github.com/iotaledger/goshimmer/packages/consensus/fcob"
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 	"github.com/iotaledger/goshimmer/packages/tangle"
 	"github.com/iotaledger/goshimmer/plugins/messagelayer"
@@ -165,6 +166,12 @@ var DiagnosticMessagesTableDescription = []string{
 	"FMLI",
 	"PayloadType",
 	"TransactionID",
+	"PayloadOpinionFormed",
+	"TimestampOpinionFormed",
+	"MessageOpinionFormed",
+	"MessageOpinionTriggered",
+	"TimestampOpinion",
+	"TimestampLoK",
 }
 
 // DiagnosticMessagesInfo holds the information of a message.
@@ -198,6 +205,13 @@ type DiagnosticMessagesInfo struct {
 	FMLI              uint64 // FutureMarkers Lowest Index
 	PayloadType       string
 	TransactionID     string
+	// Consensus information
+	PayloadOpinionFormed    bool
+	TimestampOpinionFormed  bool
+	MessageOpinionFormed    bool
+	MessageOpinionTriggered bool
+	TimestampOpinion        string
+	TimestampLoK            string
 }
 
 func getDiagnosticMessageInfo(messageID tangle.MessageID) *DiagnosticMessagesInfo {
@@ -248,6 +262,22 @@ func getDiagnosticMessageInfo(messageID tangle.MessageID) *DiagnosticMessagesInf
 
 	msgInfo.InclusionState = messagelayer.Tangle().LedgerState.BranchInclusionState(branchID).String()
 
+	// add consensus information
+	consensusMechanism := messagelayer.Tangle().Options.ConsensusMechanism.(*fcob.ConsensusMechanism)
+	if consensusMechanism != nil {
+		consensusMechanism.Storage.MessageMetadata(messageID).Consume(func(messageMetadata *fcob.MessageMetadata) {
+			msgInfo.PayloadOpinionFormed = messageMetadata.PayloadOpinionFormed()
+			msgInfo.TimestampOpinionFormed = messageMetadata.TimestampOpinionFormed()
+			msgInfo.MessageOpinionFormed = messageMetadata.MessageOpinionFormed()
+			msgInfo.MessageOpinionTriggered = messageMetadata.MessageOpinionTriggered()
+		})
+
+		consensusMechanism.Storage.TimestampOpinion(messageID).Consume(func(timestampOpinion *fcob.TimestampOpinion) {
+			msgInfo.TimestampOpinion = timestampOpinion.Value.String()
+			msgInfo.TimestampLoK = timestampOpinion.LoK.String()
+		})
+	}
+
 	return msgInfo
 }
 
@@ -282,6 +312,12 @@ func (d *DiagnosticMessagesInfo) toCSVRow() (row []string) {
 		fmt.Sprint(d.FMLI),
 		d.PayloadType,
 		d.TransactionID,
+		fmt.Sprint(d.PayloadOpinionFormed),
+		fmt.Sprint(d.TimestampOpinionFormed),
+		fmt.Sprint(d.MessageOpinionFormed),
+		fmt.Sprint(d.MessageOpinionTriggered),
+		d.TimestampOpinion,
+		d.TimestampLoK,
 	}
 
 	return row

--- a/plugins/webapi/tools/message/diagnostic_utxoDAG.go
+++ b/plugins/webapi/tools/message/diagnostic_utxoDAG.go
@@ -10,6 +10,7 @@ import (
 	"github.com/labstack/echo"
 	"github.com/mr-tron/base58"
 
+	"github.com/iotaledger/goshimmer/packages/consensus/fcob"
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 	"github.com/iotaledger/goshimmer/packages/tangle"
 	"github.com/iotaledger/goshimmer/plugins/messagelayer"
@@ -70,6 +71,9 @@ var DiagnosticUTXODAGTableDescription = []string{
 	"Finalized",
 	"LazyBooked",
 	"Liked",
+	"LoK",
+	"FCOB1Time",
+	"FCOB2Time",
 }
 
 // DiagnosticUTXODAGInfo holds the information of a UTXO.
@@ -94,6 +98,9 @@ type DiagnosticUTXODAGInfo struct {
 	Finalized                bool
 	LazyBooked               bool
 	Liked                    bool
+	LoK                      string
+	FCOBTime1                time.Time
+	FCOBTime2                time.Time
 }
 
 func getDiagnosticUTXODAGInfo(transactionID ledgerstate.TransactionID, messageID tangle.MessageID) DiagnosticUTXODAGInfo {
@@ -130,6 +137,15 @@ func getDiagnosticUTXODAGInfo(transactionID ledgerstate.TransactionID, messageID
 		txInfo.Liked = messagelayer.ConsensusMechanism().TransactionLiked(transactionID)
 	})
 
+	consensusMechanism := messagelayer.Tangle().Options.ConsensusMechanism.(*fcob.ConsensusMechanism)
+	if consensusMechanism != nil {
+		consensusMechanism.Storage.Opinion(transactionID).Consume(func(opinion *fcob.Opinion) {
+			txInfo.LoK = opinion.LevelOfKnowledge().String()
+			txInfo.FCOBTime1 = opinion.FCOBTime1()
+			txInfo.FCOBTime2 = opinion.FCOBTime2()
+		})
+	}
+
 	return txInfo
 }
 
@@ -152,6 +168,9 @@ func (d DiagnosticUTXODAGInfo) toCSV() (result string) {
 		fmt.Sprint(d.Finalized),
 		fmt.Sprint(d.LazyBooked),
 		fmt.Sprint(d.Liked),
+		d.LoK,
+		fmt.Sprint(d.FCOBTime1.UnixNano()),
+		fmt.Sprint(d.FCOBTime2.UnixNano()),
 	}
 
 	result = strings.Join(row, ",")


### PR DESCRIPTION
Adds consensus information to 
- `tools/diagnostic/utxodag` 
- `tools/diagnostic/messages`

Adds two new endpoints to get consensus metadata of message and transaction
- `ledgerstate/transactions/:transactionID/consensus`
- `messages/:messageID/consensus`