### PR TITLE
Fix: Always set the BranchID in the MessageMetadata if a Message has two or more PastMarkers

### DIFF
--- a/packages/markers/index.go
+++ b/packages/markers/index.go
@@ -10,6 +10,9 @@ import (
 
 // region Index ////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+// IndexLength represents the amount of bytes of a marshaled Index.
+const IndexLength = marshalutil.Uint64Size
+
 // Index represents the ever increasing number of the Markers in a Sequence.
 type Index uint64
 

--- a/packages/markers/manager.go
+++ b/packages/markers/manager.go
@@ -147,7 +147,7 @@ func (m *Manager) IsInPastCone(earlierStructureDetails, laterStructureDetails *S
 	}
 
 	if earlierStructureDetails.IsPastMarker {
-		earlierMarker := earlierStructureDetails.PastMarkers.HighestSequenceMarker()
+		earlierMarker := earlierStructureDetails.PastMarkers.Marker()
 		if earlierMarker == nil {
 			panic("failed to retrieve Marker")
 		}
@@ -170,7 +170,7 @@ func (m *Manager) IsInPastCone(earlierStructureDetails, laterStructureDetails *S
 	}
 
 	if laterStructureDetails.IsPastMarker {
-		laterMarker := laterStructureDetails.PastMarkers.HighestSequenceMarker()
+		laterMarker := laterStructureDetails.PastMarkers.Marker()
 		if laterMarker == nil {
 			panic("failed to retrieve Marker")
 		}

--- a/packages/markers/manager_test.go
+++ b/packages/markers/manager_test.go
@@ -180,7 +180,7 @@ func inheritPastMarkers(message *message, manager *Manager, messageDB map[string
 	// inherit new past Markers
 	message.markers, _ = manager.InheritStructureDetails(pastMarkers, increaseIndex(message), message.sequenceAlias)
 	if message.markers.IsPastMarker {
-		pastMarkerToPropagate = message.markers.PastMarkers.HighestSequenceMarker()
+		pastMarkerToPropagate = message.markers.PastMarkers.Marker()
 	}
 
 	return

--- a/packages/markers/marker.go
+++ b/packages/markers/marker.go
@@ -159,19 +159,23 @@ func (m *Markers) SequenceIDs() (sequenceIDs SequenceIDs) {
 	return NewSequenceIDs(sequenceIDsSlice...)
 }
 
-// HighestSequenceMarker returns the Marker of the highest SequenceID in the collection. It can for example be used to
-// retrieve the new Marker that was assigned when increasing the Index of a Sequence.
-func (m *Markers) HighestSequenceMarker() (highestSequenceMarker *Marker) {
+// Marker type casts the Markers to a Marker if it contains only 1 element.
+func (m *Markers) Marker() (marker *Marker) {
 	m.markersMutex.RLock()
 	defer m.markersMutex.RUnlock()
 
-	for sequenceID, index := range m.markers {
-		if highestSequenceMarker == nil || sequenceID > highestSequenceMarker.SequenceID() {
-			highestSequenceMarker = &Marker{sequenceID: sequenceID, index: index}
+	switch len(m.markers) {
+	case 0:
+		panic("converting empty Markers into a single Marker is not supported")
+	case 1:
+		panic("converting multiple Markers into a single Marker is not supported")
+	default:
+		for sequenceID, index := range m.markers {
+			return &Marker{sequenceID: sequenceID, index: index}
 		}
 	}
 
-	return highestSequenceMarker
+	return
 }
 
 // Get returns the Index of the Marker with the given Sequence and a flag that indicates if the Marker exists.

--- a/packages/markers/marker.go
+++ b/packages/markers/marker.go
@@ -16,6 +16,9 @@ import (
 
 // region Marker ///////////////////////////////////////////////////////////////////////////////////////////////////////
 
+// MarkerLength represents the amount of bytes of a marshaled Marker.
+const MarkerLength = SequenceIDLength + IndexLength
+
 // Marker represents a coordinate in a Sequence that is identified by an ever increasing Index.
 type Marker struct {
 	sequenceID SequenceID

--- a/packages/markers/marker.go
+++ b/packages/markers/marker.go
@@ -168,11 +168,11 @@ func (m *Markers) Marker() (marker *Marker) {
 	case 0:
 		panic("converting empty Markers into a single Marker is not supported")
 	case 1:
-		panic("converting multiple Markers into a single Marker is not supported")
-	default:
 		for sequenceID, index := range m.markers {
 			return &Marker{sequenceID: sequenceID, index: index}
 		}
+	default:
+		panic("converting multiple Markers into a single Marker is not supported")
 	}
 
 	return

--- a/packages/markers/sequence.go
+++ b/packages/markers/sequence.go
@@ -249,6 +249,9 @@ func (c *CachedSequence) Consume(consumer func(sequence *Sequence), forceRelease
 
 // region SequenceID ///////////////////////////////////////////////////////////////////////////////////////////////////
 
+// SequenceIDLength represents the amount of bytes of a marshaled SequenceID.
+const SequenceIDLength = marshalutil.Uint64Size
+
 // SequenceID is the type of the identifier of a Sequence.
 type SequenceID uint64
 

--- a/packages/tangle/booker.go
+++ b/packages/tangle/booker.go
@@ -391,6 +391,7 @@ func NewMarkersManager(tangle *Tangle) *MarkersManager {
 func (m *MarkersManager) InheritStructureDetails(message *Message, sequenceAlias markers.SequenceAlias) (structureDetails *markers.StructureDetails) {
 	structureDetails, _ = m.Manager.InheritStructureDetails(m.structureDetailsOfStrongParents(message), m.tangle.Options.IncreaseMarkersIndexCallback, sequenceAlias)
 	if structureDetails.IsPastMarker {
+		m.SetMessageID(structureDetails.PastMarkers.HighestSequenceMarker(), message.ID())
 		m.tangle.Utils.WalkMessageMetadata(m.propagatePastMarkerToFutureMarkers(structureDetails.PastMarkers.HighestSequenceMarker()), message.StrongParents())
 	}
 
@@ -1064,43 +1065,43 @@ func MarkerMessageMappingFromObjectStorage(key, value []byte) (result objectstor
 }
 
 // Marker returns the Marker that is mapped to a MessageID.
-func (i *MarkerMessageMapping) Marker() *markers.Marker {
-	return i.marker
+func (m *MarkerMessageMapping) Marker() *markers.Marker {
+	return m.marker
 }
 
 // MessageID returns the MessageID of the Marker.
-func (i *MarkerMessageMapping) MessageID() MessageID {
-	return i.messageID
+func (m *MarkerMessageMapping) MessageID() MessageID {
+	return m.messageID
 }
 
 // Bytes returns a marshaled version of the MarkerMessageMapping.
-func (i *MarkerMessageMapping) Bytes() []byte {
-	return byteutils.ConcatBytes(i.ObjectStorageKey(), i.ObjectStorageValue())
+func (m *MarkerMessageMapping) Bytes() []byte {
+	return byteutils.ConcatBytes(m.ObjectStorageKey(), m.ObjectStorageValue())
 }
 
 // String returns a human readable version of the MarkerMessageMapping.
-func (i *MarkerMessageMapping) String() string {
+func (m *MarkerMessageMapping) String() string {
 	return stringify.Struct("MarkerMessageMapping",
-		stringify.StructField("marker", i.marker),
-		stringify.StructField("messageID", i.messageID),
+		stringify.StructField("marker", m.marker),
+		stringify.StructField("messageID", m.messageID),
 	)
 }
 
 // Update is disabled and panics if it ever gets called - it is required to match the StorableObject interface.
-func (i *MarkerMessageMapping) Update(objectstorage.StorableObject) {
+func (m *MarkerMessageMapping) Update(objectstorage.StorableObject) {
 	panic("updates disabled")
 }
 
 // ObjectStorageKey returns the key that is used to store the object in the database. It is required to match the
 // StorableObject interface.
-func (i *MarkerMessageMapping) ObjectStorageKey() []byte {
-	return i.marker.Bytes()
+func (m *MarkerMessageMapping) ObjectStorageKey() []byte {
+	return m.marker.Bytes()
 }
 
 // ObjectStorageValue marshals the MarkerMessageMapping into a sequence of bytes that are used as the value part in
 // the object storage.
-func (i *MarkerMessageMapping) ObjectStorageValue() []byte {
-	return i.messageID.Bytes()
+func (m *MarkerMessageMapping) ObjectStorageValue() []byte {
+	return m.messageID.Bytes()
 }
 
 // code contract (make sure the type implements all required methods)

--- a/packages/tangle/booker.go
+++ b/packages/tangle/booker.go
@@ -1043,13 +1043,13 @@ func MarkerMessageMappingFromBytes(bytes []byte) (individuallyMappedMessage *Mar
 }
 
 // MarkerMessageMappingFromMarshalUtil unmarshals an MarkerMessageMapping using a MarshalUtil (for easier unmarshaling).
-func MarkerMessageMappingFromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (individuallyMappedMessage *MarkerMessageMapping, err error) {
-	individuallyMappedMessage = &MarkerMessageMapping{}
-	if individuallyMappedMessage.marker, err = markers.MarkerFromMarshalUtil(marshalUtil); err != nil {
+func MarkerMessageMappingFromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (markerMessageMapping *MarkerMessageMapping, err error) {
+	markerMessageMapping = &MarkerMessageMapping{}
+	if markerMessageMapping.marker, err = markers.MarkerFromMarshalUtil(marshalUtil); err != nil {
 		err = xerrors.Errorf("failed to parse Marker from MarshalUtil: %w", err)
 		return
 	}
-	if individuallyMappedMessage.messageID, err = MessageIDFromMarshalUtil(marshalUtil); err != nil {
+	if markerMessageMapping.messageID, err = MessageIDFromMarshalUtil(marshalUtil); err != nil {
 		err = xerrors.Errorf("failed to parse MessageID from MarshalUtil: %w", err)
 		return
 	}

--- a/packages/tangle/booker.go
+++ b/packages/tangle/booker.go
@@ -144,6 +144,10 @@ func (b *Booker) MessageBranchID(messageID MessageID) (branchID ledgerstate.Bran
 			err = xerrors.Errorf("failed to retrieve StructureDetails of %s: %w", messageID, cerrors.ErrFatal)
 			return
 		}
+		if structureDetails.PastMarkers.Size() != 1 {
+			err = xerrors.Errorf("BranchID of %s should have been mapped in the MessageMetadata (multiple PastMarkers): %w", messageID, cerrors.ErrFatal)
+			return
+		}
 
 		branchID = b.MarkersManager.BranchID(structureDetails.PastMarkers.HighestSequenceMarker())
 	}) {

--- a/packages/tangle/booker_test.go
+++ b/packages/tangle/booker_test.go
@@ -1851,7 +1851,7 @@ func checkMarkers(t *testing.T, testFramework *MessageTestFramework, expectedMar
 
 		// if we have only a single marker - check if the marker is mapped to this message (or its inherited past marker)
 		if expectedMarkersOfMessage.Size() == 1 {
-			currentMarker := expectedMarkersOfMessage.HighestSequenceMarker()
+			currentMarker := expectedMarkersOfMessage.Marker()
 
 			mappedMessageIDOfMarker := testFramework.tangle.Booker.MarkersManager.MessageID(currentMarker)
 			currentMessageID := testFramework.Message(messageID).ID()
@@ -1861,7 +1861,7 @@ func checkMarkers(t *testing.T, testFramework *MessageTestFramework, expectedMar
 			}
 
 			assert.True(t, testFramework.tangle.Storage.MessageMetadata(mappedMessageIDOfMarker).Consume(func(messageMetadata *MessageMetadata) {
-				assert.True(t, messageMetadata.StructureDetails().IsPastMarker && *messageMetadata.StructureDetails().PastMarkers.HighestSequenceMarker() == *currentMarker, "%s was mapped to wrong %s", currentMarker, messageMetadata.ID())
+				assert.True(t, messageMetadata.StructureDetails().IsPastMarker && *messageMetadata.StructureDetails().PastMarkers.Marker() == *currentMarker, "%s was mapped to wrong %s", currentMarker, messageMetadata.ID())
 			}), "failed to load Message with %s", mappedMessageIDOfMarker)
 		}
 	}

--- a/packages/tangle/booker_test.go
+++ b/packages/tangle/booker_test.go
@@ -1849,6 +1849,7 @@ func checkMarkers(t *testing.T, testFramework *MessageTestFramework, expectedMar
 			assert.Equal(t, expectedMarkersOfMessage, messageMetadata.StructureDetails().PastMarkers, "Markers of %s are wrong", messageID)
 		}))
 
+		// if we have only a single marker - check if the marker is mapped to this message (or its inherited past marker)
 		if expectedMarkersOfMessage.Size() == 1 {
 			currentMarker := expectedMarkersOfMessage.HighestSequenceMarker()
 
@@ -1860,9 +1861,7 @@ func checkMarkers(t *testing.T, testFramework *MessageTestFramework, expectedMar
 			}
 
 			assert.True(t, testFramework.tangle.Storage.MessageMetadata(mappedMessageIDOfMarker).Consume(func(messageMetadata *MessageMetadata) {
-				structureDetails := messageMetadata.StructureDetails()
-
-				assert.True(t, structureDetails.IsPastMarker && *structureDetails.PastMarkers.HighestSequenceMarker() == *currentMarker, "%s was mapped to wrong %s", currentMarker, messageMetadata.ID())
+				assert.True(t, messageMetadata.StructureDetails().IsPastMarker && *messageMetadata.StructureDetails().PastMarkers.HighestSequenceMarker() == *currentMarker, "%s was mapped to wrong %s", currentMarker, messageMetadata.ID())
 			}), "failed to load Message with %s", mappedMessageIDOfMarker)
 		}
 	}

--- a/packages/tangle/booker_test.go
+++ b/packages/tangle/booker_test.go
@@ -1787,7 +1787,7 @@ func TestBookerMarkerMappings(t *testing.T) {
 			"Message17": ledgerstate.UndefinedBranchID,
 			"Message18": ledgerstate.UndefinedBranchID,
 			"Message19": ledgerstate.UndefinedBranchID,
-			"Message20": ledgerstate.UndefinedBranchID,
+			"Message20": branchIDs["H+C"],
 		})
 		checkBranchIDs(t, testFramework, map[string]ledgerstate.BranchID{
 			"Message1":  branchIDs["A"],
@@ -1813,7 +1813,7 @@ func TestBookerMarkerMappings(t *testing.T) {
 		})
 		checkIndividuallyMappedMessages(t, testFramework, map[ledgerstate.BranchID][]string{
 			branchIDs["F+C"]: {"Message12"},
-			branchIDs["H+C"]: {"Message14", "Message15"},
+			branchIDs["H+C"]: {"Message14", "Message15", "Message20"},
 		})
 	}
 }

--- a/packages/tangle/storage.go
+++ b/packages/tangle/storage.go
@@ -300,7 +300,7 @@ func (s *Storage) DeleteMarkerMessageMapping(branchID ledgerstate.BranchID, mess
 
 // MarkerMessageMapping retrieves the MarkerMessageMapping associated with the given details.
 func (s *Storage) MarkerMessageMapping(marker *markers.Marker) (cachedMarkerMessageMappings *CachedMarkerMessageMapping) {
-	return &CachedMarkerMessageMapping{CachedObject: s.markerMessageMappingStorage.Load(byteutils.ConcatBytes(marker.Bytes()))}
+	return &CachedMarkerMessageMapping{CachedObject: s.markerMessageMappingStorage.Load(marker.Bytes())}
 }
 
 // MarkerMessageMappings retrieves the MarkerMessageMappings of a Sequence in the object storage.

--- a/packages/tangle/storage.go
+++ b/packages/tangle/storage.go
@@ -41,6 +41,9 @@ const (
 	// PrefixIndividuallyMappedMessage defines the storage prefix for the IndividuallyMappedMessage.
 	PrefixIndividuallyMappedMessage
 
+	// PrefixMarkerMessageMapping defines the storage prefix for the MarkerMessageMapping.
+	PrefixMarkerMessageMapping
+
 	// DBSequenceNumber defines the db sequence number.
 	DBSequenceNumber = "seq"
 )
@@ -60,6 +63,7 @@ type Storage struct {
 	attachmentStorage                 *objectstorage.ObjectStorage
 	markerIndexBranchIDMappingStorage *objectstorage.ObjectStorage
 	individuallyMappedMessageStorage  *objectstorage.ObjectStorage
+	markerMessageMappingStorage       *objectstorage.ObjectStorage
 
 	Events   *StorageEvents
 	shutdown chan struct{}
@@ -79,6 +83,7 @@ func NewStorage(tangle *Tangle) (storage *Storage) {
 		attachmentStorage:                 osFactory.New(PrefixAttachments, AttachmentFromObjectStorage, objectstorage.CacheTime(CacheTime), objectstorage.PartitionKey(ledgerstate.TransactionIDLength, MessageIDLength), objectstorage.LeakDetectionEnabled(false)),
 		markerIndexBranchIDMappingStorage: osFactory.New(PrefixMarkerBranchIDMapping, MarkerIndexBranchIDMappingFromObjectStorage, objectstorage.CacheTime(CacheTime), objectstorage.LeakDetectionEnabled(false)),
 		individuallyMappedMessageStorage:  osFactory.New(PrefixIndividuallyMappedMessage, IndividuallyMappedMessageFromObjectStorage, objectstorage.CacheTime(CacheTime), IndividuallyMappedMessagePartitionKeys, objectstorage.LeakDetectionEnabled(false)),
+		markerMessageMappingStorage:       osFactory.New(PrefixMarkerMessageMapping, MarkerMessageMappingFromObjectStorage, objectstorage.CacheTime(CacheTime), MarkerMessageMappingPartitionKeys),
 
 		Events: &StorageEvents{
 			MessageStored:        events.NewEvent(MessageIDCaller),
@@ -283,6 +288,30 @@ func (s *Storage) IndividuallyMappedMessages(branchID ledgerstate.BranchID) (cac
 	return
 }
 
+// StoreMarkerMessageMapping stores a MarkerMessageMapping in the underlying object storage.
+func (s *Storage) StoreMarkerMessageMapping(markerMessageMapping *MarkerMessageMapping) {
+	s.markerMessageMappingStorage.Store(markerMessageMapping).Release()
+}
+
+// DeleteMarkerMessageMapping deleted a MarkerMessageMapping in the underlying object storage.
+func (s *Storage) DeleteMarkerMessageMapping(branchID ledgerstate.BranchID, messageID MessageID) {
+	s.markerMessageMappingStorage.Delete(byteutils.ConcatBytes(branchID.Bytes(), messageID.Bytes()))
+}
+
+// MarkerMessageMapping retrieves the MarkerMessageMapping associated with the given details.
+func (s *Storage) MarkerMessageMapping(marker *markers.Marker) (cachedMarkerMessageMappings *CachedMarkerMessageMapping) {
+	return &CachedMarkerMessageMapping{CachedObject: s.markerMessageMappingStorage.Load(byteutils.ConcatBytes(marker.Bytes()))}
+}
+
+// MarkerMessageMappings retrieves the MarkerMessageMappings of a Sequence in the object storage.
+func (s *Storage) MarkerMessageMappings(sequenceID markers.SequenceID) (cachedMarkerMessageMappings CachedMarkerMessageMappings) {
+	s.markerMessageMappingStorage.ForEach(func(key []byte, cachedObject objectstorage.CachedObject) bool {
+		cachedMarkerMessageMappings = append(cachedMarkerMessageMappings, &CachedMarkerMessageMapping{CachedObject: cachedObject})
+		return true
+	}, objectstorage.WithIteratorPrefix(sequenceID.Bytes()))
+	return
+}
+
 func (s *Storage) storeGenesis() {
 	s.MessageMetadata(EmptyMessageID, func() *MessageMetadata {
 		genesisMetadata := &MessageMetadata{
@@ -327,6 +356,7 @@ func (s *Storage) Shutdown() {
 	s.attachmentStorage.Shutdown()
 	s.markerIndexBranchIDMappingStorage.Shutdown()
 	s.individuallyMappedMessageStorage.Shutdown()
+	s.markerMessageMappingStorage.Shutdown()
 
 	close(s.shutdown)
 }
@@ -341,6 +371,7 @@ func (s *Storage) Prune() error {
 		s.attachmentStorage,
 		s.markerIndexBranchIDMappingStorage,
 		s.individuallyMappedMessageStorage,
+		s.markerMessageMappingStorage,
 	} {
 		if err := storage.Prune(); err != nil {
 			err = fmt.Errorf("failed to prune storage: %w", err)


### PR DESCRIPTION
# Description of change

The Booker didn't set the BranchID in the MessageMetadata correctly if it had two or more PastMarkers.

This PR fixes this problem and adds a `MarkersManager.MessageID(marker *markers.Marker)` method to allow lookups from Markers to their corresponding Messages.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
