### PR TITLE
Process all scheduler messages during shutdown

### DIFF
--- a/packages/tangle/scheduler.go
+++ b/packages/tangle/scheduler.go
@@ -124,8 +124,11 @@ func (s *Scheduler) Setup() {
 
 // SetRate sets the rate of the scheduler.
 func (s *Scheduler) SetRate(rate time.Duration) {
-	s.ticker.Reset(rate)
 	s.tangle.Options.SchedulerParams.Rate = rate
+	// only update the ticker when the scheduler is running
+	if s.running.Load() {
+		s.ticker.Reset(rate)
+	}
 }
 
 // Submit submits a message to be considered by the scheduler.

--- a/packages/tangle/scheduler.go
+++ b/packages/tangle/scheduler.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/iotaledger/goshimmer/packages/tangle/schedulerutils"
+	"go.uber.org/atomic"
 
 	"github.com/iotaledger/hive.go/events"
 	"github.com/iotaledger/hive.go/identity"
@@ -19,6 +20,8 @@ const (
 
 // rate is the minimum time interval between two scheduled messages, i.e. 1s / MPS
 var rate = time.Second / 200
+	ErrNotRunning = xerrors.New("scheduler is not running")
+)
 
 // AccessManaRetrieveFunc is a function type to retrieve access mana (e.g. via the mana plugin)
 type AccessManaRetrieveFunc func(nodeID identity.ID) float64
@@ -44,15 +47,15 @@ type Scheduler struct {
 	deficits         map[identity.ID]float64
 	onMessageSolid   *events.Closure
 	onMessageInvalid *events.Closure
-	shutdownSignal   chan struct{}
-	shutdownOnce     sync.Once
+	running          atomic.Bool
+	wg               sync.WaitGroup
 	ticker           *time.Ticker
 }
 
 // NewScheduler returns a new Scheduler.
 func NewScheduler(tangle *Tangle) *Scheduler {
 	if tangle.Options.SchedulerParams.AccessManaRetrieveFunc == nil || tangle.Options.SchedulerParams.TotalAccessManaRetrieveFunc == nil {
-		panic("the option AccessManaRetriever and TotalAccessManaRetriever must be defined so that AccessMana can be determined in scheduler")
+		panic("scheduler: the option AccessManaRetriever and TotalAccessManaRetriever must be defined so that AccessMana can be determined in scheduler")
 	}
 	if tangle.Options.SchedulerParams.MaxQueueWeight != nil {
 		schedulerutils.MaxQueueWeight = *tangle.Options.SchedulerParams.MaxQueueWeight
@@ -67,11 +70,10 @@ func NewScheduler(tangle *Tangle) *Scheduler {
 			MessageDiscarded: events.NewEvent(MessageIDCaller),
 			NodeBlacklisted:  events.NewEvent(NodeIDCaller),
 		},
-		self:           tangle.Options.Identity.ID(),
-		tangle:         tangle,
-		buffer:         schedulerutils.NewBufferQueue(),
-		deficits:       make(map[identity.ID]float64),
-		shutdownSignal: make(chan struct{}),
+		self:     tangle.Options.Identity.ID(),
+		tangle:   tangle,
+		buffer:   schedulerutils.NewBufferQueue(),
+		deficits: make(map[identity.ID]float64),
 	}
 	scheduler.onMessageSolid = events.NewClosure(scheduler.onMessageSolidHandler)
 	scheduler.onMessageInvalid = events.NewClosure(scheduler.onMessageInvalidHandler)
@@ -79,16 +81,39 @@ func NewScheduler(tangle *Tangle) *Scheduler {
 }
 
 func (s *Scheduler) onMessageSolidHandler(messageID MessageID) {
-	s.SubmitAndReadyMessage(messageID)
+	// submit the message to the scheduler and makes it ready when it's parents are booked
+	err := s.Submit(messageID)
+	if err != nil {
+		s.tangle.Events.Error.Trigger(xerrors.Errorf("failed to submit: %w", err))
+		return
+	}
+	err = s.Ready(messageID)
+	if err != nil {
+		s.tangle.Events.Error.Trigger(xerrors.Errorf("failed to ready: %w", err))
+		return
+	}
 }
 
 func (s *Scheduler) onMessageInvalidHandler(messageID MessageID) {
-	s.Unsubmit(messageID)
+	// unsubmit the message
+	err := s.Unsubmit(messageID)
+	s.tangle.Events.Error.Trigger(xerrors.Errorf("failed to unsubmit: %w", err))
 }
 
 // Start starts the scheduler.
 func (s *Scheduler) Start() {
+	// start the main loop
+	s.wg.Add(1)
 	go s.mainLoop()
+
+	s.running.Store(true)
+}
+
+// Shutdown shuts down the Scheduler.
+// Shutdown blocks until the scheduler has been shutdown successfully.
+func (s *Scheduler) Shutdown() {
+	s.running.Store(false)
+	s.wg.Wait()
 }
 
 // Detach detaches the scheduler from the tangle events.
@@ -101,30 +126,6 @@ func (s *Scheduler) Detach() {
 func (s *Scheduler) Setup() {
 	s.tangle.Solidifier.Events.MessageSolid.Attach(s.onMessageSolid)
 	s.tangle.Events.MessageInvalid.Attach(s.onMessageInvalid)
-
-	//  TODO: wait for all messages to be scheduled here or in message layer?
-	/*
-		s.tangle.ConsensusManager.Events.MessageOpinionFormed.Attach(events.NewClosure(func(messageID MessageID) {
-			if s.scheduledMessages.Delete(messageID) {
-				s.allMessagesScheduledWG.Done()
-			}
-		}))
-	*/
-}
-
-// SubmitAndReadyMessage submits the message to the scheduler and makes it ready when it's parents are booked.
-func (s *Scheduler) SubmitAndReadyMessage(messageID MessageID) {
-	err := s.Submit(messageID)
-	if err != nil {
-		s.tangle.Events.Error.Trigger(xerrors.Errorf("error in Scheduler Submit: %v", err))
-		return
-	}
-
-	err = s.Ready(messageID)
-	if err != nil {
-		s.tangle.Events.Error.Trigger(xerrors.Errorf("error in Scheduler Ready: %v", err))
-		return
-	}
 }
 
 // SetRate sets the rate of the scheduler.
@@ -133,18 +134,13 @@ func (s *Scheduler) SetRate(rate time.Duration) {
 	s.tangle.Options.SchedulerParams.Rate = rate
 }
 
-// Shutdown shuts down the Scheduler.
-func (s *Scheduler) Shutdown() {
-	s.shutdownOnce.Do(func() {
-		close(s.shutdownSignal)
-	})
-}
-
 // Submit submits a message to be considered by the scheduler.
 // This transactions will be included in all the control metrics, but it will never be
 // scheduled until Ready(messageID) has been called.
-func (s *Scheduler) Submit(messageID MessageID) error {
-	var err error
+func (s *Scheduler) Submit(messageID MessageID) (err error) {
+	if !s.running.Load() {
+		return ErrNotRunning
+	}
 
 	if !s.tangle.Storage.Message(messageID).Consume(func(message *Message) {
 		s.mu.Lock()
@@ -169,27 +165,25 @@ func (s *Scheduler) Submit(messageID MessageID) error {
 	}) {
 		err = xerrors.Errorf("failed to get message '%x' from storage", messageID)
 	}
-
 	return err
 }
 
 // Unsubmit removes a message from the submitted messages.
 // If that message is already marked as ready, Unsubmit has no effect.
-func (s *Scheduler) Unsubmit(messageID MessageID) {
+func (s *Scheduler) Unsubmit(messageID MessageID) (err error) {
 	if !s.tangle.Storage.Message(messageID).Consume(func(message *Message) {
 		s.mu.Lock()
 		defer s.mu.Unlock()
 		s.buffer.Unsubmit(message)
 	}) {
-		s.tangle.Events.Error.Trigger(xerrors.Errorf("error in Scheduler (Unsubmit): failed to get message '%x' from storage", messageID))
+		err = xerrors.Errorf("failed to get message '%x' from storage", messageID)
 	}
+	return err
 }
 
 // Ready marks a previously submitted message as ready to be scheduled.
 // If Ready is called without a previous Submit, it has no effect.
-func (s *Scheduler) Ready(messageID MessageID) error {
-	var err error
-
+func (s *Scheduler) Ready(messageID MessageID) (err error) {
 	if !s.tangle.Storage.Message(messageID).Consume(func(message *Message) {
 		s.mu.Lock()
 		defer s.mu.Unlock()
@@ -197,22 +191,7 @@ func (s *Scheduler) Ready(messageID MessageID) error {
 	}) {
 		err = xerrors.Errorf("failed to get message '%x' from storage", messageID)
 	}
-
 	return err
-}
-
-// RemoveNode removes all messages (submitted and ready) for the given node.
-func (s *Scheduler) RemoveNode(nodeID identity.ID) (err error) {
-	if nodeID == s.self {
-		return xerrors.Errorf("Invalid node to remove")
-	}
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	// TODO: is it necessary to trigger MessageDiscarded for all the removed messages.
-	s.buffer.RemoveNode(nodeID)
-	return
 }
 
 func (s *Scheduler) parentsBooked(messageID MessageID) (parentsBooked bool) {
@@ -250,58 +229,46 @@ func (s *Scheduler) schedule() *Message {
 		if f != nil && s.getDeficit(q.NodeID()) >= float64(len(f.Bytes())) && !now.Before(f.IssuingTime()) {
 			break
 		}
-		// otherwise increase the deficit
+		// otherwise increase its deficit
 		mana := s.tangle.Options.SchedulerParams.AccessManaRetrieveFunc(q.NodeID())
-		err := s.setDeficit(q.NodeID(), s.getDeficit(q.NodeID())+mana)
-		if err != nil {
-			s.tangle.Events.Error.Trigger(err)
-			return nil
-		}
+		s.updateDeficit(q.NodeID(), mana)
 
-		// TODO: different from spec
+		// TODO: this is slightly different from the spec, check that the spec is updated
 		q = s.buffer.Next()
-		if q == nil {
-			s.tangle.Events.Error.Trigger(xerrors.Errorf("error in Scheduler (schedule): failed to get next message from bufferQueue"))
-			return nil
-		}
+		// since the buffer is not empty, this will never return nil
 		if q == start {
 			return nil
 		}
 	}
 
-	// will stay in
+	// if the parents are not booked yet, do not schedule the message
+	// TODO: eventually this should be handled outside the scheduler by only calling Ready() when the parents are booked
 	if !s.parentsBooked(s.buffer.Current().Front().(*Message).ID()) {
 		return nil
 	}
+	// remove the message from the buffer and adjust node's deficit
 	msg := s.buffer.PopFront()
 	nodeID := identity.NewID(msg.IssuerPublicKey())
-	err := s.setDeficit(nodeID, s.getDeficit(nodeID)-float64(len(msg.Bytes())))
-	if err != nil {
-		s.tangle.Events.Error.Trigger(err)
-		return nil
-	}
+	s.updateDeficit(nodeID, -float64(len(msg.Bytes())))
 
 	return msg.(*Message)
 }
 
 // mainLoop periodically triggers the scheduling of ready messages.
 func (s *Scheduler) mainLoop() {
-	s.ticker = time.NewTicker(rate)
+	defer s.wg.Done()
 	defer s.ticker.Stop()
-
 	for {
 		select {
 		// every rate time units
 		case <-s.ticker.C:
-			// TODO: do we need to pause the ticker, if there are no ready messages
-			msg := s.schedule()
-			if msg != nil {
+			// TODO: pause the ticker, if there are no ready messages
+			if msg := s.schedule(); msg != nil {
 				s.Events.MessageScheduled.Trigger(msg.ID())
 			}
-
-		// on close, exit the loop
-		case <-s.shutdownSignal:
-			return
+			if !s.running.Load() && s.buffer.Size() == 0 {
+				return
+			}
 		}
 	}
 }
@@ -310,13 +277,13 @@ func (s *Scheduler) getDeficit(nodeID identity.ID) float64 {
 	return s.deficits[nodeID]
 }
 
-func (s *Scheduler) setDeficit(nodeID identity.ID, deficit float64) (err error) {
+func (s *Scheduler) updateDeficit(nodeID identity.ID, d float64) {
+	deficit := s.deficits[nodeID] + d
 	if deficit < 0 {
-		return xerrors.Errorf("error in Scheduler (setDeficit): deficit is less than 0")
+		// this will never happen and is just here for debugging purposes
+		panic("scheduler: deficit is less than 0")
 	}
 	s.deficits[nodeID] = math.Min(deficit, MaxDeficit)
-
-	return
 }
 
 // NodeQueueSize returns the size of the nodeIDs queue.

--- a/packages/tangle/scheduler.go
+++ b/packages/tangle/scheduler.go
@@ -96,6 +96,8 @@ func (s *Scheduler) onMessageInvalidHandler(messageID MessageID) {
 
 // Start starts the scheduler.
 func (s *Scheduler) Start() {
+	// create the ticker here to assure that SetRate never hits an uninitialized ticker
+	s.ticker = time.NewTicker(s.tangle.Options.SchedulerParams.Rate)
 	// start the main loop
 	s.wg.Add(1)
 	go s.mainLoop()
@@ -123,7 +125,6 @@ func (s *Scheduler) Setup() {
 }
 
 // SetRate sets the rate of the scheduler.
-// It must only be called, when the scheduler has already been started.
 func (s *Scheduler) SetRate(rate time.Duration) {
 	s.tangle.Options.SchedulerParams.Rate = rate
 	// only update the ticker when the scheduler is running
@@ -255,9 +256,8 @@ func (s *Scheduler) schedule() *Message {
 // mainLoop periodically triggers the scheduling of ready messages.
 func (s *Scheduler) mainLoop() {
 	defer s.wg.Done()
-
-	s.ticker = time.NewTicker(s.tangle.Options.SchedulerParams.Rate)
 	defer s.ticker.Stop()
+
 	for {
 		select {
 		// every rate time units

--- a/packages/tangle/scheduler.go
+++ b/packages/tangle/scheduler.go
@@ -6,10 +6,9 @@ import (
 	"time"
 
 	"github.com/iotaledger/goshimmer/packages/tangle/schedulerutils"
-	"go.uber.org/atomic"
-
 	"github.com/iotaledger/hive.go/events"
 	"github.com/iotaledger/hive.go/identity"
+	"go.uber.org/atomic"
 	"golang.org/x/xerrors"
 )
 
@@ -18,10 +17,8 @@ const (
 	MaxDeficit = MaxMessageSize
 )
 
-var (
-	// ErrNotRunning is returned when a message is submitted when the scheduler has not been started
-	ErrNotRunning = xerrors.New("scheduler is not running")
-)
+// ErrNotRunning is returned when a message is submitted when the scheduler has not been started
+var ErrNotRunning = xerrors.New("scheduler is not running")
 
 // AccessManaRetrieveFunc is a function type to retrieve access mana (e.g. via the mana plugin)
 type AccessManaRetrieveFunc func(nodeID identity.ID) float64

--- a/packages/tangle/scheduler.go
+++ b/packages/tangle/scheduler.go
@@ -78,7 +78,7 @@ func NewScheduler(tangle *Tangle) *Scheduler {
 }
 
 func (s *Scheduler) onMessageSolidHandler(messageID MessageID) {
-	// submit the message to the scheduler and makes it ready when it's parents are booked
+	// submit the message to the scheduler and marks it ready right away
 	err := s.Submit(messageID)
 	if err != nil {
 		s.tangle.Events.Error.Trigger(xerrors.Errorf("failed to submit: %w", err))

--- a/packages/tangle/scheduler.go
+++ b/packages/tangle/scheduler.go
@@ -123,6 +123,7 @@ func (s *Scheduler) Setup() {
 }
 
 // SetRate sets the rate of the scheduler.
+// It must only be called, when the scheduler has already been started.
 func (s *Scheduler) SetRate(rate time.Duration) {
 	s.tangle.Options.SchedulerParams.Rate = rate
 	// only update the ticker when the scheduler is running

--- a/packages/tangle/scheduler.go
+++ b/packages/tangle/scheduler.go
@@ -1,7 +1,6 @@
 package tangle
 
 import (
-	"errors"
 	"math"
 	"sync"
 	"time"
@@ -164,7 +163,7 @@ func (s *Scheduler) Submit(messageID MessageID) error {
 		if err != nil {
 			s.Events.MessageDiscarded.Trigger(messageID)
 		}
-		if errors.Is(err, schedulerutils.ErrInboxExceeded) {
+		if xerrors.Is(err, schedulerutils.ErrInboxExceeded) {
 			s.Events.NodeBlacklisted.Trigger(nodeID)
 		}
 	}) {

--- a/packages/tangle/scheduler_test.go
+++ b/packages/tangle/scheduler_test.go
@@ -100,7 +100,8 @@ func TestScheduler_SetRate(t *testing.T) {
 	var scheduled atomic.Bool
 	tangle.Scheduler.Events.MessageScheduled.Attach(events.NewClosure(func(MessageID) { scheduled.Store(true) }))
 
-	// effectively disabled the rate
+	// make sure that the scheduler has been started and effectively disabled the rate
+	time.Sleep(100 * time.Millisecond)
 	tangle.Scheduler.SetRate(time.Hour)
 
 	msg := newMessage(peerNode.PublicKey())

--- a/packages/tangle/scheduler_test.go
+++ b/packages/tangle/scheduler_test.go
@@ -100,8 +100,7 @@ func TestScheduler_SetRate(t *testing.T) {
 	var scheduled atomic.Bool
 	tangle.Scheduler.Events.MessageScheduled.Attach(events.NewClosure(func(MessageID) { scheduled.Store(true) }))
 
-	// make sure that the scheduler has been started and effectively disabled the rate
-	time.Sleep(100 * time.Millisecond)
+	// effectively disabled the rate
 	tangle.Scheduler.SetRate(time.Hour)
 
 	msg := newMessage(peerNode.PublicKey())

--- a/packages/tangle/scheduler_test.go
+++ b/packages/tangle/scheduler_test.go
@@ -92,6 +92,15 @@ func TestScheduler_Schedule(t *testing.T) {
 	}, 1*time.Second, 10*time.Millisecond)
 }
 
+func TestScheduler_SetRateBeforeStart(t *testing.T) {
+	tangle := New(Identity(selfLocalIdentity), SchedulerConfig(testSchedulerParams))
+	defer tangle.Shutdown()
+
+	tangle.Scheduler.SetRate(time.Hour)
+	tangle.Scheduler.Start()
+	tangle.Scheduler.SetRate(testRate)
+}
+
 func TestScheduler_SetRate(t *testing.T) {
 	tangle := New(Identity(selfLocalIdentity), SchedulerConfig(testSchedulerParams))
 	defer tangle.Shutdown()

--- a/packages/tangle/scheduler_test.go
+++ b/packages/tangle/scheduler_test.go
@@ -5,11 +5,13 @@ import (
 	"time"
 
 	"github.com/iotaledger/goshimmer/packages/tangle/payload"
-
+	"github.com/iotaledger/goshimmer/packages/tangle/schedulerutils"
 	"github.com/iotaledger/hive.go/crypto/ed25519"
 	"github.com/iotaledger/hive.go/events"
 	"github.com/iotaledger/hive.go/identity"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/atomic"
+	"golang.org/x/xerrors"
 )
 
 // region Scheduler_test /////////////////////////////////////////////////////////////////////////////////////////////
@@ -18,40 +20,43 @@ var (
 	selfLocalIdentity = identity.GenerateLocalIdentity()
 	selfNode          = identity.New(selfLocalIdentity.PublicKey())
 	peerNode          = identity.GenerateIdentity()
-	otherNode         = identity.GenerateIdentity()
-	params            = SchedulerParams{
-		AccessManaRetrieveFunc:      getAccessMana,
-		TotalAccessManaRetrieveFunc: getTotalAccessMana,
-	}
 )
 
 func TestScheduler_StartStop(t *testing.T) {
-	tangle := New(Identity(selfLocalIdentity), SchedulerConfig(params))
+	tangle := New(Identity(selfLocalIdentity), SchedulerConfig(testSchedulerParams))
 	defer tangle.Shutdown()
+	tangle.Scheduler.Start()
+
 	time.Sleep(10 * time.Millisecond)
+	tangle.Scheduler.Shutdown()
 }
 
 func TestScheduler_Submit(t *testing.T) {
-	tangle := New(Identity(selfLocalIdentity), SchedulerConfig(params))
+	tangle := New(Identity(selfLocalIdentity), SchedulerConfig(testSchedulerParams))
 	defer tangle.Shutdown()
+	tangle.Scheduler.Start()
 
 	msg := newMessage(selfNode.PublicKey())
 	tangle.Storage.StoreMessage(msg)
-	tangle.Scheduler.Submit(msg.ID())
+	assert.NoError(t, tangle.Scheduler.Submit(msg.ID()))
 	time.Sleep(100 * time.Millisecond)
+	// unsubmit to allow the scheduler to shutdown
+	assert.NoError(t, tangle.Scheduler.Unsubmit(msg.ID()))
 }
 
 func TestScheduler_Discarded(t *testing.T) {
-	tangle := New(Identity(selfLocalIdentity), SchedulerConfig(params))
+	tangle := New(Identity(selfLocalIdentity), SchedulerConfig(testSchedulerParams))
 	defer tangle.Shutdown()
+	tangle.Scheduler.Start()
 
 	messageDiscarded := make(chan MessageID, 1)
 	tangle.Scheduler.Events.MessageDiscarded.Attach(events.NewClosure(func(id MessageID) { messageDiscarded <- id }))
 
 	// this node has no mana so the message will be discarded
-	msg := newMessage(otherNode.PublicKey())
+	msg := newMessage(noAManaNode.PublicKey())
 	tangle.Storage.StoreMessage(msg)
-	tangle.Scheduler.Submit(msg.ID())
+	err := tangle.Scheduler.Submit(msg.ID())
+	assert.Truef(t, xerrors.Is(err, schedulerutils.ErrInvalidMana), "unexpected error: %v", err)
 
 	assert.Eventually(t, func() bool {
 		select {
@@ -64,10 +69,8 @@ func TestScheduler_Discarded(t *testing.T) {
 }
 
 func TestScheduler_Schedule(t *testing.T) {
-	tangle := New(Identity(selfLocalIdentity), SchedulerConfig(params))
+	tangle := New(Identity(selfLocalIdentity), SchedulerConfig(testSchedulerParams))
 	defer tangle.Shutdown()
-
-	tangle.Scheduler.Setup()
 	tangle.Scheduler.Start()
 
 	messageScheduled := make(chan MessageID, 1)
@@ -76,8 +79,8 @@ func TestScheduler_Schedule(t *testing.T) {
 	// create a new message from a different node
 	msg := newMessage(peerNode.PublicKey())
 	tangle.Storage.StoreMessage(msg)
-	tangle.Scheduler.Submit(msg.ID())
-	tangle.Scheduler.Ready(msg.ID())
+	assert.NoError(t, tangle.Scheduler.Submit(msg.ID()))
+	assert.NoError(t, tangle.Scheduler.Ready(msg.ID()))
 
 	assert.Eventually(t, func() bool {
 		select {
@@ -90,10 +93,8 @@ func TestScheduler_Schedule(t *testing.T) {
 }
 
 func TestScheduler_Time(t *testing.T) {
-	tangle := New(Identity(selfLocalIdentity), SchedulerConfig(params))
+	tangle := New(Identity(selfLocalIdentity), SchedulerConfig(testSchedulerParams))
 	defer tangle.Shutdown()
-
-	tangle.Scheduler.Setup()
 	tangle.Scheduler.Start()
 
 	messageScheduled := make(chan MessageID, 1)
@@ -102,14 +103,14 @@ func TestScheduler_Time(t *testing.T) {
 	future := newMessage(peerNode.PublicKey())
 	future.issuingTime = time.Now().Add(time.Second)
 	tangle.Storage.StoreMessage(future)
-	tangle.Scheduler.Submit(future.ID())
+	assert.NoError(t, tangle.Scheduler.Submit(future.ID()))
 
 	now := newMessage(peerNode.PublicKey())
 	tangle.Storage.StoreMessage(now)
-	tangle.Scheduler.Submit(now.ID())
+	assert.NoError(t, tangle.Scheduler.Submit(now.ID()))
 
-	tangle.Scheduler.Ready(future.ID())
-	tangle.Scheduler.Ready(now.ID())
+	assert.NoError(t, tangle.Scheduler.Ready(future.ID()))
+	assert.NoError(t, tangle.Scheduler.Ready(now.ID()))
 
 	done := make(chan struct{})
 	var scheduledIDs []MessageID
@@ -134,9 +135,12 @@ func TestScheduler_Time(t *testing.T) {
 }
 
 func TestScheduler_Issue(t *testing.T) {
-	tangle := New(Identity(selfLocalIdentity), SchedulerConfig(params))
+	tangle := New(Identity(selfLocalIdentity), SchedulerConfig(testSchedulerParams))
 	defer tangle.Shutdown()
-	tangle.Setup()
+
+	// setup tangle up till the Scheduler
+	tangle.Storage.Setup()
+	tangle.Solidifier.Setup()
 	tangle.Scheduler.Setup()
 	tangle.Scheduler.Start()
 
@@ -167,7 +171,7 @@ func TestScheduler_Issue(t *testing.T) {
 func TestSchedulerFlow(t *testing.T) {
 	// create Scheduler dependencies
 	// create the tangle
-	tangle := New(Identity(selfLocalIdentity), SchedulerConfig(params))
+	tangle := New(Identity(selfLocalIdentity), SchedulerConfig(testSchedulerParams))
 	defer tangle.Shutdown()
 
 	// setup tangle up till the Scheduler
@@ -222,17 +226,6 @@ func TestSchedulerFlow(t *testing.T) {
 			return false
 		}
 	}, 10*time.Second, 100*time.Millisecond)
-}
-
-func getAccessMana(nodeID identity.ID) float64 {
-	if nodeID == otherNode.ID() {
-		return 0
-	}
-	return 1000
-}
-
-func getTotalAccessMana() float64 {
-	return 10000
 }
 
 func newMessage(issuerPublicKey ed25519.PublicKey) *Message {

--- a/packages/tangle/schedulerutils/bufferqueue.go
+++ b/packages/tangle/schedulerutils/bufferqueue.go
@@ -4,6 +4,7 @@ import (
 	"container/ring"
 
 	"github.com/iotaledger/hive.go/identity"
+	"go.uber.org/atomic"
 	"golang.org/x/xerrors"
 )
 
@@ -30,7 +31,7 @@ var (
 type BufferQueue struct {
 	activeNode map[identity.ID]*ring.Ring
 	ring       *ring.Ring
-	size       uint
+	size       atomic.Uint64
 }
 
 // NewBufferQueue returns a new BufferQueue
@@ -38,7 +39,6 @@ func NewBufferQueue() *BufferQueue {
 	return &BufferQueue{
 		activeNode: make(map[identity.ID]*ring.Ring),
 		ring:       nil,
-		size:       0,
 	}
 }
 
@@ -48,8 +48,9 @@ func (b *BufferQueue) NumActiveNodes() int {
 }
 
 // Size returns the total size (in bytes) of all messages in b.
-func (b *BufferQueue) Size() uint {
-	return b.size
+// Size is thread-safe.
+func (b *BufferQueue) Size() uint64 {
+	return b.size.Load()
 }
 
 // NodeQueue returns the queue for the corresponding node.
@@ -63,7 +64,7 @@ func (b *BufferQueue) NodeQueue(nodeID identity.ID) *NodeQueue {
 
 // Submit submits a message.
 func (b *BufferQueue) Submit(msg Element, rep float64) error {
-	if b.size+uint(len(msg.Bytes())) > MaxBufferSize {
+	if b.Size()+uint64(len(msg.Bytes())) > MaxBufferSize {
 		return ErrBufferFull
 	}
 
@@ -87,7 +88,7 @@ func (b *BufferQueue) Submit(msg Element, rep float64) error {
 		return xerrors.Errorf("error in BufferQueue (Submit): message has already been submitted %x", msg.IDBytes())
 	}
 
-	b.size += uint(len(msg.Bytes()))
+	b.size.Add(uint64(len(msg.Bytes())))
 	return nil
 }
 
@@ -106,7 +107,7 @@ func (b *BufferQueue) Unsubmit(msg Element) bool {
 		return false
 	}
 
-	b.size -= uint(len(msg.Bytes()))
+	b.size.Sub(uint64(len(msg.Bytes())))
 	if nodeQueue.IsInactive() {
 		b.ringRemove(element)
 		delete(b.activeNode, nodeID)
@@ -123,20 +124,6 @@ func (b *BufferQueue) Ready(msg Element) bool {
 
 	nodeQueue := element.Value.(*NodeQueue)
 	return nodeQueue.Ready(msg)
-}
-
-// RemoveNode removes all messages (submitted and ready) for the given node.
-func (b *BufferQueue) RemoveNode(nodeID identity.ID) {
-	element, ok := b.activeNode[nodeID]
-	if !ok {
-		return
-	}
-
-	nodeQueue := element.Value.(*NodeQueue)
-	b.size -= nodeQueue.Size()
-
-	b.ringRemove(element)
-	delete(b.activeNode, nodeID)
 }
 
 // Next returns the next NodeQueue in round robin order.
@@ -165,7 +152,7 @@ func (b *BufferQueue) PopFront() Element {
 		delete(b.activeNode, identity.NewID(msg.IssuerPublicKey()))
 	}
 
-	b.size -= uint(len(msg.Bytes()))
+	b.size.Sub(uint64(len(msg.Bytes())))
 	return msg
 }
 

--- a/packages/tangle/schedulerutils/bufferqueue.go
+++ b/packages/tangle/schedulerutils/bufferqueue.go
@@ -2,7 +2,6 @@ package schedulerutils
 
 import (
 	"container/ring"
-	"errors"
 
 	"github.com/iotaledger/hive.go/identity"
 	"golang.org/x/xerrors"
@@ -18,13 +17,11 @@ var MaxQueueWeight = 1024.0
 
 var (
 	// ErrInboxExceeded is returned when a node has exceeded its allowed inbox size.
-	ErrInboxExceeded = errors.New("maximum mana-scaled inbox length exceeded")
-
+	ErrInboxExceeded = xerrors.New("maximum mana-scaled inbox length exceeded")
 	// ErrInvalidMana is returned when the mana is <= 0.
-	ErrInvalidMana = errors.New("mana cannot be <= 0")
-
+	ErrInvalidMana = xerrors.New("mana cannot be <= 0")
 	// ErrBufferFull is returned when the maximum buffer size is exceeded.
-	ErrBufferFull = errors.New("maximum buffer size exceeded")
+	ErrBufferFull = xerrors.New("maximum buffer size exceeded")
 )
 
 // region BufferQueue /////////////////////////////////////////////////////////////////////////////////////////////

--- a/packages/tangle/schedulerutils/nodequeue.go
+++ b/packages/tangle/schedulerutils/nodequeue.go
@@ -31,7 +31,7 @@ func ElementIDFromBytes(bytes []byte) (result ElementID, err error) {
 
 // Element represents the generic interface for an message in NodeQueue.
 type Element interface {
-	// ID returns the ID of an Element.
+	// IDBytes returns the ID of an Element as a byte slice.
 	IDBytes() []byte
 
 	// Bytes returns a marshaled version of the Element.

--- a/packages/tangle/testutils.go
+++ b/packages/tangle/testutils.go
@@ -600,6 +600,7 @@ var (
 	totalAMana          = 1000.0
 	maxQueueWeight      = 1024.0 * 1024.0
 	testRate            = time.Second / 5000
+	noAManaNode         = identity.GenerateIdentity()
 	testSchedulerParams = SchedulerParams{
 		Rate:                        testRate,
 		MaxQueueWeight:              &maxQueueWeight,
@@ -608,7 +609,10 @@ var (
 	}
 )
 
-func accessManaRetriever(_ identity.ID) float64 {
+func accessManaRetriever(id identity.ID) float64 {
+	if id == noAManaNode.ID() {
+		return 0
+	}
 	return aMana
 }
 


### PR DESCRIPTION
- After shut down, don't accept new msg,
- `Shutdown()` blocks until the `BufferedQueue` is empty and everything has been scheduled.
- This does not consider the `MessageOpinionFormed` event, as this should be part of the booker.
- Fixes a bug in `SetRate()`; the rate as part of `SchedulerParams` are no longer optional