### PR TITLE
fix: mana leaderboard and explorer livefeed scroll view

### DIFF
--- a/plugins/analysis/dashboard/frontend/src/app/components/Mana/ManaLeaderboard.tsx
+++ b/plugins/analysis/dashboard/frontend/src/app/components/Mana/ManaLeaderboard.tsx
@@ -13,23 +13,25 @@ export default class ManaLeaderboard extends React.Component<Props, any> {
     render() {
         return (
             <Card>
-                <Card.Body style={{'overflow': 'auto', 'height':'300px', fontSize: '0.8rem',}}>
+                <Card.Body style={{'height':'300px', fontSize: '0.8rem',}}>
                     <Card.Title>{this.props.title}</Card.Title>
-                    <Table>
-                        <thead>
-                        <tr>
-                            <th style={{'position': 'sticky', 'top': 0,'background': 'white'}}>Rank</th>
-                            <th style={{'position': 'sticky', 'top': 0,'background': 'white'}}>NodeID</th>
-                            <th style={{'position': 'sticky', 'top': 0,'background': 'white'}}>Mana</th>
-                            <th style={{'position': 'sticky', 'top': 0,'background': 'white'}}>% of All</th>
-                        </tr>
-                        </thead>
-                        <tbody>
-                        {this.props.data}
-                        </tbody>
-                    </Table>
+                    <Card.Body style={{'overflow':'auto', 'height':'90%', 'padding':'0px 0px 20px 0px'}}>
+                        <Table>
+                            <thead>
+                            <tr>
+                                <th style={{'position': 'sticky', 'top': 0,'background': 'white'}}>Rank</th>
+                                <th style={{'position': 'sticky', 'top': 0,'background': 'white'}}>NodeID</th>
+                                <th style={{'position': 'sticky', 'top': 0,'background': 'white'}}>Mana</th>
+                                <th style={{'position': 'sticky', 'top': 0,'background': 'white'}}>% of All</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            {this.props.data}
+                            </tbody>
+                        </Table>
+                    </Card.Body>
                 </Card.Body>
             </Card>
-    );
+        );
     }
 }

--- a/plugins/dashboard/frontend/src/app/components/ExplorerLiveFeed.tsx
+++ b/plugins/dashboard/frontend/src/app/components/ExplorerLiveFeed.tsx
@@ -25,9 +25,9 @@ export class ExplorerLiveFeed extends React.Component<Props, any> {
                         <Card.Body>
                             <Card.Title>Live Feed</Card.Title>
                             <Row className={"mb-3"}>
-                                <Col xs={12}>
+                                <Col xs={12} style={{'height':'500px', 'overflow':'auto'}}>
                                     <h6>Messages</h6>
-                                    <Table style={{'height':'500px', 'overflow':'scroll', 'display':'block'}}>
+                                    <Table>
                                         <thead>
                                         <tr>
                                             <td>Id</td>

--- a/plugins/dashboard/frontend/src/app/components/ManaLeaderboard.tsx
+++ b/plugins/dashboard/frontend/src/app/components/ManaLeaderboard.tsx
@@ -13,21 +13,23 @@ export default class ManaLeaderboard extends React.Component<Props, any> {
     render() {
         return (
             <Card>
-                <Card.Body style={{'overflow': 'auto', 'height':'300px', fontSize: '0.8rem',}}>
+                <Card.Body style={{'height':'300px', fontSize: '0.8rem',}}>
                     <Card.Title>{this.props.title}</Card.Title>
-                    <Table>
-                        <thead>
-                        <tr>
-                            <th style={{'position': 'sticky', 'top': 0,'background': 'white'}}>Rank</th>
-                            <th style={{'position': 'sticky', 'top': 0,'background': 'white'}}>NodeID</th>
-                            <th style={{'position': 'sticky', 'top': 0,'background': 'white'}}>Mana</th>
-                            <th style={{'position': 'sticky', 'top': 0,'background': 'white'}}>% of All</th>
-                        </tr>
-                        </thead>
-                        <tbody>
-                        {this.props.data}
-                        </tbody>
-                    </Table>
+                    <Card.Body style={{'overflow':'auto', 'height':'90%', 'padding':'0px 0px 20px 0px'}}>
+                        <Table>
+                            <thead>
+                            <tr>
+                                <th style={{'position': 'sticky', 'top': 0,'background': 'white'}}>Rank</th>
+                                <th style={{'position': 'sticky', 'top': 0,'background': 'white'}}>NodeID</th>
+                                <th style={{'position': 'sticky', 'top': 0,'background': 'white'}}>Mana</th>
+                                <th style={{'position': 'sticky', 'top': 0,'background': 'white'}}>% of All</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            {this.props.data}
+                            </tbody>
+                        </Table>
+                    </Card.Body>
                 </Card.Body>
             </Card>
     );

--- a/tools/integration-tests/tester/tests/drng/drng_test.go
+++ b/tools/integration-tests/tester/tests/drng/drng_test.go
@@ -76,7 +76,7 @@ func getFirstRound(t *testing.T, peer *framework.Peer, maxAttempts int) (string,
 		resp, err := peer.GetRandomness()
 		require.NoError(t, err)
 		b, err = json.MarshalIndent(resp, "", " ")
-		if err == nil {
+		if err == nil && resp.Randomness[0].Round > 0 {
 			return string(b), resp.Randomness[0].Round, nil
 		}
 		time.Sleep(1 * time.Second)


### PR DESCRIPTION
# Description of change

Fix #1133 and improve explorer livefeed.

mana leaderboard:
![Screenshot from 2021-04-12 15-08-01](https://user-images.githubusercontent.com/11289354/114356333-0d4c2280-9ba3-11eb-875e-ae61a8be5e7a.png)

explorer livefeed:
![image](https://user-images.githubusercontent.com/11289354/114356479-3ec4ee00-9ba3-11eb-9d9a-e64a18be328b.png)

## Type of change
- Bug fix

## Change checklist
- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
