### PR TITLE
Check consumed bytes in payload unmarshalFunc

### DIFF
--- a/packages/drng/payload.go
+++ b/packages/drng/payload.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/iotaledger/hive.go/marshalutil"
 	"github.com/iotaledger/hive.go/stringify"
+	"golang.org/x/xerrors"
 
 	"github.com/iotaledger/goshimmer/packages/tangle/payload"
 )
@@ -128,7 +129,14 @@ func (p *Payload) String() string {
 
 // PayloadType defines the type of the drng payload.
 var PayloadType = payload.NewType(111, ObjectName, func(data []byte) (payload payload.Payload, err error) {
-	payload, _, err = FromBytes(data)
+	var consumedBytes int
+	payload, consumedBytes, err = FromBytes(data)
+	if err != nil {
+		return nil, err
+	}
+	if consumedBytes != len(data) {
+		return nil, xerrors.New("not all payload bytes were consumed")
+	}
 
 	return
 })

--- a/packages/ledgerstate/transaction.go
+++ b/packages/ledgerstate/transaction.go
@@ -31,7 +31,14 @@ var TransactionType payload.Type
 // init defers the initialization of the TransactionType to not have an initialization loop.
 func init() {
 	TransactionType = payload.NewType(1337, "TransactionType", func(data []byte) (payload.Payload, error) {
-		return TransactionFromMarshalUtil(marshalutil.New(data))
+		tx, consumedBytes, err := TransactionFromBytes(data)
+		if err != nil {
+			return nil, err
+		}
+		if consumedBytes != len(data) {
+			return nil, xerrors.New("not all payload bytes were consumed")
+		}
+		return tx, nil
 	})
 }
 

--- a/packages/tangle/payload/data.go
+++ b/packages/tangle/payload/data.go
@@ -12,7 +12,14 @@ var GenericDataPayloadType = NewType(0, "GenericDataPayloadType", GenericDataPay
 
 // GenericDataPayloadUnmarshaler is the UnmarshalerFunc of the GenericDataPayload which is also used as a unmarshaler for unknown Types.
 func GenericDataPayloadUnmarshaler(data []byte) (Payload, error) {
-	return GenericDataPayloadFromMarshalUtil(marshalutil.New(data))
+	payload, consumedBytes, err := GenericDataPayloadFromBytes(data)
+	if err != nil {
+		return nil, err
+	}
+	if consumedBytes != len(data) {
+		return nil, xerrors.New("not all payload bytes were consumed")
+	}
+	return payload, nil
 }
 
 // GenericDataPayload represents a payload which just contains a blob of data.

--- a/packages/vote/statement/payload.go
+++ b/packages/vote/statement/payload.go
@@ -23,7 +23,14 @@ var StatementType payload.Type
 func init() {
 	// Type defines the type of the statement payload.
 	StatementType = payload.NewType(3, ObjectName, func(data []byte) (payload payload.Payload, err error) {
-		payload, _, err = FromBytes(data)
+		var consumedBytes int
+		payload, consumedBytes, err = FromBytes(data)
+		if err != nil {
+			return nil, err
+		}
+		if consumedBytes != len(data) {
+			return nil, xerrors.New("not all payload bytes were consumed")
+		}
 		return
 	})
 }

--- a/plugins/faucet/request.go
+++ b/plugins/faucet/request.go
@@ -7,6 +7,7 @@ import (
 	"github.com/iotaledger/hive.go/cerrors"
 	"github.com/iotaledger/hive.go/marshalutil"
 	"github.com/iotaledger/hive.go/stringify"
+	"golang.org/x/xerrors"
 
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 	"github.com/iotaledger/goshimmer/packages/pow"
@@ -15,7 +16,6 @@ import (
 
 	// Only want to use init
 	_ "golang.org/x/crypto/blake2b"
-	"golang.org/x/xerrors"
 )
 
 const (
@@ -124,11 +124,14 @@ func (p *Request) String() string {
 
 // PayloadUnmarshaler sets the generic unmarshaler.
 func PayloadUnmarshaler(data []byte) (payload payload.Payload, err error) {
-	payload, _, err = FromBytes(data)
+	var consumedBytes int
+	payload, consumedBytes, err = FromBytes(data)
 	if err != nil {
-		err = xerrors.Errorf("failed to unmarshal faucet payload from bytes: %w", err)
+		return nil, err
 	}
-
+	if consumedBytes != len(data) {
+		return nil, xerrors.New("not all payload bytes were consumed")
+	}
 	return
 }
 

--- a/plugins/networkdelay/object.go
+++ b/plugins/networkdelay/object.go
@@ -7,6 +7,7 @@ import (
 	"github.com/iotaledger/hive.go/marshalutil"
 	"github.com/iotaledger/hive.go/stringify"
 	"github.com/mr-tron/base58"
+	"golang.org/x/xerrors"
 
 	"github.com/iotaledger/goshimmer/packages/tangle/payload"
 )
@@ -133,8 +134,14 @@ func (o *Object) String() string {
 
 // Type represents the identifier which addresses the network delay Object type.
 var Type = payload.NewType(189, ObjectName, func(data []byte) (payload payload.Payload, err error) {
-	payload, _, err = FromBytes(data)
-
+	var consumedBytes int
+	payload, consumedBytes, err = FromBytes(data)
+	if err != nil {
+		return nil, err
+	}
+	if consumedBytes != len(data) {
+		return nil, xerrors.New("not all payload bytes were consumed")
+	}
 	return
 })
 

--- a/plugins/syncbeacon/payload/payload.go
+++ b/plugins/syncbeacon/payload/payload.go
@@ -26,7 +26,6 @@ var Type = payload.NewType(200, ObjectName, func(data []byte) (payload payload.P
 		return nil, xerrors.New("not all payload bytes were consumed")
 	}
 	return
-	return
 })
 
 // Payload represents the syncbeacon payload

--- a/plugins/syncbeacon/payload/payload.go
+++ b/plugins/syncbeacon/payload/payload.go
@@ -3,10 +3,11 @@ package payload
 import (
 	"fmt"
 
-	"github.com/iotaledger/goshimmer/packages/tangle/payload"
-
 	"github.com/iotaledger/hive.go/marshalutil"
 	"github.com/iotaledger/hive.go/stringify"
+	"golang.org/x/xerrors"
+
+	"github.com/iotaledger/goshimmer/packages/tangle/payload"
 )
 
 const (
@@ -16,8 +17,15 @@ const (
 
 // Type is the type of the syncbeacon payload.
 var Type = payload.NewType(200, ObjectName, func(data []byte) (payload payload.Payload, err error) {
-	payload, _, err = FromBytes(data)
-
+	var consumedBytes int
+	payload, consumedBytes, err = FromBytes(data)
+	if err != nil {
+		return nil, err
+	}
+	if consumedBytes != len(data) {
+		return nil, xerrors.New("not all payload bytes were consumed")
+	}
+	return
 	return
 })
 


### PR DESCRIPTION
# Description of change
Previously, serialized payloads could have trailing, unparsed bytes and were still considered valid.
This PR introduces an extra check that makes sure that the exact number of bytes are unmarshaled, otherwise an error is returned
and the payload is considered to be invalid.


