### PR TITLE
Make fpc integration test more reliable

### DIFF
--- a/plugins/messagelayer/parameters.go
+++ b/plugins/messagelayer/parameters.go
@@ -37,6 +37,9 @@ var FPCParameters = struct {
 
 	// QuerySampleSize defines how many nodes will be queried each round.
 	QuerySampleSize int `default:"21" usage:"Size of the voting quorum (k)"`
+
+	// TotalRoundsFinalization The amount of rounds a vote context's opinion needs to stay the same to be considered final. Also called 'l'.
+	TotalRoundsFinalization int `default:"10" usage:"The number of rounds opinion needs to stay the same to become final (l)."`
 }{}
 
 // StatementParameters contains the configuration parameters used by the FPC statements in the tangle.

--- a/tools/integration-tests/tester/framework/docker.go
+++ b/tools/integration-tests/tester/framework/docker.go
@@ -120,6 +120,7 @@ func (d *DockerContainer) CreateGoShimmerPeer(config GoShimmerConfig) error {
 			fmt.Sprintf("--autopeering.entryNodes=%s@%s:14626", config.EntryNodePublicKey, config.EntryNodeHost),
 			fmt.Sprintf("--fpc.roundInterval=%d", config.FPCRoundInterval),
 			fmt.Sprintf("--fpc.listen=%v", config.FPCListen),
+			fmt.Sprintf("--fpc.totalRoundsFinalization=%d", config.FPCTotalRoundsFinalization),
 			fmt.Sprintf("--statement.writeStatement=%v", config.WriteStatement),
 			fmt.Sprintf("--statement.waitForStatement=%d", config.WaitForStatement),
 			fmt.Sprintf("--statement.readManaThreshold=%f", config.ReadManaThreshold),

--- a/tools/integration-tests/tester/framework/drngnetwork.go
+++ b/tools/integration-tests/tester/framework/drngnetwork.go
@@ -54,6 +54,9 @@ func (n *DRNGNetwork) CreatePeer(c GoShimmerConfig, publicKey ed25519.PublicKey)
 	if config.FPCRoundInterval == 0 {
 		config.FPCRoundInterval = 5
 	}
+	if config.FPCTotalRoundsFinalization == 0 {
+		config.FPCTotalRoundsFinalization = 10
+	}
 
 	// create Docker container
 	container := NewDockerContainer(n.network.dockerClient)

--- a/tools/integration-tests/tester/framework/framework.go
+++ b/tools/integration-tests/tester/framework/framework.go
@@ -165,13 +165,14 @@ func (f *Framework) CreateNetworkWithPartitions(name string, peers, partitions, 
 				}
 				return ""
 			}(i),
-			Faucet:             config.Faucet && i == 0,
-			FPCRoundInterval:   ParaFPCRoundInterval,
-			WaitForStatement:   ParaWaitForStatement,
-			FPCListen:          ParaFPCListen,
-			WriteStatement:     ParaWriteStatement,
-			WriteManaThreshold: ParaWriteManaThreshold,
-			ReadManaThreshold:  ParaReadManaThreshold,
+			Faucet:                     config.Faucet && i == 0,
+			FPCRoundInterval:           ParaFPCRoundInterval,
+			FPCTotalRoundsFinalization: ParaFPCTotalRoundsFinalization,
+			WaitForStatement:           ParaWaitForStatement,
+			FPCListen:                  ParaFPCListen,
+			WriteStatement:             ParaWriteStatement,
+			WriteManaThreshold:         ParaWriteManaThreshold,
+			ReadManaThreshold:          ParaReadManaThreshold,
 		}
 		if _, err = network.CreatePeer(config); err != nil {
 			return nil, err

--- a/tools/integration-tests/tester/framework/network.go
+++ b/tools/integration-tests/tester/framework/network.go
@@ -128,6 +128,9 @@ func (n *Network) CreatePeer(c GoShimmerConfig) (*Peer, error) {
 	if config.FPCRoundInterval == 0 {
 		config.FPCRoundInterval = 5
 	}
+	if config.FPCTotalRoundsFinalization == 0 {
+		config.FPCTotalRoundsFinalization = 10
+	}
 
 	// create wallet
 	var nodeSeed *walletseed.Seed

--- a/tools/integration-tests/tester/framework/parameters.go
+++ b/tools/integration-tests/tester/framework/parameters.go
@@ -51,7 +51,9 @@ var (
 	ParaManaOnEveryNode = true
 	// ParaFPCRoundInterval defines how long a round lasts (in seconds)
 	ParaFPCRoundInterval int64 = 5
-	// ParaWaitForStatement is the time in seconds for which the node wait for receiveing the new statement.
+	// ParaFPCTotalRoundsFinalization the amount of FPC rounds where an opinion needs to stay the same to be considered final. Also called 'l'.
+	ParaFPCTotalRoundsFinalization int = 10
+	// ParaWaitForStatement is the time in seconds for which the node wait for receiving the new statement.
 	ParaWaitForStatement = 3
 	// ParaFPCListen defines if the FPC service should listen.
 	ParaFPCListen = false
@@ -97,12 +99,13 @@ type GoShimmerConfig struct {
 	ManaAllowedAccessPledge           []string
 	ManaAllowedConsensusPledge        []string
 
-	FPCRoundInterval   int64
-	WaitForStatement   int
-	FPCListen          bool
-	WriteStatement     bool
-	WriteManaThreshold float64
-	ReadManaThreshold  float64
+	FPCRoundInterval           int64
+	FPCTotalRoundsFinalization int
+	WaitForStatement           int
+	FPCListen                  bool
+	WriteStatement             bool
+	WriteManaThreshold         float64
+	ReadManaThreshold          float64
 }
 
 // NetworkConfig defines the config of a GoShimmer Docker network.

--- a/tools/integration-tests/tester/tests/consensus/consensus_conflicts_test.go
+++ b/tools/integration-tests/tester/tests/consensus/consensus_conflicts_test.go
@@ -26,11 +26,14 @@ func TestConsensusFiftyFiftyOpinionSplit(t *testing.T) {
 
 	// override avg. network delay to accustom integration test slowness
 	backupFCoBAvgNetworkDelay := framework.ParaFCoBAverageNetworkDelay
+	// adjust l according to networkDelay l = l+c/roundTimeInterval
+	backupFPCTotalRoundsFinalization := framework.ParaFPCTotalRoundsFinalization
 	backupBootstrapOnEveryNode := framework.ParaSyncBeaconOnEveryNode
 	backupParaWaitToKill := framework.ParaWaitToKill
 	framework.ParaFCoBAverageNetworkDelay = 60
 	framework.ParaSyncBeaconOnEveryNode = true
 	framework.ParaWaitToKill = 2*framework.ParaFCoBAverageNetworkDelay + 10
+	framework.ParaFPCTotalRoundsFinalization = backupFPCTotalRoundsFinalization + framework.ParaFCoBAverageNetworkDelay/int(framework.ParaFPCRoundInterval)
 
 	const numberOfPeers = 6
 
@@ -39,6 +42,7 @@ func TestConsensusFiftyFiftyOpinionSplit(t *testing.T) {
 		framework.ParaFCoBAverageNetworkDelay = backupFCoBAvgNetworkDelay
 		framework.ParaSyncBeaconOnEveryNode = backupBootstrapOnEveryNode
 		framework.ParaWaitToKill = backupParaWaitToKill
+		framework.ParaFPCTotalRoundsFinalization = backupFPCTotalRoundsFinalization
 	}()
 
 	// create two partitions with their own peers


### PR DESCRIPTION
# Description of change
Adjusting the l parameter for fpc conflict integration test, according to #1162
The number of consecutive rounds (I) in the test is l =l+c/roundTimeInterval
Addi FPCTotalRoundsFinalization to configurable docker parameters

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested
docker network, double spend

## Change checklist
Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [ ] My code follows the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
