### PR TITLE
TangleTime, timy-time and node sync status

### DIFF
--- a/packages/tangle/tangle.go
+++ b/packages/tangle/tangle.go
@@ -31,6 +31,7 @@ type Tangle struct {
 	Scheduler             *Scheduler
 	Booker                *Booker
 	ApprovalWeightManager *ApprovalWeightManager
+	TimeManager           *TimeManager
 	ConsensusManager      *ConsensusManager
 	TipManager            *TipManager
 	Requester             *Requester
@@ -64,6 +65,7 @@ func New(options ...Option) (tangle *Tangle) {
 	tangle.LedgerState = NewLedgerState(tangle)
 	tangle.Booker = NewBooker(tangle)
 	tangle.ApprovalWeightManager = NewApprovalWeightManager(tangle)
+	tangle.TimeManager = NewTimeManager(tangle)
 	tangle.ConsensusManager = NewConsensusManager(tangle)
 	tangle.Requester = NewRequester(tangle)
 	tangle.TipManager = NewTipManager(tangle)
@@ -102,6 +104,7 @@ func (t *Tangle) Setup() {
 	t.Scheduler.Setup()
 	t.Booker.Setup()
 	t.ApprovalWeightManager.Setup()
+	t.TimeManager.Setup()
 	t.ConsensusManager.Setup()
 	t.TipManager.Setup()
 
@@ -230,6 +233,7 @@ type Options struct {
 	ConsensusMechanism           ConsensusMechanism
 	GenesisNode                  *ed25519.PublicKey
 	WeightProvider               WeightProvider
+	SyncTimeWindow               time.Duration
 }
 
 // Store is an Option for the Tangle that allows to specify which storage layer is supposed to be used to persist data.
@@ -287,6 +291,12 @@ func GenesisNode(genesisNodeBase58 string) Option {
 func ApprovalWeights(weightProvider WeightProvider) Option {
 	return func(options *Options) {
 		options.WeightProvider = weightProvider
+	}
+}
+
+func SyncTimeWindow(syncTimeWindow time.Duration) Option {
+	return func(options *Options) {
+		options.SyncTimeWindow = syncTimeWindow
 	}
 }
 

--- a/packages/tangle/tangle.go
+++ b/packages/tangle/tangle.go
@@ -191,6 +191,7 @@ func (t *Tangle) Shutdown() {
 	t.ConsensusManager.Shutdown()
 	t.Storage.Shutdown()
 	t.LedgerState.Shutdown()
+	t.TimeManager.Shutdown()
 	t.Options.Store.Shutdown()
 	t.TipManager.Shutdown()
 }
@@ -294,6 +295,8 @@ func ApprovalWeights(weightProvider WeightProvider) Option {
 	}
 }
 
+// SyncTimeWindow is an Option for the Tangle that allows to define the time window in which the node will consider
+// itself in sync.
 func SyncTimeWindow(syncTimeWindow time.Duration) Option {
 	return func(options *Options) {
 		options.SyncTimeWindow = syncTimeWindow

--- a/packages/tangle/timemanager.go
+++ b/packages/tangle/timemanager.go
@@ -1,0 +1,61 @@
+package tangle
+
+import (
+	"sync"
+	"time"
+
+	"github.com/iotaledger/goshimmer/packages/clock"
+	"github.com/iotaledger/goshimmer/packages/markers"
+	"github.com/iotaledger/hive.go/events"
+)
+
+type TimeManager struct {
+	tangle *Tangle
+
+	lastConfirmedTime      time.Time
+	lastConfirmedTimeMutex sync.RWMutex
+}
+
+func NewTimeManager(tangle *Tangle) *TimeManager {
+	return &TimeManager{
+		tangle: tangle,
+	}
+	// TODO: set default value for lastConfirmedTime when starting up
+}
+
+func (t *TimeManager) Setup() {
+	// TODO: maybe it is better to attach to an event for each message being confirmed.
+	//  However, we're confirming a marker and walking in its past cone, hence it should have the most recent timestamp.
+	t.tangle.ApprovalWeightManager.Events.MarkerConfirmation.Attach(events.NewClosure(t.updateTime))
+}
+
+func (t *TimeManager) Time() time.Time {
+	t.lastConfirmedTimeMutex.RLock()
+	defer t.lastConfirmedTimeMutex.RUnlock()
+
+	return t.lastConfirmedTime
+}
+
+func (t *TimeManager) Synced() bool {
+	t.lastConfirmedTimeMutex.RLock()
+	defer t.lastConfirmedTimeMutex.RUnlock()
+
+	return clock.SyncedTime().Sub(t.lastConfirmedTime) < t.tangle.Options.SyncTimeWindow
+}
+
+func (t *TimeManager) updateTime(marker markers.Marker, newLevel int, transition events.ThresholdEventTransition) {
+	if transition != events.ThresholdLevelIncreased {
+		return
+	}
+	// get message ID of marker
+	messageID := t.tangle.Booker.MarkersManager.MessageID(&marker)
+
+	t.tangle.Storage.Message(messageID).Consume(func(message *Message) {
+		t.lastConfirmedTimeMutex.Lock()
+		defer t.lastConfirmedTimeMutex.Unlock()
+
+		if t.lastConfirmedTime.Before(message.IssuingTime()) {
+			t.lastConfirmedTime = message.IssuingTime()
+		}
+	})
+}

--- a/packages/tangle/timemanager.go
+++ b/packages/tangle/timemanager.go
@@ -1,48 +1,100 @@
 package tangle
 
 import (
+	"errors"
 	"sync"
 	"time"
 
 	"github.com/iotaledger/goshimmer/packages/clock"
+	"github.com/iotaledger/goshimmer/packages/epochs"
 	"github.com/iotaledger/goshimmer/packages/markers"
+	"github.com/iotaledger/hive.go/cerrors"
 	"github.com/iotaledger/hive.go/events"
+	"github.com/iotaledger/hive.go/kvstore"
+	"github.com/iotaledger/hive.go/marshalutil"
+	"github.com/iotaledger/hive.go/stringify"
+	"golang.org/x/xerrors"
 )
 
+const (
+	lastConfirmedKey = "lastConfirmedMessage"
+)
+
+// region TimeManager //////////////////////////////////////////////////////////////////////////////////////////////////
+
+// TimeManager is a Tangle component that keeps track of the TangleTime. The TangleTime can be seen as a clock for the
+// entire network as it tracks the time of the last confirmed message. Comparing the issuing time of the last confirmed
+// message to the node's current wall clock time then yields a reasonable assessment of how much in sync the node is.
 type TimeManager struct {
 	tangle *Tangle
 
-	lastConfirmedTime      time.Time
-	lastConfirmedTimeMutex sync.RWMutex
+	lastConfirmedMessage lastConfirmedMessage
+	lastConfirmedMutex   sync.RWMutex
 }
 
-func NewTimeManager(tangle *Tangle) *TimeManager {
-	return &TimeManager{
+// NewTimeManager is the constructor for TimeManager.
+func NewTimeManager(tangle *Tangle) (timeManager *TimeManager) {
+	timeManager = &TimeManager{
 		tangle: tangle,
 	}
-	// TODO: set default value for lastConfirmedTime when starting up
+
+	marshaledLastConfirmedMessage, err := tangle.Options.Store.Get(kvstore.Key(lastConfirmedKey))
+	if err != nil && !errors.Is(err, kvstore.ErrKeyNotFound) {
+		panic(err)
+	}
+	// Load from storage if key was found.
+	if marshaledLastConfirmedMessage != nil {
+		if timeManager.lastConfirmedMessage, _, err = lastConfirmedMessageFromBytes(marshaledLastConfirmedMessage); err != nil {
+			panic(err)
+		}
+		return
+	}
+
+	// Initialize with Genesis if not found in storage.
+	timeManager.lastConfirmedMessage = lastConfirmedMessage{
+		MessageID: EmptyMessageID,
+		Time:      time.Unix(epochs.DefaultGenesisTime, 0),
+	}
+
+	return
 }
 
+// Setup sets up the behavior of the component by making it attach to the relevant events of other components.
 func (t *TimeManager) Setup() {
 	// TODO: maybe it is better to attach to an event for each message being confirmed.
 	//  However, we're confirming a marker and walking in its past cone, hence it should have the most recent timestamp.
 	t.tangle.ApprovalWeightManager.Events.MarkerConfirmation.Attach(events.NewClosure(t.updateTime))
 }
 
+// Shutdown shuts down the TimeManager and persists its state.
+func (t *TimeManager) Shutdown() {
+	t.lastConfirmedMutex.RLock()
+	defer t.lastConfirmedMutex.RUnlock()
+
+	if err := t.tangle.Options.Store.Set(kvstore.Key(lastConfirmedKey), t.lastConfirmedMessage.Bytes()); err != nil {
+		t.tangle.Events.Error.Trigger(xerrors.Errorf("failed to persists lastConfirmedMessage (%v): %w", err, cerrors.ErrFatal))
+		return
+	}
+}
+
+// Time returns the TangleTime, i.e., the issuing time of the last confirmed message.
 func (t *TimeManager) Time() time.Time {
-	t.lastConfirmedTimeMutex.RLock()
-	defer t.lastConfirmedTimeMutex.RUnlock()
+	t.lastConfirmedMutex.RLock()
+	defer t.lastConfirmedMutex.RUnlock()
 
-	return t.lastConfirmedTime
+	return t.lastConfirmedMessage.Time
 }
 
+// Synced returns whether the node is in sync based on the difference between TangleTime and current wall time which can
+// be configured via SyncTimeWindow.
 func (t *TimeManager) Synced() bool {
-	t.lastConfirmedTimeMutex.RLock()
-	defer t.lastConfirmedTimeMutex.RUnlock()
+	t.lastConfirmedMutex.RLock()
+	defer t.lastConfirmedMutex.RUnlock()
 
-	return clock.SyncedTime().Sub(t.lastConfirmedTime) < t.tangle.Options.SyncTimeWindow
+	return clock.SyncedTime().Sub(t.lastConfirmedMessage.Time) < t.tangle.Options.SyncTimeWindow
 }
 
+// updateTime updates the last confirmed message.
 func (t *TimeManager) updateTime(marker markers.Marker, newLevel int, transition events.ThresholdEventTransition) {
 	if transition != events.ThresholdLevelIncreased {
 		return
@@ -51,11 +103,70 @@ func (t *TimeManager) updateTime(marker markers.Marker, newLevel int, transition
 	messageID := t.tangle.Booker.MarkersManager.MessageID(&marker)
 
 	t.tangle.Storage.Message(messageID).Consume(func(message *Message) {
-		t.lastConfirmedTimeMutex.Lock()
-		defer t.lastConfirmedTimeMutex.Unlock()
+		t.lastConfirmedMutex.Lock()
+		defer t.lastConfirmedMutex.Unlock()
 
-		if t.lastConfirmedTime.Before(message.IssuingTime()) {
-			t.lastConfirmedTime = message.IssuingTime()
+		if t.lastConfirmedMessage.Time.Before(message.IssuingTime()) {
+			t.lastConfirmedMessage = lastConfirmedMessage{
+				MessageID: messageID,
+				Time:      message.IssuingTime(),
+			}
 		}
 	})
 }
+
+// endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// region lastConfirmedMessage /////////////////////////////////////////////////////////////////////////////////////////
+
+// lastConfirmedMessage is a wrapper type for the last confirmed message, consisting of MessageID and time.
+type lastConfirmedMessage struct {
+	MessageID MessageID
+	Time      time.Time
+}
+
+// lastConfirmedMessageFromBytes unmarshals a lastConfirmedMessage object from a sequence of bytes.
+func lastConfirmedMessageFromBytes(bytes []byte) (lcm lastConfirmedMessage, consumedBytes int, err error) {
+	marshalUtil := marshalutil.New(bytes)
+	if lcm, err = lastConfirmedMessageFromMarshalUtil(marshalUtil); err != nil {
+		err = xerrors.Errorf("failed to parse lastConfirmedMessage from MarshalUtil: %w", err)
+		return
+	}
+	consumedBytes = marshalUtil.ReadOffset()
+
+	return
+}
+
+// lastConfirmedMessageFromMarshalUtil unmarshals a lastConfirmedMessage object using a MarshalUtil (for easier unmarshaling).
+func lastConfirmedMessageFromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (lcm lastConfirmedMessage, err error) {
+	lcm = lastConfirmedMessage{}
+	if lcm.MessageID, err = MessageIDFromMarshalUtil(marshalUtil); err != nil {
+		err = xerrors.Errorf("failed to parse MessageID from MarshalUtil: %w", err)
+		return
+	}
+
+	if lcm.Time, err = marshalUtil.ReadTime(); err != nil {
+		err = xerrors.Errorf("failed to parse time (%v): %w", err, cerrors.ErrParseBytesFailed)
+		return
+	}
+
+	return
+}
+
+// Bytes returns a marshaled version of the lastConfirmedMessage.
+func (l lastConfirmedMessage) Bytes() (marshaledLastConfirmedMessage []byte) {
+	return marshalutil.New(MessageIDLength + marshalutil.TimeSize).
+		Write(l.MessageID).
+		WriteTime(l.Time).
+		Bytes()
+}
+
+// String returns a human readable version of the lastConfirmedMessage.
+func (l lastConfirmedMessage) String() string {
+	return stringify.Struct("lastConfirmedMessage",
+		stringify.StructField("MessageID", l.MessageID),
+		stringify.StructField("Time", l.Time),
+	)
+}
+
+// endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/packages/tangle/timemanager.go
+++ b/packages/tangle/timemanager.go
@@ -62,8 +62,6 @@ func NewTimeManager(tangle *Tangle) (timeManager *TimeManager) {
 
 // Setup sets up the behavior of the component by making it attach to the relevant events of other components.
 func (t *TimeManager) Setup() {
-	// TODO: maybe it is better to attach to an event for each message being confirmed.
-	//  However, we're confirming a marker and walking in its past cone, hence it should have the most recent timestamp.
 	t.tangle.ApprovalWeightManager.Events.MarkerConfirmation.Attach(events.NewClosure(t.updateTime))
 }
 

--- a/plugins/dashboard/frontend/src/app/components/Dashboard.tsx
+++ b/plugins/dashboard/frontend/src/app/components/Dashboard.tsx
@@ -13,6 +13,7 @@ import ListGroup from "react-bootstrap/ListGroup";
 import Card from "react-bootstrap/Card";
 import MemChart from "app/components/MemChart";
 import ComponentCounterChart from "app/components/ComponentCounterChart";
+import TangleTime from "app/components/TangleTime";
 interface Props {
     nodeStore?: NodeStore;
 }
@@ -47,6 +48,9 @@ export class Dashboard extends React.Component<Props, any> {
                 </Row>
                 <Row className={"mb-3"}>
                     <Col><Synced/></Col>
+                </Row>
+                <Row className={"mb-3"}>
+                    <Col><TangleTime/></Col>
                 </Row>
                 <Row className={"mb-3"}>
                     <Col><MPSChart/></Col>

--- a/plugins/dashboard/frontend/src/app/components/TangleTime.tsx
+++ b/plugins/dashboard/frontend/src/app/components/TangleTime.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import NodeStore from "app/stores/NodeStore";
+import Card from "react-bootstrap/Card";
+import {Link} from 'react-router-dom';
+import {inject, observer} from "mobx-react";
+import * as dateformat from 'dateformat';
+
+interface Props {
+    nodeStore?: NodeStore;
+}
+
+@inject("nodeStore")
+@observer
+export default class TangleTime extends React.Component<Props, any> {
+    render() {
+        return (
+            <Card>
+                <Card.Body>
+                    <Card.Title>TangleTime Synced: {this.props.nodeStore.status.tangleTime.synced? "Yes":"No"} (experimental)</Card.Title>
+                    <small>
+                        <div>
+                            <hr/>
+                            <div>Message: <Link to={`/explorer/message/${this.props.nodeStore.status.tangleTime.messageID}`}>
+                                            {this.props.nodeStore.status.tangleTime.messageID}
+                                        </Link></div>
+                            <div>Time: {dateformat(new Date(this.props.nodeStore.status.tangleTime.time/1000000), "dd.mm.yyyy HH:MM:ss")}</div>
+                        </div>
+                    </small>
+
+                </Card.Body>
+            </Card>
+        );
+    }
+}

--- a/plugins/dashboard/frontend/src/app/stores/NodeStore.ts
+++ b/plugins/dashboard/frontend/src/app/stores/NodeStore.ts
@@ -14,6 +14,13 @@ class Status {
     synced: boolean;
     beacons: Map<string, Beacon>;
     mem: MemoryMetrics = new MemoryMetrics();
+    tangleTime: TangleTime;
+}
+
+class TangleTime {
+    synced: boolean;
+    time: number;
+    messageID: string;
 }
 
 class Beacon {
@@ -179,6 +186,8 @@ export class NodeStore {
 
     constructor() {
         this.status.beacons = new Map<string, Beacon>();
+        this.status.tangleTime = new TangleTime;
+        this.status.tangleTime.time = 0;
         this.registerHandlers();
     }
 

--- a/plugins/dashboard/plugin.go
+++ b/plugins/dashboard/plugin.go
@@ -195,12 +195,19 @@ type msg struct {
 }
 
 type nodestatus struct {
-	ID      string            `json:"id"`
-	Version string            `json:"version"`
-	Uptime  int64             `json:"uptime"`
-	Synced  bool              `json:"synced"`
-	Beacons map[string]Beacon `json:"beacons"`
-	Mem     *memmetrics       `json:"mem"`
+	ID         string            `json:"id"`
+	Version    string            `json:"version"`
+	Uptime     int64             `json:"uptime"`
+	Synced     bool              `json:"synced"`
+	Beacons    map[string]Beacon `json:"beacons"`
+	Mem        *memmetrics       `json:"mem"`
+	TangleTime tangleTime        `json:"tangleTime"`
+}
+
+type tangleTime struct {
+	Synced    bool   `json:"synced"`
+	Time      int64  `json:"time"`
+	MessageID string `json:"messageID"`
 }
 
 // Beacon contains a sync beacons detailed status.
@@ -299,6 +306,14 @@ func currentNodeStatus() *nodestatus {
 		HeapObjects:  m.HeapObjects,
 		NumGC:        m.NumGC,
 		LastPauseGC:  m.PauseNs[(m.NumGC+255)%256],
+	}
+
+	// get TangleTime
+	lcm := messagelayer.Tangle().TimeManager.LastConfirmedMessage()
+	status.TangleTime = tangleTime{
+		Synced:    messagelayer.Tangle().TimeManager.Synced(),
+		Time:      lcm.Time.UnixNano(),
+		MessageID: lcm.MessageID.Base58(),
 	}
 	return status
 }

--- a/plugins/messagelayer/parameters.go
+++ b/plugins/messagelayer/parameters.go
@@ -22,6 +22,9 @@ var Parameters = struct {
 	FCOB struct {
 		AverageNetworkDelay int `default:"5" usage:"the avg. network delay to use for FCoB rules"`
 	}
+
+	// TangleTimeWindow defines the time window in which the node considers itself as synced according to TangleTime.
+	TangleTimeWindow time.Duration `default:"1m" usage:"the time window in which the node considers itself as synced according to TangleTime"`
 }{}
 
 // FPCParameters contains the configuration parameters used by the FPC consensus.

--- a/plugins/messagelayer/plugin.go
+++ b/plugins/messagelayer/plugin.go
@@ -110,6 +110,7 @@ func Tangle() *tangle.Tangle {
 			tangle.Consensus(ConsensusMechanism()),
 			tangle.GenesisNode(Parameters.Snapshot.GenesisNode),
 			tangle.ApprovalWeights(tangle.WeightProviderFromEpochsManager(epochManager)),
+			tangle.SyncTimeWindow(Parameters.TangleTimeWindow),
 		)
 
 		tangleInstance.Setup()


### PR DESCRIPTION
This PR adds TangleTime which basically transforms the Tangle into a clock. In this way every node can follow the latest confirmed message and therefore determine whether in sync or not. 

![image](https://user-images.githubusercontent.com/4181434/115951389-d1895500-a4e0-11eb-9eeb-d942a292129b.png)
