### PR TITLE
Release/v0.5.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v0.5.7 - 2021-04-21
+# v0.5.7 - 2021-04-22
 * Add approval weight manager (soft launch)
 * Add epochs
 * Add debug APIs for epochs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+# v0.5.7 - 2021-04-21
+* Add approval weight manager (soft launch)
+* Add epochs
+* Add debug APIs for epochs
+* Update local dashboard to show finalization based on approval weight
+* Improve FPC
+* Improve markers manager
+* Improve integration tests
+* Improve payload unmarshaling
+* Remove unless-stopped option from Docker default config
+* Increase CfgGossipAgeThreshold parameter
+* Fix several bugs on hive.go
+* Fix mana event storage pruning
+* Fix mana leaderboard and explorer live feed scroll view
+* Update snapshot with initial mana state
+* Update to latest hive.go
+* **Breaking**: bumps network and database versions
+
 # v0.5.6 - 2021-04-03
 * Fix childBranchType
 * Fix FPC empty round increase

--- a/plugins/autopeering/discovery/parameters.go
+++ b/plugins/autopeering/discovery/parameters.go
@@ -5,7 +5,7 @@ import "github.com/iotaledger/hive.go/configuration"
 // Parameters contains the configuration parameters used by the message layer.
 var Parameters = struct {
 	// NetworkVersion defines the config flag of the network version.
-	NetworkVersion int `default:"24" usage:"autopeering network version"`
+	NetworkVersion int `default:"25" usage:"autopeering network version"`
 
 	// EntryNodes defines the config flag of the entry nodes.
 	EntryNodes []string `default:"2PV5487xMw5rasGBXXWeqSi4hLz7r19YBt8Y1TGAsQbj@ressims.iota.cafe:15626,5EDH4uY78EA6wrBkHHAVBWBMDt7EcksRq6pjzipoW15B@entryshimmer.tanglebay.com:14646" usage:"list of trusted entry nodes for auto peering"`

--- a/plugins/banner/plugin.go
+++ b/plugins/banner/plugin.go
@@ -17,7 +17,7 @@ var (
 	once   sync.Once
 
 	// AppVersion version number
-	AppVersion = "v0.5.6"
+	AppVersion = "v0.5.7"
 	// SimplifiedAppVersion is the version number without commit hash
 	SimplifiedAppVersion = simplifiedVersion(AppVersion)
 )

--- a/plugins/database/versioning.go
+++ b/plugins/database/versioning.go
@@ -11,7 +11,7 @@ import (
 const (
 	// DBVersion defines the version of the database schema this version of GoShimmer supports.
 	// Every time there's a breaking change regarding the stored data, this version flag should be adjusted.
-	DBVersion = 26
+	DBVersion = 27
 )
 
 var (


### PR DESCRIPTION
# v0.5.7 - 2021-04-22
* Add approval weight manager (soft launch)
* Add epochs
* Add debug APIs for epochs
* Update local dashboard to show finalization based on approval weight
* Improve FPC
* Improve markers manager
* Improve integration tests
* Improve payload unmarshaling
* Remove unless-stopped option from Docker default config
* Increase CfgGossipAgeThreshold parameter
* Fix several bugs on hive.go
* Fix mana event storage pruning
* Fix mana leaderboard and explorer live feed scroll view
* Update snapshot with initial mana state
* Update to latest hive.go
* **Breaking**: bumps network and database versions