### PR TITLE
Implement Orderer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/golang/protobuf v1.4.3
 	github.com/golang/snappy v0.0.2 // indirect
 	github.com/gorilla/websocket v1.4.2
-	github.com/iotaledger/hive.go v0.0.0-20210427112115-75c7ebf4ebbb
+	github.com/iotaledger/hive.go v0.0.0-20210503211838-dec77b0328c1
 	github.com/kr/pretty v0.2.1 // indirect
 	github.com/labstack/echo v3.3.10+incompatible
 	github.com/labstack/gommon v0.3.0

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/golang/protobuf v1.4.3
 	github.com/golang/snappy v0.0.2 // indirect
 	github.com/gorilla/websocket v1.4.2
-	github.com/iotaledger/hive.go v0.0.0-20210420114224-0b2c378f627f
+	github.com/iotaledger/hive.go v0.0.0-20210427112115-75c7ebf4ebbb
 	github.com/kr/pretty v0.2.1 // indirect
 	github.com/labstack/echo v3.3.10+incompatible
 	github.com/labstack/gommon v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -406,8 +406,8 @@ github.com/hydrogen18/memlistener v0.0.0-20141126152155-54553eb933fb/go.mod h1:q
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/iotaledger/hive.go v0.0.0-20210427112115-75c7ebf4ebbb h1:/rQpy4+WTsgdlh4azuPoICb60y15yXN+ArjVlAu01Js=
-github.com/iotaledger/hive.go v0.0.0-20210427112115-75c7ebf4ebbb/go.mod h1:NyBg/Ny7FFAdDs59zdwTVoysU2ZbJVQnRwyLIDFKJYA=
+github.com/iotaledger/hive.go v0.0.0-20210503211838-dec77b0328c1 h1:Dd2e7s3HcP/+oE+U0ih0Z9KcTMReY1r0gqnVixnubdk=
+github.com/iotaledger/hive.go v0.0.0-20210503211838-dec77b0328c1/go.mod h1:NyBg/Ny7FFAdDs59zdwTVoysU2ZbJVQnRwyLIDFKJYA=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.2/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.3/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=

--- a/go.sum
+++ b/go.sum
@@ -406,8 +406,8 @@ github.com/hydrogen18/memlistener v0.0.0-20141126152155-54553eb933fb/go.mod h1:q
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/iotaledger/hive.go v0.0.0-20210420114224-0b2c378f627f h1:dIveuMy0KoN6gXIuKp0rTdo2ZmYbQvLRGCGpq/7dqhY=
-github.com/iotaledger/hive.go v0.0.0-20210420114224-0b2c378f627f/go.mod h1:NyBg/Ny7FFAdDs59zdwTVoysU2ZbJVQnRwyLIDFKJYA=
+github.com/iotaledger/hive.go v0.0.0-20210427112115-75c7ebf4ebbb h1:/rQpy4+WTsgdlh4azuPoICb60y15yXN+ArjVlAu01Js=
+github.com/iotaledger/hive.go v0.0.0-20210427112115-75c7ebf4ebbb/go.mod h1:NyBg/Ny7FFAdDs59zdwTVoysU2ZbJVQnRwyLIDFKJYA=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.2/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.3/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=

--- a/packages/consensus/fcob/consensusmechanism.go
+++ b/packages/consensus/fcob/consensusmechanism.go
@@ -56,6 +56,15 @@ func (f *ConsensusMechanism) Init(tangle *tangle.Tangle) {
 
 // Setup sets up the behavior of the ConsensusMechanism by making it attach to the relevant events in the Tangle.
 func (f *ConsensusMechanism) Setup() {
+	f.tangle.LedgerState.BranchDAG.Events.BranchConfirmed.Attach(events.NewClosure(func(branchDAGEvent *ledgerstate.BranchDAGEvent) {
+		defer branchDAGEvent.Release()
+		f.SetTransactionLiked(branchDAGEvent.Branch.ID().TransactionID(), true)
+	}))
+	f.tangle.LedgerState.BranchDAG.Events.BranchRejected.Attach(events.NewClosure(func(branchDAGEvent *ledgerstate.BranchDAGEvent) {
+		defer branchDAGEvent.Release()
+		f.SetTransactionLiked(branchDAGEvent.Branch.ID().TransactionID(), false)
+	}))
+
 	f.tangle.Booker.Events.MessageBooked.Attach(events.NewClosure(f.Evaluate))
 	f.tangle.Booker.Events.MessageBooked.Attach(events.NewClosure(f.EvaluateTimestamp))
 }

--- a/packages/epochs/epoch.go
+++ b/packages/epochs/epoch.go
@@ -154,8 +154,11 @@ func (e *Epoch) AddNode(id identity.ID) {
 	e.manaMutex.Lock()
 	defer e.manaMutex.Unlock()
 
-	e.mana[id] = 0
+	if e.manaRetrieved {
+		return
+	}
 
+	e.mana[id] = 0
 	e.SetModified()
 }
 

--- a/packages/epochs/manager.go
+++ b/packages/epochs/manager.go
@@ -128,27 +128,27 @@ func (m *Manager) RelativeNodeMana(nodeID identity.ID, t time.Time) (ownWeight, 
 // ActiveMana returns the active consensus mana that is valid for the given time t. Active consensus mana is always
 // retrieved from the oracle epoch.
 func (m *Manager) ActiveMana(epochID ID) (manaPerID map[identity.ID]float64, totalMana float64) {
-	if !m.Epoch(epochID).Consume(func(epoch *Epoch) {
+	//if !m.Epoch(epochID).Consume(func(epoch *Epoch) {
+	//	if !epoch.ManaRetrieved() {
+	//		consensusMana := m.options.ManaRetriever(m.EpochIDToEndTime(epochID))
+	//		epoch.SetMana(consensusMana)
+	//	}
+	//
+	//	manaPerID = epoch.Mana()
+	//	totalMana = epoch.TotalMana()
+	//}) {
+	// TODO: improve this: always default to epoch 0
+	epochID = ID(0)
+	m.Epoch(epochID, NewEpoch).Consume(func(epoch *Epoch) {
 		if !epoch.ManaRetrieved() {
 			consensusMana := m.options.ManaRetriever(m.EpochIDToEndTime(epochID))
-			epoch.SetMana(consensusMana)
+			epoch.SetMana(consensusMana, true)
 		}
 
 		manaPerID = epoch.Mana()
 		totalMana = epoch.TotalMana()
-	}) {
-		// TODO: improve this: always default to epoch 0
-		epochID = ID(0)
-		m.Epoch(epochID, NewEpoch).Consume(func(epoch *Epoch) {
-			if !epoch.ManaRetrieved() {
-				consensusMana := m.options.ManaRetriever(m.EpochIDToEndTime(epochID))
-				epoch.SetMana(consensusMana, true)
-			}
-
-			manaPerID = epoch.Mana()
-			totalMana = epoch.TotalMana()
-		})
-	}
+	})
+	//}
 
 	return
 }

--- a/packages/ledgerstate/branch.go
+++ b/packages/ledgerstate/branch.go
@@ -95,6 +95,13 @@ func BranchIDFromRandomness() (branchID BranchID) {
 	return
 }
 
+// TransactionID returns the TransactionID of its underlying conflicting Transaction.
+func (b BranchID) TransactionID() (transactionID TransactionID) {
+	copy(transactionID[:], b[:])
+
+	return
+}
+
 // Bytes returns a marshaled version of the BranchID.
 func (b BranchID) Bytes() []byte {
 	return b[:]

--- a/packages/ledgerstate/branch_dag.go
+++ b/packages/ledgerstate/branch_dag.go
@@ -116,6 +116,26 @@ func (b *BranchDAG) AggregateBranches(branchIDS BranchIDs) (cachedAggregatedBran
 	return
 }
 
+// SetBranchConfirmed sets a Branch to be monotonically liked and finalized. It automatically triggers conflicting
+// Branches to be marked as rejected.
+func (b *BranchDAG) SetBranchConfirmed(branchID BranchID) (err error) {
+	if b.InclusionState(branchID) == Confirmed {
+		return
+	}
+
+	if _, branchErr := b.SetBranchMonotonicallyLiked(branchID, true); branchErr != nil {
+		err = xerrors.Errorf("failed to set Branch with %s to be monotonically liked: %w", branchID, branchErr)
+		return
+	}
+
+	if _, branchErr := b.SetBranchFinalized(branchID, true); branchErr != nil {
+		err = xerrors.Errorf("failed to set Branch with %s to be finalized: %w", branchID, branchErr)
+		return
+	}
+
+	return
+}
+
 // SetBranchLiked sets the liked flag of the given Branch. It returns true if the value has been updated or an error if
 // it failed.
 func (b *BranchDAG) SetBranchLiked(branchID BranchID, liked bool) (modified bool, err error) {

--- a/packages/ledgerstate/utxo_dag.go
+++ b/packages/ledgerstate/utxo_dag.go
@@ -9,6 +9,7 @@ import (
 	"github.com/iotaledger/hive.go/byteutils"
 	"github.com/iotaledger/hive.go/cerrors"
 	"github.com/iotaledger/hive.go/datastructure/set"
+	"github.com/iotaledger/hive.go/datastructure/walker"
 	"github.com/iotaledger/hive.go/events"
 	"github.com/iotaledger/hive.go/kvstore"
 	"github.com/iotaledger/hive.go/marshalutil"
@@ -44,6 +45,7 @@ func NewUTXODAG(store kvstore.KVStore, branchDAG *BranchDAG) (utxoDAG *UTXODAG) 
 	utxoDAG = &UTXODAG{
 		Events: &UTXODAGEvents{
 			TransactionBranchIDUpdated: events.NewEvent(transactionIDEventHandler),
+			TransactionConfirmed:       events.NewEvent(transactionIDEventHandler),
 		},
 		transactionStorage:          osFactory.New(PrefixTransactionStorage, TransactionFromObjectStorage, transactionStorageOptions...),
 		transactionMetadataStorage:  osFactory.New(PrefixTransactionMetadataStorage, TransactionMetadataFromObjectStorage, transactionMetadataStorageOptions...),
@@ -304,6 +306,76 @@ func (u *UTXODAG) AddressOutputMapping(address Address) (cachedAddressOutputMapp
 		cachedAddressOutputMappings = append(cachedAddressOutputMappings, &CachedAddressOutputMapping{cachedObject})
 		return true
 	}, objectstorage.WithIteratorPrefix(address.Bytes()))
+	return
+}
+
+// SetTransactionConfirmed marks a Transaction (and all Transactions in its past cone) as confirmed. It also marks the
+// conflicting Transactions to be rejected.
+func (u *UTXODAG) SetTransactionConfirmed(transactionID TransactionID) (err error) {
+	confirmationWalker := walker.New()
+	confirmationWalker.Push(transactionID)
+
+	u.TransactionMetadata(transactionID).Consume(func(transactionMetadata *TransactionMetadata) {
+		err = u.branchDAG.SetBranchConfirmed(transactionMetadata.BranchID())
+	})
+	if err != nil {
+		return xerrors.Errorf("failed to set Branch of Transaction with %s to be confirmed: %w", transactionID, cerrors.ErrFatal)
+	}
+
+	seenTransactions := set.New()
+	confirmedTransactions := list.New()
+	for confirmationWalker.HasNext() {
+		u.setTransactionConfirmed(confirmationWalker.Next().(TransactionID), confirmedTransactions, seenTransactions, confirmationWalker)
+	}
+
+	triggeredEvents := set.New()
+	for confirmedTransactions.Len() > 0 {
+		currentElement := confirmedTransactions.Front()
+		confirmedTransactions.Remove(currentElement)
+		currentTransactionID := currentElement.Value.(TransactionID)
+
+		if !triggeredEvents.Add(currentTransactionID) {
+			continue
+		}
+
+		u.Events.TransactionConfirmed.Trigger(currentTransactionID)
+	}
+
+	return err
+}
+
+func (u *UTXODAG) setTransactionConfirmed(transactionID TransactionID, confirmedTransactions *list.List, seenTransactions set.Set, confirmationWalker *walker.Walker) {
+	u.TransactionMetadata(transactionID).Consume(func(transactionMetadata *TransactionMetadata) {
+		if !transactionMetadata.SetFinalized(true) {
+			return
+		}
+
+		seenTransactions.Add(transactionID)
+		confirmedTransactions.PushFront(transactionID)
+
+		u.Transaction(transactionID).Consume(func(transaction *Transaction) {
+			for _, output := range transaction.Essence().Outputs() {
+				u.OutputMetadata(output.ID()).Consume(func(outputMetadata *OutputMetadata) {
+					outputMetadata.SetFinalized(true)
+				})
+			}
+
+			for referencedTransactionID := range transaction.ReferencedTransactionIDs() {
+				u.TransactionMetadata(referencedTransactionID).Consume(func(referencedTransactionMetadata *TransactionMetadata) {
+					if referencedTransactionMetadata.Finalized() {
+						if seenTransactions.Has(referencedTransactionID) {
+							confirmedTransactions.PushFront(referencedTransactionID)
+						}
+
+						return
+					}
+
+					confirmationWalker.Push(referencedTransactionID)
+				})
+			}
+		})
+	})
+
 	return
 }
 
@@ -830,6 +902,8 @@ func (u *UTXODAG) lockTransaction(transaction *Transaction) {
 type UTXODAGEvents struct {
 	// TransactionBranchIDUpdated gets triggered when the BranchID of a Transaction is changed after the initial booking.
 	TransactionBranchIDUpdated *events.Event
+	// Fired when a transaction gets confirmed.
+	TransactionConfirmed *events.Event
 }
 
 func transactionIDEventHandler(handler interface{}, params ...interface{}) {

--- a/packages/mana/consensusbasevector.go
+++ b/packages/mana/consensusbasevector.go
@@ -131,9 +131,11 @@ func (c *ConsensusBaseManaVector) Book(txInfo *TxInfo) {
 		err := c.vector[pledgeNodeID].revoke(inputInfo.Amount, txInfo.TimeStamp)
 		switch err {
 		case ErrBaseManaNegative:
-			panic(fmt.Sprintf("Revoking %f base mana 1 from node %s results in negative balance", inputInfo.Amount, pledgeNodeID.String()))
+			fmt.Println(txInfo)
+			panic(fmt.Sprintf("Revoking %f base mana 1 of input %s from node %s results in negative balance", inputInfo.Amount, inputInfo.InputID, pledgeNodeID.String()))
 		case ErrEffBaseManaNegative:
-			panic(fmt.Sprintf("Revoking (%f) eff base mana 1 from node %s results in negative balance", inputInfo.Amount, pledgeNodeID.String()))
+			fmt.Println(txInfo)
+			panic(fmt.Sprintf("Revoking (%f) eff base mana 1 of input %s from node %s results in negative balance", inputInfo.Amount, inputInfo.InputID, pledgeNodeID.String()))
 		}
 		// trigger events
 		Events().Revoked.Trigger(&RevokedEvent{pledgeNodeID, inputInfo.Amount, txInfo.TimeStamp, c.Type(), txInfo.TransactionID, inputInfo.InputID})

--- a/packages/markers/sequence.go
+++ b/packages/markers/sequence.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/iotaledger/hive.go/byteutils"
 	"github.com/iotaledger/hive.go/cerrors"
+	"github.com/iotaledger/hive.go/datastructure/orderedmap"
 	"github.com/iotaledger/hive.go/marshalutil"
 	"github.com/iotaledger/hive.go/objectstorage"
 	"github.com/iotaledger/hive.go/stringify"
@@ -16,17 +17,25 @@ import (
 	"golang.org/x/xerrors"
 )
 
+// maxVerticesWithoutFutureMarker defines the amount of vertices in the DAG are allowed to have no future marker before
+// we spawn a new Sequence for the same SequenceAlias.
+const maxVerticesWithoutFutureMarker = 300
+
 // region Sequence /////////////////////////////////////////////////////////////////////////////////////////////////////
 
 // Sequence represents a set of ever increasing Indexes that are encapsulating a certain part of the DAG.
 type Sequence struct {
-	id                 SequenceID
-	referencedMarkers  *ReferencedMarkers
-	referencingMarkers *ReferencingMarkers
-	rank               uint64
-	lowestIndex        Index
-	highestIndex       Index
-	highestIndexMutex  sync.RWMutex
+	id                               SequenceID
+	referencedMarkers                *ReferencedMarkers
+	referencingMarkers               *ReferencingMarkers
+	rank                             uint64
+	lowestIndex                      Index
+	highestIndex                     Index
+	newSequenceTrigger               uint64
+	maxPastMarkerGap                 uint64
+	verticesWithoutFutureMarker      uint64
+	verticesWithoutFutureMarkerMutex sync.RWMutex
+	highestIndexMutex                sync.RWMutex
 
 	objectstorage.StorableObjectFlags
 }
@@ -74,6 +83,18 @@ func SequenceFromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (sequence *Se
 	}
 	if sequence.rank, err = marshalUtil.ReadUint64(); err != nil {
 		err = xerrors.Errorf("failed to parse rank (%v): %w", err, cerrors.ErrParseBytesFailed)
+		return
+	}
+	if sequence.newSequenceTrigger, err = marshalUtil.ReadUint64(); err != nil {
+		err = xerrors.Errorf("failed to parse newSequenceTrigger (%v): %w", err, cerrors.ErrParseBytesFailed)
+		return
+	}
+	if sequence.maxPastMarkerGap, err = marshalUtil.ReadUint64(); err != nil {
+		err = xerrors.Errorf("failed to parse maxPastMarkerGap (%v): %w", err, cerrors.ErrParseBytesFailed)
+		return
+	}
+	if sequence.verticesWithoutFutureMarker, err = marshalUtil.ReadUint64(); err != nil {
+		err = xerrors.Errorf("failed to parse verticesWithoutFutureMarker (%v): %w", err, cerrors.ErrParseBytesFailed)
 		return
 	}
 	if sequence.lowestIndex, err = IndexFromMarshalUtil(marshalUtil); err != nil {
@@ -170,9 +191,9 @@ func (s *Sequence) AddReferencingMarker(index Index, referencingMarker *Marker) 
 func (s *Sequence) String() string {
 	return stringify.Struct("Sequence",
 		stringify.StructField("ID", s.ID()),
-		stringify.StructField("ID", s.Rank()),
-		stringify.StructField("ID", s.LowestIndex()),
-		stringify.StructField("ID", s.HighestIndex()),
+		stringify.StructField("Rank", s.Rank()),
+		stringify.StructField("LowestIndex", s.LowestIndex()),
+		stringify.StructField("HighestIndex", s.HighestIndex()),
 	)
 }
 
@@ -182,7 +203,7 @@ func (s *Sequence) Bytes() []byte {
 }
 
 // Update is required to match the StorableObject interface but updates of the object are disabled.
-func (s *Sequence) Update(other objectstorage.StorableObject) {
+func (s *Sequence) Update(objectstorage.StorableObject) {
 	panic("updates disabled")
 }
 
@@ -195,13 +216,71 @@ func (s *Sequence) ObjectStorageKey() []byte {
 // ObjectStorageValue marshals the Sequence into a sequence of bytes. The ID is not serialized here as it is only used as
 // a key in the object storage.
 func (s *Sequence) ObjectStorageValue() []byte {
+	s.verticesWithoutFutureMarkerMutex.RLock()
+	defer s.verticesWithoutFutureMarkerMutex.RUnlock()
+
 	return marshalutil.New().
 		Write(s.referencedMarkers).
 		Write(s.referencingMarkers).
 		WriteUint64(s.rank).
+		WriteUint64(s.newSequenceTrigger).
+		WriteUint64(s.maxPastMarkerGap).
+		WriteUint64(s.verticesWithoutFutureMarker).
 		Write(s.lowestIndex).
 		Write(s.HighestIndex()).
 		Bytes()
+}
+
+func (s *Sequence) increaseVerticesWithoutFutureMarker() {
+	s.verticesWithoutFutureMarkerMutex.Lock()
+	defer s.verticesWithoutFutureMarkerMutex.Unlock()
+
+	s.verticesWithoutFutureMarker++
+
+	s.SetModified()
+}
+
+func (s *Sequence) decreaseVerticesWithoutFutureMarker() {
+	s.verticesWithoutFutureMarkerMutex.Lock()
+	defer s.verticesWithoutFutureMarkerMutex.Unlock()
+
+	s.verticesWithoutFutureMarker--
+
+	s.SetModified()
+}
+
+func (s *Sequence) newSequenceRequired(pastMarkerGap uint64) (newSequenceRequired bool) {
+	s.verticesWithoutFutureMarkerMutex.Lock()
+	defer s.verticesWithoutFutureMarkerMutex.Unlock()
+
+	s.SetModified()
+
+	// decrease the maxPastMarkerGap threshold with every processed message so it ultimately goes back to a healthy
+	// level after the triggering
+	if s.maxPastMarkerGap > 0 {
+		s.maxPastMarkerGap--
+	}
+
+	if pastMarkerGap > s.maxPastMarkerGap {
+		s.maxPastMarkerGap = pastMarkerGap
+	}
+
+	if s.verticesWithoutFutureMarker < maxVerticesWithoutFutureMarker {
+		return false
+	}
+
+	if s.newSequenceTrigger == 0 {
+		s.newSequenceTrigger = s.maxPastMarkerGap
+		return false
+	}
+
+	if pastMarkerGap < s.newSequenceTrigger {
+		return false
+	}
+
+	s.newSequenceTrigger = 0
+
+	return true
 }
 
 // code contract (make sure the type implements all required methods)
@@ -468,7 +547,7 @@ func (a SequenceAlias) String() (humanReadableSequenceAlias string) {
 // SequenceAliasMapping represents the mapping between a SequenceAlias and its SequenceID.
 type SequenceAliasMapping struct {
 	sequenceAlias SequenceAlias
-	sequenceID    SequenceID
+	sequenceIDs   *orderedmap.OrderedMap
 
 	objectstorage.StorableObjectFlags
 }
@@ -487,14 +566,28 @@ func SequenceAliasMappingFromBytes(mappingBytes []byte) (mapping *SequenceAliasM
 
 // SequenceAliasMappingFromMarshalUtil unmarshals a SequenceAliasMapping using a MarshalUtil (for easier unmarshaling).
 func SequenceAliasMappingFromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (mapping *SequenceAliasMapping, err error) {
-	mapping = &SequenceAliasMapping{}
+	mapping = &SequenceAliasMapping{
+		sequenceIDs: orderedmap.New(),
+	}
+
 	if mapping.sequenceAlias, err = SequenceAliasFromMarshalUtil(marshalUtil); err != nil {
 		err = xerrors.Errorf("failed to parse Alias from MarshalUtil: %w", err)
 		return
 	}
-	if mapping.sequenceID, err = SequenceIDFromMarshalUtil(marshalUtil); err != nil {
-		err = xerrors.Errorf("failed to parse SequenceID from MarshalUtil: %w", err)
+
+	sequenceIDCount, err := marshalUtil.ReadUint64()
+	if err != nil {
+		err = xerrors.Errorf("failed to SequenceID count from MarshalUtil (%v): %w", err, cerrors.ErrFatal)
 		return
+	}
+	for i := uint64(0); i < sequenceIDCount; i++ {
+		currentSequenceID, sequenceIDErr := SequenceIDFromMarshalUtil(marshalUtil)
+		if sequenceIDErr != nil {
+			err = xerrors.Errorf("failed to parse SequenceID from MarshalUtil: %w", sequenceIDErr)
+			return
+		}
+
+		mapping.sequenceIDs.Set(currentSequenceID, types.Void)
 	}
 
 	return
@@ -516,8 +609,45 @@ func (s *SequenceAliasMapping) SequenceAlias() (sequenceAlias SequenceAlias) {
 }
 
 // SequenceID returns the SequenceID of the SequenceAliasMapping.
-func (s *SequenceAliasMapping) SequenceID() (sequenceID SequenceID) {
-	return s.sequenceID
+func (s *SequenceAliasMapping) SequenceID(referencedMarkers *Markers) (sequenceID SequenceID) {
+	s.sequenceIDs.ForEachReverse(func(key, value interface{}) bool {
+		if _, exists := referencedMarkers.Get(key.(SequenceID)); exists {
+			sequenceID = key.(SequenceID)
+			return false
+		}
+
+		return true
+	})
+
+	if sequenceID != 0 {
+		return
+	}
+
+	lastSequenceID, _, _ := s.sequenceIDs.Tail()
+	sequenceID = lastSequenceID.(SequenceID)
+
+	return
+}
+
+// RegisterMapping adds a mapping to a new SequenceID from the current SequenceAlias.
+func (s *SequenceAliasMapping) RegisterMapping(sequenceID SequenceID) (updated bool) {
+	if updated = s.sequenceIDs.Set(sequenceID, types.Void); updated {
+		s.SetModified()
+	}
+
+	return
+}
+
+// UnregisterMapping removed a mapping to a SequenceID from the current SequenceAlias.
+func (s *SequenceAliasMapping) UnregisterMapping(sequenceID SequenceID) (updated, emptied bool) {
+	if updated = s.sequenceIDs.Delete(sequenceID); !updated {
+		return
+	}
+
+	s.SetModified()
+	emptied = s.sequenceIDs.Size() == 0
+
+	return
 }
 
 // Bytes returns a marshaled version of the SequenceAliasMapping.
@@ -526,9 +656,16 @@ func (s *SequenceAliasMapping) Bytes() (marshaledSequenceAliasMapping []byte) {
 }
 
 func (s *SequenceAliasMapping) String() string {
+	sequenceIDs := make(SequenceIDs)
+	s.sequenceIDs.ForEach(func(key, value interface{}) bool {
+		sequenceIDs[key.(SequenceID)] = value.(types.Empty)
+
+		return true
+	})
+
 	return stringify.Struct("SequenceAliasMapping",
 		stringify.StructField("sequenceAlias", s.sequenceAlias),
-		stringify.StructField("sequenceID", s.sequenceID),
+		stringify.StructField("sequenceIDs", sequenceIDs),
 	)
 }
 
@@ -546,7 +683,15 @@ func (s *SequenceAliasMapping) ObjectStorageKey() (objectStorageKey []byte) {
 // ObjectStorageValue marshals the Transaction into a sequence of bytes. The ID is not serialized here as it is only
 // used as a key in the object storage.
 func (s *SequenceAliasMapping) ObjectStorageValue() (objectStorageValue []byte) {
-	return s.sequenceID.Bytes()
+	marshalUtil := marshalutil.New()
+	marshalUtil.WriteUint64(uint64(s.sequenceIDs.Size()))
+
+	s.sequenceIDs.ForEach(func(key, _ interface{}) bool {
+		marshalUtil.Write(key.(SequenceID))
+		return true
+	})
+
+	return marshalUtil.Bytes()
 }
 
 // code contract (make sure the type implements all required methods)

--- a/packages/markers/structuredetails.go
+++ b/packages/markers/structuredetails.go
@@ -15,7 +15,9 @@ import (
 // to interact with the public API of this package.
 type StructureDetails struct {
 	Rank                     uint64
+	PastMarkerGap            uint64
 	IsPastMarker             bool
+	SequenceID               SequenceID
 	PastMarkers              *Markers
 	FutureMarkers            *Markers
 	futureMarkersUpdateMutex sync.Mutex
@@ -34,7 +36,7 @@ func StructureDetailsFromBytes(markersBytes []byte) (markersPair *StructureDetai
 }
 
 // StructureDetailsFromMarshalUtil unmarshals a StructureDetails using a MarshalUtil (for easier unmarshaling).
-func StructureDetailsFromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (markersPair *StructureDetails, err error) {
+func StructureDetailsFromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (structureDetails *StructureDetails, err error) {
 	detailsExist, err := marshalUtil.ReadBool()
 	if err != nil {
 		err = xerrors.Errorf("failed to parse exists flag (%v): %w", err, cerrors.ErrParseBytesFailed)
@@ -44,20 +46,28 @@ func StructureDetailsFromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (mark
 		return
 	}
 
-	markersPair = &StructureDetails{}
-	if markersPair.Rank, err = marshalUtil.ReadUint64(); err != nil {
+	structureDetails = &StructureDetails{}
+	if structureDetails.Rank, err = marshalUtil.ReadUint64(); err != nil {
 		err = xerrors.Errorf("failed to parse Rank (%v): %w", err, cerrors.ErrParseBytesFailed)
 		return
 	}
-	if markersPair.IsPastMarker, err = marshalUtil.ReadBool(); err != nil {
+	if structureDetails.PastMarkerGap, err = marshalUtil.ReadUint64(); err != nil {
+		err = xerrors.Errorf("failed to parse PastMarkerGap (%v): %w", err, cerrors.ErrParseBytesFailed)
+		return
+	}
+	if structureDetails.IsPastMarker, err = marshalUtil.ReadBool(); err != nil {
 		err = xerrors.Errorf("failed to parse IsPastMarker (%v): %w", err, cerrors.ErrParseBytesFailed)
 		return
 	}
-	if markersPair.PastMarkers, err = FromMarshalUtil(marshalUtil); err != nil {
+	if structureDetails.SequenceID, err = SequenceIDFromMarshalUtil(marshalUtil); err != nil {
+		err = xerrors.Errorf("failed to parse SequenceID from MarshalUtil: %w", err)
+		return
+	}
+	if structureDetails.PastMarkers, err = FromMarshalUtil(marshalUtil); err != nil {
 		err = xerrors.Errorf("failed to parse PastMarkers from MarshalUtil: %w", err)
 		return
 	}
-	if markersPair.FutureMarkers, err = FromMarshalUtil(marshalUtil); err != nil {
+	if structureDetails.FutureMarkers, err = FromMarshalUtil(marshalUtil); err != nil {
 		err = xerrors.Errorf("failed to parse FutureMarkers from MarshalUtil: %w", err)
 		return
 	}
@@ -69,7 +79,9 @@ func StructureDetailsFromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (mark
 func (m *StructureDetails) Clone() (clone *StructureDetails) {
 	return &StructureDetails{
 		Rank:          m.Rank,
+		PastMarkerGap: m.PastMarkerGap,
 		IsPastMarker:  m.IsPastMarker,
+		SequenceID:    m.SequenceID,
 		PastMarkers:   m.PastMarkers.Clone(),
 		FutureMarkers: m.FutureMarkers.Clone(),
 	}
@@ -84,7 +96,9 @@ func (m *StructureDetails) Bytes() (marshaledStructureDetails []byte) {
 	return marshalutil.New().
 		WriteBool(true).
 		WriteUint64(m.Rank).
+		WriteUint64(m.PastMarkerGap).
 		WriteBool(m.IsPastMarker).
+		Write(m.SequenceID).
 		Write(m.PastMarkers).
 		Write(m.FutureMarkers).
 		Bytes()
@@ -94,7 +108,9 @@ func (m *StructureDetails) Bytes() (marshaledStructureDetails []byte) {
 func (m *StructureDetails) String() (humanReadableStructureDetails string) {
 	return stringify.Struct("StructureDetails",
 		stringify.StructField("Rank", m.Rank),
+		stringify.StructField("PastMarkerGap", m.PastMarkerGap),
 		stringify.StructField("IsPastMarker", m.IsPastMarker),
+		stringify.StructField("SequenceID", m.SequenceID),
 		stringify.StructField("PastMarkers", m.PastMarkers),
 		stringify.StructField("FutureMarkers", m.FutureMarkers),
 	)

--- a/packages/tangle/booker_test.go
+++ b/packages/tangle/booker_test.go
@@ -1,6 +1,7 @@
 package tangle
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
@@ -540,54 +541,64 @@ func TestScenario_2(t *testing.T) {
 		structureDetails := make(map[MessageID]*markers.StructureDetails)
 		structureDetails[messages["1"].ID()] = &markers.StructureDetails{
 			Rank:          1,
+			SequenceID:    1,
 			IsPastMarker:  true,
 			PastMarkers:   markers.NewMarkers(markers.NewMarker(1, 1)),
 			FutureMarkers: markers.NewMarkers(markers.NewMarker(1, 2), markers.NewMarker(3, 2)),
 		}
 		structureDetails[messages["2"].ID()] = &markers.StructureDetails{
 			Rank:          2,
+			SequenceID:    1,
 			IsPastMarker:  true,
 			PastMarkers:   markers.NewMarkers(markers.NewMarker(1, 2)),
 			FutureMarkers: markers.NewMarkers(markers.NewMarker(1, 3), markers.NewMarker(2, 3)),
 		}
 		structureDetails[messages["3"].ID()] = &markers.StructureDetails{
 			Rank:          3,
+			SequenceID:    1,
 			IsPastMarker:  true,
 			PastMarkers:   markers.NewMarkers(markers.NewMarker(1, 3)),
 			FutureMarkers: markers.NewMarkers(),
 		}
 		structureDetails[messages["4"].ID()] = &markers.StructureDetails{
 			Rank:          2,
+			SequenceID:    1,
+			PastMarkerGap: 1,
 			IsPastMarker:  false,
 			PastMarkers:   markers.NewMarkers(markers.NewMarker(1, 1)),
 			FutureMarkers: markers.NewMarkers(markers.NewMarker(3, 2)),
 		}
 		structureDetails[messages["5"].ID()] = &markers.StructureDetails{
 			Rank:          3,
+			SequenceID:    2,
 			IsPastMarker:  true,
 			PastMarkers:   markers.NewMarkers(markers.NewMarker(2, 3)),
 			FutureMarkers: markers.NewMarkers(markers.NewMarker(2, 4)),
 		}
 		structureDetails[messages["6"].ID()] = &markers.StructureDetails{
 			Rank:          4,
+			SequenceID:    2,
 			IsPastMarker:  true,
 			PastMarkers:   markers.NewMarkers(markers.NewMarker(2, 4)),
 			FutureMarkers: markers.NewMarkers(),
 		}
 		structureDetails[messages["7"].ID()] = &markers.StructureDetails{
 			Rank:          3,
+			SequenceID:    3,
 			IsPastMarker:  true,
 			PastMarkers:   markers.NewMarkers(markers.NewMarker(3, 2)),
 			FutureMarkers: markers.NewMarkers(markers.NewMarker(3, 3), markers.NewMarker(4, 3)),
 		}
 		structureDetails[messages["8"].ID()] = &markers.StructureDetails{
 			Rank:          4,
+			SequenceID:    3,
 			IsPastMarker:  true,
 			PastMarkers:   markers.NewMarkers(markers.NewMarker(3, 3)),
 			FutureMarkers: markers.NewMarkers(),
 		}
 		structureDetails[messages["9"].ID()] = &markers.StructureDetails{
 			Rank:          4,
+			SequenceID:    4,
 			IsPastMarker:  true,
 			PastMarkers:   markers.NewMarkers(markers.NewMarker(4, 3)),
 			FutureMarkers: markers.NewMarkers(),
@@ -884,6 +895,40 @@ func TestScenario_3(t *testing.T) {
 	txBranchID, err = transactionBranchID(tangle, transactions["2"].ID())
 	require.NoError(t, err)
 	assert.Equal(t, branches["purple"], txBranchID)
+}
+
+func TestBookerNewAutomaticSequence(t *testing.T) {
+	tangle := New()
+	defer tangle.Shutdown()
+
+	testFramework := NewMessageTestFramework(tangle)
+
+	tangle.Setup()
+
+	testFramework.CreateMessage("Message1", WithStrongParents("Genesis"))
+	testFramework.CreateMessage("Message2", WithStrongParents("Message1"))
+	testFramework.IssueMessages("Message1", "Message2").WaitMessagesBooked()
+
+	messageAliases := []string{"Message1"}
+	for i := 0; i < 320; i++ {
+		parentMessageAlias := messageAliases[i]
+		currentMessageAlias := "Message" + strconv.Itoa(i+3)
+		messageAliases = append(messageAliases, currentMessageAlias)
+		testFramework.CreateMessage(currentMessageAlias, WithStrongParents(parentMessageAlias))
+		testFramework.IssueMessages(currentMessageAlias)
+		testFramework.WaitMessagesBooked()
+	}
+
+	assert.True(t, tangle.Storage.MessageMetadata(testFramework.Message("Message309").ID()).Consume(func(messageMetadata *MessageMetadata) {
+		assert.Equal(t, &markers.StructureDetails{
+			Rank:          308,
+			PastMarkerGap: 0,
+			IsPastMarker:  true,
+			SequenceID:    2,
+			PastMarkers:   markers.NewMarkers(markers.NewMarker(2, 9)),
+			FutureMarkers: markers.NewMarkers(markers.NewMarker(2, 10)),
+		}, messageMetadata.StructureDetails())
+	}))
 }
 
 func TestBookerMarkerMappings(t *testing.T) {

--- a/packages/tangle/consensusmanager.go
+++ b/packages/tangle/consensusmanager.go
@@ -20,7 +20,6 @@ func NewConsensusManager(tangle *Tangle) (opinionFormer *ConsensusManager) {
 	opinionFormer = &ConsensusManager{
 		Events: &ConsensusManagerEvents{
 			MessageOpinionFormed: events.NewEvent(MessageIDCaller),
-			TransactionConfirmed: events.NewEvent(MessageIDCaller),
 		},
 
 		tangle: tangle,
@@ -98,9 +97,6 @@ func (o *ConsensusManager) SetTransactionLiked(transactionID ledgerstate.Transac
 type ConsensusManagerEvents struct {
 	// Fired when an opinion of a message is formed.
 	MessageOpinionFormed *events.Event
-
-	// Fired when a transaction gets confirmed.
-	TransactionConfirmed *events.Event
 }
 
 // endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/packages/tangle/ledgerstate.go
+++ b/packages/tangle/ledgerstate.go
@@ -14,7 +14,7 @@ import (
 type LedgerState struct {
 	tangle    *Tangle
 	BranchDAG *ledgerstate.BranchDAG
-	utxoDAG   *ledgerstate.UTXODAG
+	UTXODAG   *ledgerstate.UTXODAG
 }
 
 // NewLedgerState is the constructor of the LedgerState component.
@@ -23,13 +23,13 @@ func NewLedgerState(tangle *Tangle) (ledgerState *LedgerState) {
 	return &LedgerState{
 		tangle:    tangle,
 		BranchDAG: branchDAG,
-		utxoDAG:   ledgerstate.NewUTXODAG(tangle.Options.Store, branchDAG),
+		UTXODAG:   ledgerstate.NewUTXODAG(tangle.Options.Store, branchDAG),
 	}
 }
 
 // Shutdown shuts down the LedgerState and persists its state.
 func (l *LedgerState) Shutdown() {
-	l.utxoDAG.Shutdown()
+	l.UTXODAG.Shutdown()
 	l.BranchDAG.Shutdown()
 }
 
@@ -66,7 +66,7 @@ func (l *LedgerState) InheritBranch(referencedBranchIDs ledgerstate.BranchIDs) (
 // TransactionValid performs some fast checks of the Transaction and triggers a MessageInvalid event if the checks do
 // not pass.
 func (l *LedgerState) TransactionValid(transaction *ledgerstate.Transaction, messageID MessageID) (err error) {
-	if err = l.utxoDAG.CheckTransaction(transaction); err != nil {
+	if err = l.UTXODAG.CheckTransaction(transaction); err != nil {
 		l.tangle.Storage.MessageMetadata(messageID).Consume(func(messagemetadata *MessageMetadata) {
 			messagemetadata.SetInvalid(true)
 		})
@@ -85,18 +85,18 @@ func (l *LedgerState) TransactionConflicting(transactionID ledgerstate.Transacti
 
 // TransactionMetadata retrieves the TransactionMetadata with the given TransactionID from the object storage.
 func (l *LedgerState) TransactionMetadata(transactionID ledgerstate.TransactionID) (cachedTransactionMetadata *ledgerstate.CachedTransactionMetadata) {
-	return l.utxoDAG.TransactionMetadata(transactionID)
+	return l.UTXODAG.TransactionMetadata(transactionID)
 }
 
 // Transaction retrieves the Transaction with the given TransactionID from the object storage.
 func (l *LedgerState) Transaction(transactionID ledgerstate.TransactionID) *ledgerstate.CachedTransaction {
-	return l.utxoDAG.Transaction(transactionID)
+	return l.UTXODAG.Transaction(transactionID)
 }
 
 // BookTransaction books the given Transaction into the underlying LedgerState and returns the target Branch and an
 // eventual error.
 func (l *LedgerState) BookTransaction(transaction *ledgerstate.Transaction, messageID MessageID) (targetBranch ledgerstate.BranchID, err error) {
-	targetBranch, err = l.utxoDAG.BookTransaction(transaction)
+	targetBranch, err = l.UTXODAG.BookTransaction(transaction)
 	if err != nil {
 		if !xerrors.Is(err, ledgerstate.ErrTransactionInvalid) && !xerrors.Is(err, ledgerstate.ErrTransactionNotSolid) {
 			err = xerrors.Errorf("failed to book Transaction: %w", err)
@@ -137,7 +137,7 @@ func (l *LedgerState) ConflictSet(transactionID ledgerstate.TransactionID) (conf
 // TransactionInclusionState returns the InclusionState of the Transaction with the given TransactionID which can either be
 // Pending, Confirmed or Rejected.
 func (l *LedgerState) TransactionInclusionState(transactionID ledgerstate.TransactionID) (ledgerstate.InclusionState, error) {
-	return l.utxoDAG.InclusionState(transactionID)
+	return l.UTXODAG.InclusionState(transactionID)
 }
 
 // BranchInclusionState returns the InclusionState of the Branch with the given BranchID which can either be
@@ -151,7 +151,7 @@ func (l *LedgerState) BranchInclusionState(branchID ledgerstate.BranchID) (inclu
 
 // BranchID returns the branchID of the given transactionID.
 func (l *LedgerState) BranchID(transactionID ledgerstate.TransactionID) (branchID ledgerstate.BranchID) {
-	l.utxoDAG.TransactionMetadata(transactionID).Consume(func(transactionMetadata *ledgerstate.TransactionMetadata) {
+	l.UTXODAG.TransactionMetadata(transactionID).Consume(func(transactionMetadata *ledgerstate.TransactionMetadata) {
 		branchID = transactionMetadata.BranchID()
 	})
 	return
@@ -159,7 +159,7 @@ func (l *LedgerState) BranchID(transactionID ledgerstate.TransactionID) (branchI
 
 // LoadSnapshot creates a set of outputs in the UTXO-DAG, that are forming the genesis for future transactions.
 func (l *LedgerState) LoadSnapshot(snapshot *ledgerstate.Snapshot) {
-	l.utxoDAG.LoadSnapshot(snapshot)
+	l.UTXODAG.LoadSnapshot(snapshot)
 	for txID := range snapshot.Transactions {
 		attachment, _ := l.tangle.Storage.StoreAttachment(txID, EmptyMessageID)
 		if attachment != nil {
@@ -174,17 +174,17 @@ func (l *LedgerState) LoadSnapshot(snapshot *ledgerstate.Snapshot) {
 
 // Output returns the Output with the given ID.
 func (l *LedgerState) Output(outputID ledgerstate.OutputID) *ledgerstate.CachedOutput {
-	return l.utxoDAG.Output(outputID)
+	return l.UTXODAG.Output(outputID)
 }
 
 // OutputMetadata returns the OutputMetadata with the given ID.
 func (l *LedgerState) OutputMetadata(outputID ledgerstate.OutputID) *ledgerstate.CachedOutputMetadata {
-	return l.utxoDAG.OutputMetadata(outputID)
+	return l.UTXODAG.OutputMetadata(outputID)
 }
 
 // OutputsOnAddress retrieves all the Outputs that are associated with an address.
 func (l *LedgerState) OutputsOnAddress(address ledgerstate.Address) (cachedOutputs ledgerstate.CachedOutputs) {
-	l.utxoDAG.AddressOutputMapping(address).Consume(func(addressOutputMapping *ledgerstate.AddressOutputMapping) {
+	l.UTXODAG.AddressOutputMapping(address).Consume(func(addressOutputMapping *ledgerstate.AddressOutputMapping) {
 		cachedOutputs = append(cachedOutputs, l.Output(addressOutputMapping.OutputID()))
 	})
 	return
@@ -192,17 +192,17 @@ func (l *LedgerState) OutputsOnAddress(address ledgerstate.Address) (cachedOutpu
 
 // CheckTransaction contains fast checks that have to be performed before booking a Transaction.
 func (l *LedgerState) CheckTransaction(transaction *ledgerstate.Transaction) (err error) {
-	return l.utxoDAG.CheckTransaction(transaction)
+	return l.UTXODAG.CheckTransaction(transaction)
 }
 
 // ConsumedOutputs returns the consumed (cached)Outputs of the given Transaction.
 func (l *LedgerState) ConsumedOutputs(transaction *ledgerstate.Transaction) (cachedInputs ledgerstate.CachedOutputs) {
-	return l.utxoDAG.ConsumedOutputs(transaction)
+	return l.UTXODAG.ConsumedOutputs(transaction)
 }
 
 // Consumers returns the (cached) consumers of the given outputID.
 func (l *LedgerState) Consumers(outputID ledgerstate.OutputID) (cachedTransactions ledgerstate.CachedConsumers) {
-	return l.utxoDAG.Consumers(outputID)
+	return l.UTXODAG.Consumers(outputID)
 }
 
 // endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/packages/tangle/orderer.go
+++ b/packages/tangle/orderer.go
@@ -108,7 +108,7 @@ func (o *Orderer) run() {
 
 // scheduleUntil schedules messages in stored buckets from lastScheduledBucket until the given bucketTime + allowedFutureBookingSeconds.
 func (o *Orderer) scheduleUntil(bucketTime int64) {
-	for ; o.lastScheduledBucket <= bucketTime+allowedFutureBookingSeconds; o.lastScheduledBucket += bucketGranularity {
+	for ; o.lastScheduledBucket < bucketTime+allowedFutureBookingSeconds; o.lastScheduledBucket += bucketGranularity {
 		o.tangle.Storage.BucketMessageIDs(o.lastScheduledBucket).Consume(func(bucketMessageID *BucketMessageID) {
 			o.Events.MessageOrdered.Trigger(bucketMessageID.MessageID())
 		})

--- a/packages/tangle/orderer.go
+++ b/packages/tangle/orderer.go
@@ -1,0 +1,245 @@
+package tangle
+
+import (
+	"time"
+
+	"github.com/iotaledger/hive.go/byteutils"
+	"github.com/iotaledger/hive.go/cerrors"
+	"github.com/iotaledger/hive.go/events"
+	"github.com/iotaledger/hive.go/marshalutil"
+	"github.com/iotaledger/hive.go/objectstorage"
+	"github.com/iotaledger/hive.go/stringify"
+	"golang.org/x/xerrors"
+)
+
+const (
+	allowedFutureBooking = 10 * time.Minute
+	bucketGranularity    = 60
+)
+
+type Orderer struct {
+	Events *OrdererEvents
+
+	tangle *Tangle
+}
+
+func NewOrderer(tangle *Tangle) (orderer *Orderer) {
+	orderer = &Orderer{
+		Events: &OrdererEvents{
+			MessageOrdered: events.NewEvent(MessageIDCaller),
+		},
+		tangle: tangle,
+	}
+
+	return
+}
+
+func (o *Orderer) Setup() {
+	o.tangle.Solidifier.Events.MessageSolid.Attach(events.NewClosure(o.Order))
+
+}
+
+func (o *Orderer) Shutdown() {
+
+}
+
+func (o *Orderer) Order(messageID MessageID) {
+	o.tangle.Storage.Message(messageID).Consume(func(message *Message) {
+		if o.tangle.TimeManager.IsGenesis() || message.IssuingTime().Before(o.tangle.TimeManager.Time().Add(allowedFutureBooking)) {
+			// messages can be scheduled directly
+			o.Events.MessageOrdered.Trigger(messageID)
+			return
+		}
+
+		// store message in corresponding bucket
+		o.tangle.Storage.StoreBucketMessageID(o.bucketTime(message.IssuingTime()), messageID)
+	})
+}
+
+func (o *Orderer) run() {
+
+}
+
+func (o *Orderer) bucketTime(t time.Time) int64 {
+	return t.Unix() / bucketGranularity * bucketGranularity
+}
+
+// region OrdererEvents ////////////////////////////////////////////////////////////////////////////////////////////////
+
+// OrdererEvents represents events happening in the Orderer.
+type OrdererEvents struct {
+	// MessageOrdered is triggered when a message is ordered and thus ready to be scheduled.
+	MessageOrdered *events.Event
+}
+
+// endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// region BucketMessageID //////////////////////////////////////////////////////////////////////////////////////////////
+
+// BucketMessageIDPartitionKeys defines the "layout" of the key. This enables prefix iterations in the object
+// storage.
+var BucketMessageIDPartitionKeys = objectstorage.PartitionKey(marshalutil.Int64Size, MessageIDLength)
+
+// BucketMessageID is a data structure that maps a time bucket to a MessageID.
+type BucketMessageID struct {
+	bucketTime int64
+	messageID  MessageID
+
+	objectstorage.StorableObjectFlags
+}
+
+// NewBucketMessageID creates a new BucketMessageID.
+func NewBucketMessageID(bucketTime int64, messageID MessageID) (bucketMessageID *BucketMessageID) {
+	bucketMessageID = &BucketMessageID{
+		bucketTime: bucketTime,
+		messageID:  messageID,
+	}
+
+	return
+}
+
+// BucketMessageIDFromBytes unmarshals a BucketMessageID object from a sequence of bytes.
+func BucketMessageIDFromBytes(bytes []byte) (bucketMessageID *BucketMessageID, consumedBytes int, err error) {
+	marshalUtil := marshalutil.New(bytes)
+	if bucketMessageID, err = BucketMessageIDFromMarshalUtil(marshalUtil); err != nil {
+		err = xerrors.Errorf("failed to parse BucketMessageID from MarshalUtil: %w", err)
+		return
+	}
+	consumedBytes = marshalUtil.ReadOffset()
+
+	return
+}
+
+// BucketMessageIDFromMarshalUtil unmarshals a BucketMessageID object using a MarshalUtil (for easier unmarshaling).
+func BucketMessageIDFromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (bucketMessageID *BucketMessageID, err error) {
+	bucketMessageID = &BucketMessageID{}
+
+	if bucketMessageID.bucketTime, err = marshalUtil.ReadInt64(); err != nil {
+		err = xerrors.Errorf("failed to parse bucket time (%v): %w", err, cerrors.ErrParseBytesFailed)
+		return
+	}
+
+	if bucketMessageID.messageID, err = MessageIDFromMarshalUtil(marshalUtil); err != nil {
+		err = xerrors.Errorf("failed to parse MessageID from MarshalUtil: %w", err)
+		return
+	}
+
+	return
+}
+
+// BucketMessageIDFromObjectStorage restores a BucketMessageID object from the object storage.
+func BucketMessageIDFromObjectStorage(key, data []byte) (result objectstorage.StorableObject, err error) {
+	if result, _, err = BucketMessageIDFromBytes(byteutils.ConcatBytes(key, data)); err != nil {
+		err = xerrors.Errorf("failed to parse BucketMessageID from bytes: %w", err)
+		return
+	}
+
+	return
+}
+
+// BucketTime returns the time of the bucket.
+func (b *BucketMessageID) BucketTime() (bucketTime int64) {
+	return b.bucketTime
+}
+
+// MessageID returns the MessageID that belongs to the bucket time.
+func (b *BucketMessageID) MessageID() (messageID MessageID) {
+	return b.messageID
+}
+
+// Bytes returns a marshaled version of the BucketMessageID.
+func (b *BucketMessageID) Bytes() (marshaledSequenceSupporters []byte) {
+	return byteutils.ConcatBytes(b.ObjectStorageKey(), b.ObjectStorageValue())
+}
+
+// String returns a human readable version of the BucketMessageID.
+func (b *BucketMessageID) String() string {
+	return stringify.Struct("BucketMessageID",
+		stringify.StructField("bucketTime", b.BucketTime()),
+		stringify.StructField("MessageID", b.MessageID()),
+	)
+}
+
+// Update is disabled and panics if it ever gets called - it is required to match the StorableObject interface.
+func (b *BucketMessageID) Update(objectstorage.StorableObject) {
+	panic("updates disabled")
+}
+
+// ObjectStorageKey returns the key that is used to store the object in the database. It is required to match the
+// StorableObject interface.
+func (b *BucketMessageID) ObjectStorageKey() []byte {
+	marshalUtil := marshalutil.New(marshalutil.Int64Size + MessageIDLength)
+
+	return marshalUtil.
+		WriteInt64(b.bucketTime).
+		Write(b.messageID).
+		Bytes()
+}
+
+// ObjectStorageValue marshals the BucketMessageID into a sequence of bytes that are used as the value part in the
+// object storage.
+func (b *BucketMessageID) ObjectStorageValue() (value []byte) {
+	return
+}
+
+// code contract (make sure the struct implements all required methods)
+var _ objectstorage.StorableObject = &BucketMessageID{}
+
+// endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// region CachedBucketMessageID ////////////////////////////////////////////////////////////////////////////////////////
+
+// CachedBucketMessageID is a wrapper for a stored cached object representing a BucketMessageID.
+type CachedBucketMessageID struct {
+	objectstorage.CachedObject
+}
+
+// Unwrap unwraps the CachedBucketMessageID into the underlying BucketMessageID.
+// If stored object cannot be cast into a BucketMessageID or has been deleted, it returns nil.
+func (c *CachedBucketMessageID) Unwrap() *BucketMessageID {
+	untypedObject := c.Get()
+	if untypedObject == nil {
+		return nil
+	}
+
+	typedObject := untypedObject.(*BucketMessageID)
+	if typedObject == nil || typedObject.IsDeleted() {
+		return nil
+	}
+
+	return typedObject
+}
+
+// Consume consumes the CachedBucketMessageID.
+// It releases the object when the callback is done.
+// It returns true if the callback was called.
+func (c *CachedBucketMessageID) Consume(consumer func(bucketMessageID *BucketMessageID), forceRelease ...bool) (consumed bool) {
+	return c.CachedObject.Consume(func(object objectstorage.StorableObject) {
+		consumer(object.(*BucketMessageID))
+	}, forceRelease...)
+}
+
+// String returns a human readable version of the CachedBucketMessageID.
+func (c *CachedBucketMessageID) String() string {
+	return stringify.Struct("CachedBucketMessageID",
+		stringify.StructField("CachedObject", c.Unwrap()),
+	)
+}
+
+// CachedBucketMessageIDs represents a collection of CachedBucketMessageID.
+type CachedBucketMessageIDs []*CachedBucketMessageID
+
+// Consume iterates over the CachedObjects, unwraps them and passes a type-casted version to the consumer (if the object
+// is not empty - it exists). It automatically releases the object when the consumer finishes. It returns true, if at
+// least one object was consumed.
+func (cachedBucketMessageIDs CachedBucketMessageIDs) Consume(consumer func(bucketMessageID *BucketMessageID)) (consumed bool) {
+	for _, cachedBucketMessageID := range cachedBucketMessageIDs {
+		consumed = cachedBucketMessageID.Consume(func(output *BucketMessageID) {
+			consumer(output)
+		}) || consumed
+	}
+
+	return
+}
+
+// endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/packages/tangle/orderer_test.go
+++ b/packages/tangle/orderer_test.go
@@ -1,0 +1,84 @@
+package tangle
+
+import (
+	"testing"
+	"time"
+
+	"github.com/iotaledger/hive.go/crypto/ed25519"
+	"github.com/iotaledger/hive.go/identity"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotaledger/goshimmer/packages/clock"
+	"github.com/iotaledger/goshimmer/packages/epochs"
+)
+
+func TestBucketMessageIDMarshalling(t *testing.T) {
+	bucketMessageID := NewBucketMessageID(1234, randomMessageID())
+
+	bucketMessageIDFromBytes, _, err := BucketMessageIDFromBytes(bucketMessageID.Bytes())
+	require.NoError(t, err)
+
+	assert.Equal(t, bucketMessageID.Bytes(), bucketMessageIDFromBytes.Bytes())
+	assert.Equal(t, bucketMessageID.BucketTime(), bucketMessageIDFromBytes.BucketTime())
+	assert.Equal(t, bucketMessageID.MessageID(), bucketMessageIDFromBytes.MessageID())
+}
+
+func TestOrderer_Order(t *testing.T) {
+	keyPair := ed25519.GenerateKeyPair()
+
+	manaRetrieverMock := func(t time.Time) map[identity.ID]float64 {
+		return map[identity.ID]float64{
+			identity.NewID(keyPair.PublicKey): 100,
+		}
+	}
+	manager := epochs.NewManager(epochs.ManaRetriever(manaRetrieverMock), epochs.CacheTime(0))
+
+	tangle := New(ApprovalWeights(WeightProviderFromEpochsManager(manager)))
+	defer tangle.Shutdown()
+
+	testFramework := NewMessageTestFramework(
+		tangle,
+		WithGenesisOutput("A", 500),
+	)
+	tangle.Setup()
+
+	time1 := clock.SyncedTime().Add(-18 * time.Minute)
+	{
+		testFramework.CreateMessage("Message1", WithStrongParents("Genesis"), WithIssuingTime(time1), WithIssuer(keyPair.PublicKey))
+		testFramework.IssueMessages("Message1").WaitApprovalWeightProcessed()
+
+		assert.True(t, testFramework.MessageMetadata("Message1").IsBooked())
+		assert.Equal(t, time1, tangle.TimeManager.Time())
+	}
+
+	// issue message in time
+	time2 := time1.Add(2 * time.Minute)
+	{
+		testFramework.CreateMessage("Message2", WithStrongParents("Message1"), WithIssuingTime(time2), WithIssuer(keyPair.PublicKey))
+		testFramework.IssueMessages("Message2").WaitApprovalWeightProcessed()
+
+		assert.True(t, testFramework.MessageMetadata("Message2").IsBooked())
+		assert.Equal(t, time2, tangle.TimeManager.Time())
+	}
+
+	// issue message too far in the future of TangleTime
+	time3 := time2.Add(12 * time.Minute)
+	{
+		testFramework.CreateMessage("Message3", WithStrongParents("Message2"), WithIssuingTime(time3), WithIssuer(keyPair.PublicKey))
+		testFramework.IssueMessages("Message3")
+
+		assert.False(t, testFramework.MessageMetadata("Message3").IsBooked())
+		assert.Equal(t, time2, tangle.TimeManager.Time())
+
+		expectedBucketTime := tangle.Orderer.bucketTime(time3)
+		cachedBucketMessageIDs := tangle.Storage.BucketMessageIDs(expectedBucketTime)
+		assert.Len(t, cachedBucketMessageIDs, 1)
+
+		cachedBucketMessageIDs.Consume(func(bucketMessageID *BucketMessageID) {
+			assert.Equal(t, bucketMessageID.BucketTime(), expectedBucketTime)
+			assert.Equal(t, bucketMessageID.MessageID(), testFramework.MessageMetadata("Message3").ID())
+		})
+
+	}
+}

--- a/packages/tangle/orderer_test.go
+++ b/packages/tangle/orderer_test.go
@@ -98,3 +98,78 @@ func TestOrderer_Order(t *testing.T) {
 		return testFramework.MessageMetadata("Message3").IsBooked()
 	}, 10*time.Second, 500*time.Millisecond, "Message %s not booked in time.", testFramework.MessageMetadata("Message3").ID())
 }
+
+func TestOrderer(t *testing.T) {
+	nodes := map[string]ed25519.PublicKey{
+		"A": ed25519.GenerateKeyPair().PublicKey,
+		"B": ed25519.GenerateKeyPair().PublicKey,
+	}
+
+	manaRetrieverMock := func(t time.Time) map[identity.ID]float64 {
+		return map[identity.ID]float64{
+			identity.NewID(nodes["A"]): 33,
+			identity.NewID(nodes["B"]): 67,
+		}
+	}
+	manager := epochs.NewManager(epochs.ManaRetriever(manaRetrieverMock), epochs.CacheTime(0))
+
+	tangle := New(ApprovalWeights(WeightProviderFromEpochsManager(manager)), GenesisNode(nodes["B"].String()))
+	defer tangle.Shutdown()
+
+	testFramework := NewMessageTestFramework(
+		tangle,
+		WithGenesisOutput("A", 500),
+	)
+	tangle.Setup()
+
+	time1 := time.Unix(1618034400, 0) // 2021-04-10 06:00:00
+	{
+		testFramework.CreateMessage("Message1", WithStrongParents("Genesis"), WithIssuingTime(time1), WithIssuer(nodes["B"]))
+		testFramework.IssueMessages("Message1").WaitApprovalWeightProcessed()
+
+		assert.True(t, testFramework.MessageMetadata("Message1").IsBooked())
+		assert.Equal(t, time1, tangle.TimeManager.Time())
+	}
+
+	// issue chain of messages (not enough approval weight)
+	time2 := time1.Add(9 * time.Minute)
+	{
+		testFramework.CreateMessage("Message2", WithStrongParents("Message1"), WithIssuingTime(time2), WithIssuer(nodes["A"]))
+		testFramework.IssueMessages("Message2").WaitApprovalWeightProcessed()
+
+		assert.True(t, testFramework.MessageMetadata("Message2").IsBooked())
+		assert.Equal(t, time1, tangle.TimeManager.Time())
+	}
+	{
+		testFramework.PreventNewMarkers(true)
+		time3 := time2.Add(12 * time.Minute)
+		testFramework.CreateMessage("Message3", WithStrongParents("Message2"), WithIssuingTime(time3), WithIssuer(nodes["A"]))
+		testFramework.IssueMessages("Message3")
+		testFramework.PreventNewMarkers(false)
+
+		assert.False(t, testFramework.MessageMetadata("Message3").IsBooked())
+		assert.Equal(t, time1, tangle.TimeManager.Time())
+	}
+
+	time4 := time2.Add(59 * time.Second)
+	{
+		testFramework.CreateMessage("Message4", WithStrongParents("Message1", "Message2"), WithIssuingTime(time4), WithIssuer(nodes["B"]))
+		testFramework.IssueMessages("Message4")
+
+		assert.Eventuallyf(t, func() bool {
+			return testFramework.MessageMetadata("Message4").IsBooked()
+		}, 5*time.Second, 200*time.Millisecond, "Message4 not booked in time.")
+		assert.Equal(t, time4, tangle.TimeManager.Time())
+	}
+
+	// Message3 should now be booked too
+	time5 := time4.Add(5 * time.Minute)
+	{
+		testFramework.CreateMessage("Message5", WithStrongParents("Message4"), WithIssuingTime(time5), WithIssuer(nodes["B"]))
+		testFramework.IssueMessages("Message5").WaitApprovalWeightProcessed()
+
+		assert.True(t, testFramework.MessageMetadata("Message3").IsBooked())
+		assert.True(t, testFramework.MessageMetadata("Message5").IsBooked())
+		assert.Equal(t, time5, tangle.TimeManager.Time())
+	}
+}

--- a/packages/tangle/scheduler.go
+++ b/packages/tangle/scheduler.go
@@ -1,6 +1,7 @@
 package tangle
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/iotaledger/hive.go/datastructure/set"
@@ -95,6 +96,7 @@ func (s *Scheduler) run() {
 
 func (s *Scheduler) scheduleMessage(messageID MessageID) {
 	if !s.parentsBooked(messageID) {
+		fmt.Println("Parents not booked", messageID)
 		return
 	}
 

--- a/packages/tangle/scheduler.go
+++ b/packages/tangle/scheduler.go
@@ -45,7 +45,7 @@ func NewScheduler(tangle *Tangle) (scheduler *Scheduler) {
 
 // Setup sets up the behavior of the component by making it attach to the relevant events of the other components.
 func (s *Scheduler) Setup() {
-	s.tangle.Solidifier.Events.MessageSolid.Attach(events.NewClosure(s.Schedule))
+	s.tangle.Orderer.Events.MessageOrdered.Attach(events.NewClosure(s.Schedule))
 
 	s.tangle.ConsensusManager.Events.MessageOpinionFormed.Attach(events.NewClosure(func(messageID MessageID) {
 		if s.scheduledMessages.Delete(messageID) {

--- a/packages/tangle/scheduler.go
+++ b/packages/tangle/scheduler.go
@@ -46,7 +46,7 @@ func NewScheduler(tangle *Tangle) (scheduler *Scheduler) {
 
 // Setup sets up the behavior of the component by making it attach to the relevant events of the other components.
 func (s *Scheduler) Setup() {
-	s.tangle.Orderer.Events.MessageOrdered.Attach(events.NewClosure(s.Schedule))
+	s.tangle.Solidifier.Events.MessageSolid.Attach(events.NewClosure(s.Schedule))
 
 	s.tangle.ConsensusManager.Events.MessageOpinionFormed.Attach(events.NewClosure(func(messageID MessageID) {
 		if s.scheduledMessages.Delete(messageID) {

--- a/packages/tangle/scheduler_test.go
+++ b/packages/tangle/scheduler_test.go
@@ -17,6 +17,7 @@ func TestScheduler(t *testing.T) {
 	// setup tangle up till the Scheduler
 	tangle.Storage.Setup()
 	tangle.Solidifier.Setup()
+	tangle.Orderer.Setup()
 	tangle.Scheduler.Setup()
 
 	// testing desired scheduled order: A - B - D - C  (B - A - D - C is equivalent)

--- a/packages/tangle/scheduler_test.go
+++ b/packages/tangle/scheduler_test.go
@@ -17,7 +17,7 @@ func TestScheduler(t *testing.T) {
 	// setup tangle up till the Scheduler
 	tangle.Storage.Setup()
 	tangle.Solidifier.Setup()
-	tangle.Orderer.Setup()
+	//tangle.Orderer.Setup()
 	tangle.Scheduler.Setup()
 
 	// testing desired scheduled order: A - B - D - C  (B - A - D - C is equivalent)

--- a/packages/tangle/solidifier.go
+++ b/packages/tangle/solidifier.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/iotaledger/hive.go/datastructure/walker"
 	"github.com/iotaledger/hive.go/events"
+	"github.com/iotaledger/hive.go/syncutils"
 )
 
 // maxParentsTimeDifference defines the smallest allowed time difference between a child Message and its parents.
@@ -21,6 +22,8 @@ type Solidifier struct {
 	Events *SolidifierEvents
 
 	tangle *Tangle
+
+	triggerMutex syncutils.RWMultiMutex
 }
 
 // NewSolidifier is the constructor of the Solidifier.
@@ -61,6 +64,15 @@ func (s *Solidifier) checkMessageSolidity(message *Message, messageMetadata *Mes
 		return
 	}
 
+	lockBuilder := syncutils.MultiMutexLockBuilder{}
+	lockBuilder.AddLock(messageMetadata.ID())
+	for _, parentMessageID := range message.Parents() {
+		lockBuilder.AddLock(parentMessageID)
+	}
+	lock := lockBuilder.Build()
+
+	s.triggerMutex.Lock(lock...)
+	defer s.triggerMutex.Unlock(lock...)
 	if !messageMetadata.SetSolid(true) {
 		return
 	}

--- a/packages/tangle/storage.go
+++ b/packages/tangle/storage.go
@@ -400,6 +400,25 @@ func (s *Storage) BucketMessageIDs(bucketTime int64) (cachedBucketMessageIDs Cac
 	return
 }
 
+// AllBucketMessageIDsBuckets retrieves all time buckets in bucketMessageIDStorage for debug purposes.
+func (s *Storage) AllBucketMessageIDsBuckets() (buckets []int64, bucketsMap map[int64]int) {
+	bucketsMap = make(map[int64]int)
+	s.bucketMessageIDStorage.ForEach(func(key []byte, cachedObject objectstorage.CachedObject) bool {
+		cachedBucketMessageID := &CachedBucketMessageID{CachedObject: cachedObject}
+		cachedBucketMessageID.Consume(func(bucketMessageID *BucketMessageID) {
+			bucketTime := bucketMessageID.BucketTime()
+			if _, ok := bucketsMap[bucketTime]; !ok {
+				bucketsMap[bucketTime] = 1
+				buckets = append(buckets, bucketTime)
+			} else {
+				bucketsMap[bucketTime]++
+			}
+		})
+		return true
+	})
+	return
+}
+
 func (s *Storage) storeGenesis() {
 	s.MessageMetadata(EmptyMessageID, func() *MessageMetadata {
 		genesisMetadata := &MessageMetadata{

--- a/packages/tangle/tangle.go
+++ b/packages/tangle/tangle.go
@@ -24,11 +24,11 @@ import (
 
 // Tangle is the central data structure of the IOTA protocol.
 type Tangle struct {
-	Options               *Options
-	Parser                *Parser
-	Storage               *Storage
-	Solidifier            *Solidifier
-	Orderer               *Orderer
+	Options    *Options
+	Parser     *Parser
+	Storage    *Storage
+	Solidifier *Solidifier
+	//Orderer               *Orderer
 	Scheduler             *Scheduler
 	Booker                *Booker
 	ApprovalWeightManager *ApprovalWeightManager
@@ -62,7 +62,7 @@ func New(options ...Option) (tangle *Tangle) {
 	tangle.Parser = NewParser()
 	tangle.Storage = NewStorage(tangle)
 	tangle.Solidifier = NewSolidifier(tangle)
-	tangle.Orderer = NewOrderer(tangle)
+	//tangle.Orderer = NewOrderer(tangle)
 	tangle.Scheduler = NewScheduler(tangle)
 	tangle.LedgerState = NewLedgerState(tangle)
 	tangle.Booker = NewBooker(tangle)
@@ -103,7 +103,7 @@ func (t *Tangle) Setup() {
 	t.Storage.Setup()
 	t.Solidifier.Setup()
 	t.Requester.Setup()
-	t.Orderer.Setup()
+	//t.Orderer.Setup()
 	t.Scheduler.Setup()
 	t.Booker.Setup()
 	t.ApprovalWeightManager.Setup()
@@ -188,7 +188,7 @@ func (t *Tangle) Prune() (err error) {
 // Shutdown marks the tangle as stopped, so it will not accept any new messages (waits for all backgroundTasks to finish).
 func (t *Tangle) Shutdown() {
 	t.MessageFactory.Shutdown()
-	t.Orderer.Shutdown()
+	//t.Orderer.Shutdown()
 	t.Scheduler.Shutdown()
 	t.Booker.Shutdown()
 	t.LedgerState.Shutdown()

--- a/packages/tangle/tangle.go
+++ b/packages/tangle/tangle.go
@@ -28,6 +28,7 @@ type Tangle struct {
 	Parser                *Parser
 	Storage               *Storage
 	Solidifier            *Solidifier
+	Orderer               *Orderer
 	Scheduler             *Scheduler
 	Booker                *Booker
 	ApprovalWeightManager *ApprovalWeightManager
@@ -61,6 +62,7 @@ func New(options ...Option) (tangle *Tangle) {
 	tangle.Parser = NewParser()
 	tangle.Storage = NewStorage(tangle)
 	tangle.Solidifier = NewSolidifier(tangle)
+	tangle.Orderer = NewOrderer(tangle)
 	tangle.Scheduler = NewScheduler(tangle)
 	tangle.LedgerState = NewLedgerState(tangle)
 	tangle.Booker = NewBooker(tangle)
@@ -101,6 +103,7 @@ func (t *Tangle) Setup() {
 	t.Storage.Setup()
 	t.Solidifier.Setup()
 	t.Requester.Setup()
+	t.Orderer.Setup()
 	t.Scheduler.Setup()
 	t.Booker.Setup()
 	t.ApprovalWeightManager.Setup()
@@ -185,6 +188,7 @@ func (t *Tangle) Prune() (err error) {
 // Shutdown marks the tangle as stopped, so it will not accept any new messages (waits for all backgroundTasks to finish).
 func (t *Tangle) Shutdown() {
 	t.MessageFactory.Shutdown()
+	t.Orderer.Shutdown()
 	t.Scheduler.Shutdown()
 	t.Booker.Shutdown()
 	t.LedgerState.Shutdown()

--- a/packages/tangle/tangle_test.go
+++ b/packages/tangle/tangle_test.go
@@ -140,7 +140,6 @@ func TestTangle_InvalidParentsAgeMessage(t *testing.T) {
 	messageTangle.Storage.Events.MessageStored.Attach(events.NewClosure(func(messageID MessageID) {
 		fmt.Println("STORED:", messageID)
 		atomic.AddInt32(&storedMessages, 1)
-		wg.Done()
 	}))
 
 	messageTangle.Solidifier.Events.MessageSolid.Attach(events.NewClosure(func(messageID MessageID) {
@@ -148,9 +147,15 @@ func TestTangle_InvalidParentsAgeMessage(t *testing.T) {
 		atomic.AddInt32(&solidMessages, 1)
 	}))
 
+	messageTangle.Booker.Events.MessageBooked.AttachAfter(events.NewClosure(func(messageID MessageID) {
+		fmt.Println("BOOKED:", messageID)
+		wg.Done()
+	}))
+
 	messageTangle.Events.MessageInvalid.Attach(events.NewClosure(func(messageID MessageID) {
 		fmt.Println("INVALID:", messageID)
 		atomic.AddInt32(&invalidMessages, 1)
+		wg.Done()
 	}))
 
 	messageA := newTestDataMessage("some data")

--- a/packages/tangle/tangle_test.go
+++ b/packages/tangle/tangle_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 	"github.com/iotaledger/goshimmer/packages/pow"
 	"github.com/iotaledger/goshimmer/packages/tangle/payload"
 )
@@ -531,7 +532,7 @@ func TestTangle_Flow(t *testing.T) {
 	}))
 
 	// data messages should not trigger this event
-	tangle.ConsensusManager.Events.TransactionConfirmed.Attach(events.NewClosure(func(messageID MessageID) {
+	tangle.LedgerState.UTXODAG.Events.TransactionConfirmed.Attach(events.NewClosure(func(transactionID ledgerstate.TransactionID) {
 		n := atomic.AddInt32(&opinionFormedTransactions, 1)
 		t.Logf("opinion formed transaction %d/%d", n, totalMsgCount)
 	}))

--- a/packages/tangle/testutils.go
+++ b/packages/tangle/testutils.go
@@ -167,6 +167,10 @@ func (m *MessageTestFramework) BranchID(messageAlias string) ledgerstate.BranchI
 
 // createGenesisOutputs initializes the Outputs that are used by the MessageTestFramework as the genesis.
 func (m *MessageTestFramework) createGenesisOutputs() {
+	if len(m.options.genesisOutputs) == 0 {
+		return
+	}
+
 	genesisOutputs := make(map[ledgerstate.Address]*ledgerstate.ColoredBalances)
 
 	for alias, balance := range m.options.genesisOutputs {
@@ -214,8 +218,8 @@ func (m *MessageTestFramework) createGenesisOutputs() {
 	m.tangle.LedgerState.LoadSnapshot(snapshot)
 
 	for alias := range m.options.genesisOutputs {
-		m.tangle.LedgerState.utxoDAG.AddressOutputMapping(m.walletsByAlias[alias].address).Consume(func(addressOutputMapping *ledgerstate.AddressOutputMapping) {
-			m.tangle.LedgerState.utxoDAG.Output(addressOutputMapping.OutputID()).Consume(func(output ledgerstate.Output) {
+		m.tangle.LedgerState.UTXODAG.AddressOutputMapping(m.walletsByAlias[alias].address).Consume(func(addressOutputMapping *ledgerstate.AddressOutputMapping) {
+			m.tangle.LedgerState.UTXODAG.Output(addressOutputMapping.OutputID()).Consume(func(output ledgerstate.Output) {
 				m.outputsByAlias[alias] = output
 				m.outputsByID[addressOutputMapping.OutputID()] = output
 				m.inputsByAlias[alias] = ledgerstate.NewUTXOInput(addressOutputMapping.OutputID())
@@ -224,8 +228,8 @@ func (m *MessageTestFramework) createGenesisOutputs() {
 	}
 
 	for alias := range m.options.coloredGenesisOutputs {
-		m.tangle.LedgerState.utxoDAG.AddressOutputMapping(m.walletsByAlias[alias].address).Consume(func(addressOutputMapping *ledgerstate.AddressOutputMapping) {
-			m.tangle.LedgerState.utxoDAG.Output(addressOutputMapping.OutputID()).Consume(func(output ledgerstate.Output) {
+		m.tangle.LedgerState.UTXODAG.AddressOutputMapping(m.walletsByAlias[alias].address).Consume(func(addressOutputMapping *ledgerstate.AddressOutputMapping) {
+			m.tangle.LedgerState.UTXODAG.Output(addressOutputMapping.OutputID()).Consume(func(output ledgerstate.Output) {
 				m.outputsByAlias[alias] = output
 				m.outputsByID[addressOutputMapping.OutputID()] = output
 			})

--- a/packages/tangle/timemanager.go
+++ b/packages/tangle/timemanager.go
@@ -101,6 +101,10 @@ func (t *TimeManager) Synced() bool {
 	return clock.Since(t.lastConfirmedMessage.Time) < t.tangle.Options.SyncTimeWindow
 }
 
+func (t *TimeManager) IsGenesis() bool {
+	return t.Time() == time.Unix(epochs.DefaultGenesisTime, 0)
+}
+
 // updateTime updates the last confirmed message.
 func (t *TimeManager) updateTime(marker markers.Marker, newLevel int, transition events.ThresholdEventTransition) {
 	if transition != events.ThresholdLevelIncreased {

--- a/packages/tangle/tipmanager_test.go
+++ b/packages/tangle/tipmanager_test.go
@@ -431,7 +431,7 @@ func TestTipManager_TransactionTips(t *testing.T) {
 	tangle.LedgerState.LoadSnapshot(snapshot)
 	// determine genesis index so that correct output can be referenced
 	var g1, g2 uint16
-	tangle.LedgerState.utxoDAG.Output(ledgerstate.NewOutputID(genesisTransaction.ID(), 0)).Consume(func(output ledgerstate.Output) {
+	tangle.LedgerState.UTXODAG.Output(ledgerstate.NewOutputID(genesisTransaction.ID(), 0)).Consume(func(output ledgerstate.Output) {
 		balance, _ := output.Balances().Get(ledgerstate.ColorIOTA)
 		if balance == uint64(5) {
 			g1 = 0
@@ -835,7 +835,7 @@ func storeBookLikeMessage(t *testing.T, tangle *Tangle, message *Message) {
 	tangle.Storage.StoreMessage(message)
 	// TODO: CheckTransaction should be removed here once the booker passes on errors
 	if message.payload.Type() == ledgerstate.TransactionType {
-		err := tangle.LedgerState.utxoDAG.CheckTransaction(message.payload.(*ledgerstate.Transaction))
+		err := tangle.LedgerState.UTXODAG.CheckTransaction(message.payload.(*ledgerstate.Transaction))
 		require.NoError(t, err)
 	}
 	err := tangle.Booker.BookMessage(message.ID())

--- a/packages/tangle/utils.go
+++ b/packages/tangle/utils.go
@@ -232,6 +232,7 @@ func (u *Utils) messageStronglyApprovedBy(approvedMessageID MessageID, approving
 	case types.False:
 		stronglyApproved = false
 	case types.Maybe:
+		fmt.Println("Need to walk...", approvedMessageID, approvingMessageID)
 		u.WalkMessageID(func(messageID MessageID, walker *walker.Walker) {
 			if messageID == approvingMessageID {
 				stronglyApproved = true

--- a/plugins/dashboard/explorer_routes.go
+++ b/plugins/dashboard/explorer_routes.go
@@ -52,6 +52,8 @@ type ExplorerMessage struct {
 
 	// Structure details
 	Rank          uint64 `json:"rank"`
+	SequenceID    uint64 `json:"sequenceID"`
+	PastMarkerGap uint64 `json:"pastMarkerGap"`
 	IsPastMarker  bool   `json:"isPastMarker"`
 	PastMarkers   string `json:"pastMarkers"`
 	FutureMarkers string `json:"futureMarkers"`
@@ -92,6 +94,8 @@ func createExplorerMessage(msg *tangle.Message) *ExplorerMessage {
 
 	if d := messageMetadata.StructureDetails(); d != nil {
 		t.Rank = d.Rank
+		t.SequenceID = uint64(d.SequenceID)
+		t.PastMarkerGap = d.PastMarkerGap
 		t.IsPastMarker = d.IsPastMarker
 		t.PastMarkers = d.PastMarkers.String()
 		t.FutureMarkers = d.FutureMarkers.String()

--- a/plugins/dashboard/frontend/src/app/components/ExplorerMessageQueryResult.tsx
+++ b/plugins/dashboard/frontend/src/app/components/ExplorerMessageQueryResult.tsx
@@ -162,6 +162,12 @@ export class ExplorerMessageQueryResult extends React.Component<Props, any> {
                                             Rank: {msg.rank}
                                         </ListGroup.Item>
                                         <ListGroup.Item>
+                                            SequenceID: {msg.sequenceID}
+                                        </ListGroup.Item>
+                                        <ListGroup.Item>
+                                            PastMarkerGap: {msg.pastMarkerGap}
+                                        </ListGroup.Item>
+                                        <ListGroup.Item>
                                             IsPastMarker: {msg.isPastMarker ? 'Yes' : 'No'}
                                         </ListGroup.Item>
                                         <ListGroup.Item>

--- a/plugins/dashboard/frontend/src/app/stores/ExplorerStore.tsx
+++ b/plugins/dashboard/frontend/src/app/stores/ExplorerStore.tsx
@@ -37,7 +37,9 @@ export class Message {
     payload_type: number;
     payload: any;
     rank: number;
+    sequenceID: number;
     isPastMarker: boolean;
+    pastMarkerGap: number;
     pastMarkers: string;
     futureMarkers: string;
 }

--- a/plugins/messagelayer/approvalweight.go
+++ b/plugins/messagelayer/approvalweight.go
@@ -20,7 +20,7 @@ func configureApprovalWeight() {
 
 func onMarkerConfirmed(marker markers.Marker, newLevel int, transition events.ThresholdEventTransition) {
 	if transition != events.ThresholdLevelIncreased {
-		Plugin().LogInfo("transition != events.ThresholdLevelIncreased")
+		plugin.LogInfo("transition != events.ThresholdLevelIncreased for %s", marker)
 		return
 	}
 	// get message ID of marker
@@ -36,17 +36,13 @@ func propagateFinalizedApprovalWeight(message *tangle.Message, messageMetadata *
 	}
 
 	// abort if the message is already finalized
-	if !setMessageFinalized(message, messageMetadata) {
+	if !setMessageFinalized(messageMetadata) {
 		return
 	}
 
 	// mark weak parents as finalized but not propagate finalized flag to its past cone
 	message.ForEachWeakParent(func(parentID tangle.MessageID) {
-		Tangle().Storage.Message(parentID).Consume(func(parentMessage *tangle.Message) {
-			Tangle().Storage.MessageMetadata(parentID).Consume(func(parentMetadata *tangle.MessageMetadata) {
-				setMessageFinalized(parentMessage, parentMetadata)
-			})
-		})
+		setPayloadFinalized(parentID)
 	})
 
 	// propagate finalized to strong parents
@@ -56,7 +52,10 @@ func propagateFinalizedApprovalWeight(message *tangle.Message, messageMetadata *
 }
 
 func onBranchConfirmed(branchID ledgerstate.BranchID, newLevel int, transition events.ThresholdEventTransition) {
-	plugin.LogDebugf("%s confirmed by ApprovalWeight.", branchID)
+	if transition != events.ThresholdLevelIncreased {
+		plugin.LogInfo("transition != events.ThresholdLevelIncreased for %s", branchID)
+		return
+	}
 
 	_, err := Tangle().LedgerState.BranchDAG.SetBranchMonotonicallyLiked(branchID, true)
 	if err != nil {
@@ -73,36 +72,21 @@ func onBranchConfirmed(branchID ledgerstate.BranchID, newLevel int, transition e
 	}
 }
 
-func setMessageFinalized(message *tangle.Message, messageMetadata *tangle.MessageMetadata) (modified bool) {
+func setMessageFinalized(messageMetadata *tangle.MessageMetadata) (modified bool) {
 	// abort if the message is already finalized
 	if modified = messageMetadata.SetFinalized(true); !modified {
 		return
 	}
 
-	Tangle().Utils.ComputeIfTransaction(message.ID(), func(transactionID ledgerstate.TransactionID) {
-		Tangle().LedgerState.TransactionMetadata(transactionID).Consume(func(transactionMetadata *ledgerstate.TransactionMetadata) {
-			if transactionMetadata.SetFinalized(true) {
-				Tangle().ConsensusManager.SetTransactionLiked(transactionID, true)
-				// trigger TransactionOpinionFormed if the message contains a transaction
-				Tangle().ConsensusManager.Events.TransactionConfirmed.Trigger(message.ID())
-			}
-
-			if !Tangle().LedgerState.TransactionConflicting(transactionID) {
-				return
-			}
-
-			for conflicingTx := range Tangle().LedgerState.ConflictSet(transactionID) {
-				if conflicingTx == transactionID {
-					continue
-				}
-				Tangle().LedgerState.TransactionMetadata(conflicingTx).Consume(func(conflictingTransactionMetadata *ledgerstate.TransactionMetadata) {
-					if conflictingTransactionMetadata.SetFinalized(true) {
-						Tangle().ConsensusManager.SetTransactionLiked(transactionID, false)
-					}
-				})
-			}
-		})
-	})
+	setPayloadFinalized(messageMetadata.ID())
 
 	return modified
+}
+
+func setPayloadFinalized(messageID tangle.MessageID) {
+	Tangle().Utils.ComputeIfTransaction(messageID, func(transactionID ledgerstate.TransactionID) {
+		if err := Tangle().LedgerState.UTXODAG.SetTransactionConfirmed(transactionID); err != nil {
+			plugin.LogError(err)
+		}
+	})
 }

--- a/plugins/webapi/jsonmodels/markers.go
+++ b/plugins/webapi/jsonmodels/markers.go
@@ -9,6 +9,7 @@ import (
 // StructureDetails represents the JSON model of the markers.StructureDetails.
 type StructureDetails struct {
 	Rank          uint64   `json:"rank"`
+	PastMarkerGap uint64   `json:"pastMarkerGap"`
 	IsPastMarker  bool     `json:"isPastMarker"`
 	PastMarkers   *Markers `json:"pastMarkers"`
 	FutureMarkers *Markers `json:"futureMarkers"`
@@ -23,6 +24,7 @@ func NewStructureDetails(structureDetails *markersPackage.StructureDetails) *Str
 	return &StructureDetails{
 		Rank:          structureDetails.Rank,
 		IsPastMarker:  structureDetails.IsPastMarker,
+		PastMarkerGap: structureDetails.PastMarkerGap,
 		PastMarkers:   NewMarkers(structureDetails.PastMarkers),
 		FutureMarkers: NewMarkers(structureDetails.FutureMarkers),
 	}

--- a/plugins/webapi/tools/message/orderer.go
+++ b/plugins/webapi/tools/message/orderer.go
@@ -1,0 +1,28 @@
+package message
+
+import (
+	"fmt"
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/labstack/echo"
+
+	"github.com/iotaledger/goshimmer/plugins/messagelayer"
+)
+
+// OrdererDebugHandler runs the tangle.Orderer analysis which consists of printing all the time buckets.
+func OrdererDebugHandler(c echo.Context) error {
+	buckets, bucketsMap := messagelayer.Tangle().Storage.AllBucketMessageIDsBuckets()
+
+	sort.Slice(buckets, func(i, j int) bool { return buckets[i] < buckets[j] })
+
+	for i, b := range buckets {
+		fmt.Println(i, bucketsMap[b], time.Unix(b, 0))
+		if i > 100 {
+			break
+		}
+	}
+
+	return c.NoContent(http.StatusNoContent)
+}

--- a/plugins/webapi/tools/plugin.go
+++ b/plugins/webapi/tools/plugin.go
@@ -34,6 +34,7 @@ func configure(_ *node.Plugin) {
 	webapi.Server().GET("tools/message/approval", message.ApprovalHandler)
 	webapi.Server().GET("tools/value/objects", value.ObjectsHandler)
 	webapi.Server().GET("tools/message/orphanage", message.OrphanageHandler)
+	webapi.Server().GET("tools/orderer/debug", message.OrdererDebugHandler)
 
 	webapi.Server().GET("tools/diagnostic/messages", message.DiagnosticMessagesHandler)
 	webapi.Server().GET("tools/diagnostic/messages/firstweakreferences", message.DiagnosticMessagesOnlyFirstWeakReferencesHandler)

--- a/tools/integration-tests/tester/go.mod
+++ b/tools/integration-tests/tester/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/drand/drand v1.1.1
 	github.com/iotaledger/goshimmer v0.1.3
-	github.com/iotaledger/hive.go v0.0.0-20210427112115-75c7ebf4ebbb
+	github.com/iotaledger/hive.go v0.0.0-20210503211838-dec77b0328c1
 	github.com/mr-tron/base58 v1.2.0
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/stretchr/testify v1.7.0

--- a/tools/integration-tests/tester/go.mod
+++ b/tools/integration-tests/tester/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/drand/drand v1.1.1
 	github.com/iotaledger/goshimmer v0.1.3
-	github.com/iotaledger/hive.go v0.0.0-20210420114224-0b2c378f627f
+	github.com/iotaledger/hive.go v0.0.0-20210427112115-75c7ebf4ebbb
 	github.com/mr-tron/base58 v1.2.0
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/stretchr/testify v1.7.0

--- a/tools/integration-tests/tester/go.sum
+++ b/tools/integration-tests/tester/go.sum
@@ -399,8 +399,8 @@ github.com/hydrogen18/memlistener v0.0.0-20141126152155-54553eb933fb/go.mod h1:q
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/iotaledger/hive.go v0.0.0-20210427112115-75c7ebf4ebbb h1:/rQpy4+WTsgdlh4azuPoICb60y15yXN+ArjVlAu01Js=
-github.com/iotaledger/hive.go v0.0.0-20210427112115-75c7ebf4ebbb/go.mod h1:NyBg/Ny7FFAdDs59zdwTVoysU2ZbJVQnRwyLIDFKJYA=
+github.com/iotaledger/hive.go v0.0.0-20210503211838-dec77b0328c1 h1:Dd2e7s3HcP/+oE+U0ih0Z9KcTMReY1r0gqnVixnubdk=
+github.com/iotaledger/hive.go v0.0.0-20210503211838-dec77b0328c1/go.mod h1:NyBg/Ny7FFAdDs59zdwTVoysU2ZbJVQnRwyLIDFKJYA=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.2/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.3/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=

--- a/tools/integration-tests/tester/go.sum
+++ b/tools/integration-tests/tester/go.sum
@@ -399,8 +399,8 @@ github.com/hydrogen18/memlistener v0.0.0-20141126152155-54553eb933fb/go.mod h1:q
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/iotaledger/hive.go v0.0.0-20210420114224-0b2c378f627f h1:dIveuMy0KoN6gXIuKp0rTdo2ZmYbQvLRGCGpq/7dqhY=
-github.com/iotaledger/hive.go v0.0.0-20210420114224-0b2c378f627f/go.mod h1:NyBg/Ny7FFAdDs59zdwTVoysU2ZbJVQnRwyLIDFKJYA=
+github.com/iotaledger/hive.go v0.0.0-20210427112115-75c7ebf4ebbb h1:/rQpy4+WTsgdlh4azuPoICb60y15yXN+ArjVlAu01Js=
+github.com/iotaledger/hive.go v0.0.0-20210427112115-75c7ebf4ebbb/go.mod h1:NyBg/Ny7FFAdDs59zdwTVoysU2ZbJVQnRwyLIDFKJYA=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.2/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.3/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=


### PR DESCRIPTION
Orderer is a Tangle component that makes sure that no messages too far ahead of the TangleTime are booked. This is necessary to basically replay the tangle data structure as it was constructed during syncing to avoid distortions in perceptions of the approval weight.