### PR TITLE
Fix mana event storage pruning

### DIFF
--- a/packages/mana/consensusbase.go
+++ b/packages/mana/consensusbase.go
@@ -28,14 +28,13 @@ func (c *ConsensusBaseMana) updateEBM1(n time.Duration) {
 	if c.BaseMana1 == c.EffectiveBaseMana1 {
 		return
 	}
-	// they are not the same, but close. Stop the future updates.
-	if math.Abs(c.BaseMana1-c.EffectiveBaseMana1) < DeltaStopUpdate {
-		c.EffectiveBaseMana1 = c.BaseMana1
-		return
-	}
 	// normal update
 	c.EffectiveBaseMana1 = math.Pow(math.E, -emaCoeff1*n.Seconds())*c.EffectiveBaseMana1 +
 		(1-math.Pow(math.E, -emaCoeff1*n.Seconds()))*c.BaseMana1
+	// they are not the same, but close. Stop the future updates.
+	if math.Abs(c.BaseMana1-c.EffectiveBaseMana1) < DeltaStopUpdate {
+		c.EffectiveBaseMana1 = c.BaseMana1
+	}
 }
 
 func (c *ConsensusBaseMana) revoke(amount float64, t time.Time) error {

--- a/packages/mana/events.go
+++ b/packages/mana/events.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/iotaledger/hive.go/events"
 	"github.com/iotaledger/hive.go/identity"
+	"github.com/iotaledger/hive.go/stringify"
+	"github.com/mr-tron/base58"
 
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 )
@@ -53,14 +55,16 @@ const (
 
 // Event is the interface definition of an event.
 type Event interface {
-	// ManaType returns the type of the event.
+	// Type returns the type of the event.
 	Type() byte
 	// ToJSONSerializable returns a struct that can be serialized into JSON object.
 	ToJSONSerializable() interface{}
 	// ToPersistable returns an event that can be persisted.
 	ToPersistable() *PersistableEvent
-	// Time returns the time of the event.
+	// Timestamp returns the time of the event.
 	Timestamp() time.Time
+	// String returns a human readable version of the event.
+	String() string
 }
 
 // PledgedEvent is the struct that is passed along with triggering a Pledged event.
@@ -90,6 +94,18 @@ func (p *PledgedEvent) ToJSONSerializable() interface{} {
 		TxID:     p.TransactionID.Base58(),
 		Amount:   p.Amount,
 	}
+}
+
+// String returns a human readable version of the event.
+func (p *PledgedEvent) String() string {
+	return stringify.Struct("PledgeEvent",
+		stringify.StructField("type", p.ManaType.String()),
+		stringify.StructField("shortNodeID", p.NodeID.String()),
+		stringify.StructField("fullNodeID", base58.Encode(p.NodeID.Bytes())),
+		stringify.StructField("time", p.Time.String()),
+		stringify.StructField("amount", p.Amount),
+		stringify.StructField("txID", p.TransactionID),
+	)
 }
 
 // ToPersistable returns an event that can be persisted.
@@ -174,6 +190,19 @@ func (r *RevokedEvent) ToJSONSerializable() interface{} {
 	}
 }
 
+// String returns a human readable version of the event.
+func (r *RevokedEvent) String() string {
+	return stringify.Struct("RevokedEvent",
+		stringify.StructField("type", r.ManaType.String()),
+		stringify.StructField("shortNodeID", r.NodeID.String()),
+		stringify.StructField("fullNodeID", base58.Encode(r.NodeID.Bytes())),
+		stringify.StructField("time", r.Time.String()),
+		stringify.StructField("amount", r.Amount),
+		stringify.StructField("txID", r.TransactionID),
+		stringify.StructField("inputID", r.InputID),
+	)
+}
+
 // ToPersistable returns an event that can be persisted.
 func (r *RevokedEvent) ToPersistable() *PersistableEvent {
 	return &PersistableEvent{
@@ -238,6 +267,17 @@ func (u *UpdatedEvent) ToJSONSerializable() interface{} {
 			LastUpdated:       u.NewMana.LastUpdate().Unix(),
 		},
 	}
+}
+
+// String returns a human readable version of the event.
+func (u *UpdatedEvent) String() string {
+	return stringify.Struct("UpdatedEvent",
+		stringify.StructField("type", u.ManaType.String()),
+		stringify.StructField("shortNodeID", u.NodeID.String()),
+		stringify.StructField("fullNodeID", base58.Encode(u.NodeID.Bytes())),
+		stringify.StructField("oldBaseMana", u.OldMana),
+		stringify.StructField("newBaseMana", u.NewMana),
+	)
 }
 
 // ToPersistable converts the event to a persistable event.

--- a/plugins/messagelayer/mana_plugin.go
+++ b/plugins/messagelayer/mana_plugin.go
@@ -688,7 +688,7 @@ func pruneConsensusEventLogsStorage() {
 	}
 	manaLogger.Infof("going to prune %d events", i)
 	toBePrunedEvents := make(mana.EventSlice, i)
-	for k := 0; k < i+1; k++ {
+	for k := 0; k < i; k++ {
 		toBePrunedEvents[k] = eventLogs[k]
 	}
 	t := toBePrunedEvents[len(toBePrunedEvents)-1].Timestamp()

--- a/plugins/messagelayer/mana_plugin.go
+++ b/plugins/messagelayer/mana_plugin.go
@@ -654,14 +654,17 @@ func pruneConsensusEventLogsStorage() {
 		cachedPe := &mana.CachedPersistableEvent{CachedObject: cachedObject}
 		defer cachedPe.Release()
 		pe := cachedPe.Unwrap()
-		metadata := cachedMetadata.Unwrap()
-
 		var ev mana.Event
 		ev, err = mana.FromPersistableEvent(pe)
-		if ev.Timestamp().Before(metadata.Timestamp) {
-			manaLogger.Errorf("consensus event storage contains event that is older, than the stored metadata timestamp %s: %s", metadata.Timestamp, ev.String())
-			return true
+
+		if cachedMetadata.Exists() {
+			metadata := cachedMetadata.Unwrap()
+			if ev.Timestamp().Before(metadata.Timestamp) {
+				manaLogger.Errorf("consensus event storage contains event that is older, than the stored metadata timestamp %s: %s", metadata.Timestamp, ev.String())
+				return true
+			}
 		}
+
 		if err != nil {
 			return false
 		}

--- a/plugins/messagelayer/mana_plugin.go
+++ b/plugins/messagelayer/mana_plugin.go
@@ -654,9 +654,14 @@ func pruneConsensusEventLogsStorage() {
 		cachedPe := &mana.CachedPersistableEvent{CachedObject: cachedObject}
 		defer cachedPe.Release()
 		pe := cachedPe.Unwrap()
+		metadata := cachedMetadata.Unwrap()
 
 		var ev mana.Event
 		ev, err = mana.FromPersistableEvent(pe)
+		if ev.Timestamp().Before(metadata.Timestamp) {
+			manaLogger.Errorf("consensus event storage contains event that is older, than the stored metadata timestamp %s: %s", metadata.Timestamp, ev.String())
+			return true
+		}
 		if err != nil {
 			return false
 		}
@@ -683,7 +688,7 @@ func pruneConsensusEventLogsStorage() {
 
 	err = cbmvPast.BuildPastBaseVector(eventLogs, t)
 	if err != nil {
-		manaLogger.Error("error building past consensus base mana vector: %v", err)
+		manaLogger.Errorf("error building past consensus base mana vector: %w", err)
 		return
 	}
 
@@ -701,12 +706,11 @@ func pruneConsensusEventLogsStorage() {
 		Timestamp: t,
 	}
 
-	if !cachedMetadata.Exists() {
-		consensusBaseManaPastVectorMetadataStorage.Store(metadata).Release()
-	} else {
-		m := cachedMetadata.Unwrap()
-		m.Update(metadata)
+	if err = consensusBaseManaPastVectorMetadataStorage.Prune(); err != nil {
+		manaLogger.Errorf("error pruning consensus base mana vector metadata storage: %w", err)
+		return
 	}
+	consensusBaseManaPastVectorMetadataStorage.Store(metadata).Release()
 
 	var entriesToDelete [][]byte
 	for _, ev := range eventLogs {


### PR DESCRIPTION
Fix #1184

# Description

 - Mana event log storage couldn't been pruned because of wrong inputs: the algorithm only looked into the cache to find the previous state, instead of loading it from database.
 - Be careful with `objectStorage.Get()` and  `objectStorage.Load()`, the former only fetches from cache.
 - Pruner always removes events until size is reduced to ~90% of the capacity .
 - Otherwise small improvements, added logging and human readable printing of mana events.