### PR TITLE
always like future time stamps

### DIFF
--- a/packages/consensus/fcob/timestamp.go
+++ b/packages/consensus/fcob/timestamp.go
@@ -18,13 +18,23 @@ var (
 // region TimestampQuality /////////////////////////////////////////////////////////////////////////////////////////////
 
 // TimestampQuality returns the TimestampOpinion based on the given times (e.g., arrival and current).
-func TimestampQuality(messageID tangle.MessageID, target, current time.Time) (timestampOpinion *TimestampOpinion) {
-	diff := abs(current.Sub(target))
-
+func TimestampQuality(messageID tangle.MessageID, target, current time.Time) (timestampOpinion *TimestampOpinion, err error) {
 	timestampOpinion = &TimestampOpinion{
 		MessageID: messageID,
 		Value:     opinion.Like,
 	}
+
+	diff := current.Sub(target)
+
+	// timestamp is in the future
+	if diff < 0 {
+		timestampOpinion.Value = opinion.Like
+		timestampOpinion.LoK = Three
+		// This point in the code should not be reached
+		// err = xerrors.Errorf("Timestamp is in the future : %w", err, cerrors.ErrFatal)
+		return
+	}
+
 	if diff >= TimestampWindow {
 		timestampOpinion.Value = opinion.Dislike
 	}

--- a/packages/consensus/fcob/timestamp_test.go
+++ b/packages/consensus/fcob/timestamp_test.go
@@ -18,53 +18,35 @@ func TestTimestampQuality(t *testing.T) {
 
 	current := time.Now()
 
-	// Testing Like
-	issuedTime := current.Add(-offset)
-	o := TimestampQuality(tangle.EmptyMessageID, issuedTime, current)
+	// Testing Future
+	issuedTime := current.Add(offset)
+	o, _ := TimestampQuality(tangle.EmptyMessageID, issuedTime, current)
 	assert.True(t, o.Equals(&TimestampOpinion{MessageID: tangle.EmptyMessageID, Value: opinion.Like, LoK: Three}))
 
-	issuedTime = current.Add(offset)
-	o = TimestampQuality(tangle.EmptyMessageID, issuedTime, current)
+	// Testing Like
+	issuedTime = current.Add(-offset)
+	o, _ = TimestampQuality(tangle.EmptyMessageID, issuedTime, current)
 	assert.True(t, o.Equals(&TimestampOpinion{MessageID: tangle.EmptyMessageID, Value: opinion.Like, LoK: Three}))
 
 	issuedTime = current.Add(-offset - (2 * GratuitousNetworkDelay))
-	o = TimestampQuality(tangle.EmptyMessageID, issuedTime, current)
-	assert.True(t, o.Equals(&TimestampOpinion{MessageID: tangle.EmptyMessageID, Value: opinion.Like, LoK: Two}))
-
-	issuedTime = current.Add(offset + (2 * GratuitousNetworkDelay))
-	o = TimestampQuality(tangle.EmptyMessageID, issuedTime, current)
+	o, _ = TimestampQuality(tangle.EmptyMessageID, issuedTime, current)
 	assert.True(t, o.Equals(&TimestampOpinion{MessageID: tangle.EmptyMessageID, Value: opinion.Like, LoK: Two}))
 
 	issuedTime = current.Add(-offset - (3 * GratuitousNetworkDelay))
-	o = TimestampQuality(tangle.EmptyMessageID, issuedTime, current)
-	assert.True(t, o.Equals(&TimestampOpinion{MessageID: tangle.EmptyMessageID, Value: opinion.Like, LoK: One}))
-
-	issuedTime = current.Add(offset + (3 * GratuitousNetworkDelay))
-	o = TimestampQuality(tangle.EmptyMessageID, issuedTime, current)
+	o, _ = TimestampQuality(tangle.EmptyMessageID, issuedTime, current)
 	assert.True(t, o.Equals(&TimestampOpinion{MessageID: tangle.EmptyMessageID, Value: opinion.Like, LoK: One}))
 
 	// Testing Dislike
 	issuedTime = current.Add(-offset - TimestampWindow)
-	o = TimestampQuality(tangle.EmptyMessageID, issuedTime, current)
-	assert.True(t, o.Equals(&TimestampOpinion{MessageID: tangle.EmptyMessageID, Value: opinion.Dislike, LoK: One}))
-
-	issuedTime = current.Add(offset + TimestampWindow)
-	o = TimestampQuality(tangle.EmptyMessageID, issuedTime, current)
+	o, _ = TimestampQuality(tangle.EmptyMessageID, issuedTime, current)
 	assert.True(t, o.Equals(&TimestampOpinion{MessageID: tangle.EmptyMessageID, Value: opinion.Dislike, LoK: One}))
 
 	issuedTime = current.Add(-(GratuitousNetworkDelay) - TimestampWindow)
-	o = TimestampQuality(tangle.EmptyMessageID, issuedTime, current)
-	assert.True(t, o.Equals(&TimestampOpinion{MessageID: tangle.EmptyMessageID, Value: opinion.Dislike, LoK: Two}))
-
-	issuedTime = current.Add(GratuitousNetworkDelay + TimestampWindow)
-	o = TimestampQuality(tangle.EmptyMessageID, issuedTime, current)
+	o, _ = TimestampQuality(tangle.EmptyMessageID, issuedTime, current)
 	assert.True(t, o.Equals(&TimestampOpinion{MessageID: tangle.EmptyMessageID, Value: opinion.Dislike, LoK: Two}))
 
 	issuedTime = current.Add(-(2 * GratuitousNetworkDelay) - TimestampWindow)
-	o = TimestampQuality(tangle.EmptyMessageID, issuedTime, current)
+	o, _ = TimestampQuality(tangle.EmptyMessageID, issuedTime, current)
 	assert.True(t, o.Equals(&TimestampOpinion{MessageID: tangle.EmptyMessageID, Value: opinion.Dislike, LoK: Three}))
 
-	issuedTime = current.Add((2 * GratuitousNetworkDelay) + TimestampWindow)
-	o = TimestampQuality(tangle.EmptyMessageID, issuedTime, current)
-	assert.True(t, o.Equals(&TimestampOpinion{MessageID: tangle.EmptyMessageID, Value: opinion.Dislike, LoK: Three}))
 }

--- a/packages/tangle/scheduler.go
+++ b/packages/tangle/scheduler.go
@@ -98,6 +98,10 @@ func (s *Scheduler) scheduleMessage(messageID MessageID) {
 		return
 	}
 
+	// if !s.isInTheFuture(messageID) {
+	// 	return
+	// }
+
 	s.tangle.Storage.MessageMetadata(messageID).Consume(func(messageMetadata *MessageMetadata) {
 		if messageMetadata.SetScheduled(true) {
 			if s.scheduledMessages.Add(messageID) {
@@ -126,6 +130,20 @@ func (s *Scheduler) parentsBooked(messageID MessageID) (parentsBooked bool) {
 
 	return
 }
+
+// check if message is currently in the future
+// func (s *Scheduler) isInTheFuture(messageID MessageID) (isInTheFuture bool) {
+// 	s.tangle.Storage.Message(messageID).Consume(func(message *Message) {
+// 		isInTheFuture = false
+// 		current := clock.SyncedTime()
+// 		// current := time.Now()
+// 		if current.Sub(message.issuingTime) < 0 {
+// 			isInTheFuture = true
+// 		}
+// 	})
+
+// 	return
+// }
 
 // endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/packages/tangle/scheduler.go
+++ b/packages/tangle/scheduler.go
@@ -98,10 +98,6 @@ func (s *Scheduler) scheduleMessage(messageID MessageID) {
 		return
 	}
 
-	// if !s.isInTheFuture(messageID) {
-	// 	return
-	// }
-
 	s.tangle.Storage.MessageMetadata(messageID).Consume(func(messageMetadata *MessageMetadata) {
 		if messageMetadata.SetScheduled(true) {
 			if s.scheduledMessages.Add(messageID) {
@@ -130,20 +126,6 @@ func (s *Scheduler) parentsBooked(messageID MessageID) (parentsBooked bool) {
 
 	return
 }
-
-// check if message is currently in the future
-// func (s *Scheduler) isInTheFuture(messageID MessageID) (isInTheFuture bool) {
-// 	s.tangle.Storage.Message(messageID).Consume(func(message *Message) {
-// 		isInTheFuture = false
-// 		current := clock.SyncedTime()
-// 		// current := time.Now()
-// 		if current.Sub(message.issuingTime) < 0 {
-// 			isInTheFuture = true
-// 		}
-// 	})
-
-// 	return
-// }
 
 // endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
# Description of change
Always like future transactions

## Type of change
set like to all future messages. This is a temporary solution until the booker/scheduler is updated.