### PR TITLE
fix: Show nothing if msg.rank is 0

### DIFF
--- a/plugins/dashboard/frontend/src/app/components/ExplorerMessageQueryResult.tsx
+++ b/plugins/dashboard/frontend/src/app/components/ExplorerMessageQueryResult.tsx
@@ -150,7 +150,7 @@ export class ExplorerMessageQueryResult extends React.Component<Props, any> {
                         </Row>
 
                         {
-                            msg.rank &&
+                            !!msg.rank &&
                             <Row className={"mb-3"}>
                                 <Col>
                                     <h5>Markers</h5>


### PR DESCRIPTION
# Description of change
The marker section in message search result shows `0` instead of showing nothing if markers are not yet determined.   As figure:
![image](https://user-images.githubusercontent.com/11289354/119255074-4fc63d80-bbec-11eb-8010-3dd70d5dff2a.png)

This PR fixes this by applying boolean cast in condition `msg.rank`.
 
## Type of change

Bug fix

## Change checklist
- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
