### PR TITLE
Fix message branch in APIs

### DIFF
--- a/plugins/dashboard/explorer_routes.go
+++ b/plugins/dashboard/explorer_routes.go
@@ -55,6 +55,12 @@ func createExplorerMessage(msg *tangle.Message) *ExplorerMessage {
 	cachedMessageMetadata := messagelayer.Tangle().Storage.MessageMetadata(messageID)
 	defer cachedMessageMetadata.Release()
 	messageMetadata := cachedMessageMetadata.Unwrap()
+
+	branchID, err := messagelayer.Tangle().Booker.MessageBranchID(messageID)
+	if err != nil {
+		branchID = ledgerstate.BranchID{}
+	}
+
 	t := &ExplorerMessage{
 		ID:                      messageID.Base58(),
 		SolidificationTimestamp: messageMetadata.SolidificationTime().Unix(),
@@ -67,7 +73,7 @@ func createExplorerMessage(msg *tangle.Message) *ExplorerMessage {
 		StrongApprovers:         messagelayer.Tangle().Utils.ApprovingMessageIDs(messageID, tangle.StrongApprover).ToStrings(),
 		WeakApprovers:           messagelayer.Tangle().Utils.ApprovingMessageIDs(messageID, tangle.WeakApprover).ToStrings(),
 		Solid:                   messageMetadata.IsSolid(),
-		BranchID:                messageMetadata.BranchID().Base58(),
+		BranchID:                branchID.Base58(),
 		Scheduled:               messageMetadata.Scheduled(),
 		Booked:                  messageMetadata.IsBooked(),
 		Eligible:                messageMetadata.IsEligible(),

--- a/plugins/webapi/jsonmodels/tangle.go
+++ b/plugins/webapi/jsonmodels/tangle.go
@@ -69,13 +69,18 @@ type MessageMetadata struct {
 
 // NewMessageMetadata returns MessageMetadata from the given tangle.MessageMetadata.
 func NewMessageMetadata(metadata *tangle.MessageMetadata) MessageMetadata {
+	branchID, err := messagelayer.Tangle().Booker.MessageBranchID(metadata.ID())
+	if err != nil {
+		branchID = ledgerstate.BranchID{}
+	}
+
 	return MessageMetadata{
 		ID:                 metadata.ID().Base58(),
 		ReceivedTime:       metadata.ReceivedTime().Unix(),
 		Solid:              metadata.IsSolid(),
 		SolidificationTime: metadata.SolidificationTime().Unix(),
 		StructureDetails:   NewStructureDetails(metadata.StructureDetails()),
-		BranchID:           metadata.BranchID().String(),
+		BranchID:           branchID.String(),
 		Scheduled:          metadata.Scheduled(),
 		Booked:             metadata.IsBooked(),
 		Eligible:           metadata.IsEligible(),

--- a/plugins/webapi/tools/message/diagnostic_messages.go
+++ b/plugins/webapi/tools/message/diagnostic_messages.go
@@ -231,11 +231,14 @@ func getDiagnosticMessageInfo(messageID tangle.MessageID) *DiagnosticMessagesInf
 		}
 	})
 
-	branchID := ledgerstate.BranchID{}
+	branchID, err := messagelayer.Tangle().Booker.MessageBranchID(messageID)
+	if err != nil {
+		branchID = ledgerstate.BranchID{}
+	}
 	messagelayer.Tangle().Storage.MessageMetadata(messageID).Consume(func(metadata *tangle.MessageMetadata) {
 		msgInfo.ArrivalTime = metadata.ReceivedTime()
 		msgInfo.SolidTime = metadata.SolidificationTime()
-		msgInfo.BranchID = metadata.BranchID().String()
+		msgInfo.BranchID = branchID.String()
 		msgInfo.Scheduled = metadata.Scheduled()
 		msgInfo.ScheduledTime = metadata.ScheduledTime()
 		msgInfo.BookedTime = metadata.BookedTime()
@@ -253,8 +256,6 @@ func getDiagnosticMessageInfo(messageID tangle.MessageID) *DiagnosticMessagesInf
 			msgInfo.FMHI = uint64(metadata.StructureDetails().FutureMarkers.HighestIndex())
 			msgInfo.FMLI = uint64(metadata.StructureDetails().FutureMarkers.LowestIndex())
 		}
-
-		branchID = metadata.BranchID()
 	}, false)
 
 	msgInfo.StrongApprovers = messagelayer.Tangle().Utils.ApprovingMessageIDs(messageID, tangle.StrongApprover)


### PR DESCRIPTION
Since introducing the branch to markers mapping the branchID needs to be retrieved via the booker.