### PR TITLE
Release v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# v0.6.2 - 2021-05-24
+* Add Congestion Control
+* Add global snapshot
+* Add Central Asset Registry to cli-wallet
+* Switch to RocksDB instead of BadgerDB
+* Enhance manual peering
+* Improve gossip
+* Improve APIs
+* Fix several dashboard bugs
+* Update lo latest hive.go
+* Update snapshot file 
+* **Breaking**: bumps network and database versions
+
 # v0.6.1 - 2021-05-19
 * Change Faucet default parameters
 * **Breaking**: bumps network and database versions

--- a/plugins/autopeering/discovery/parameters.go
+++ b/plugins/autopeering/discovery/parameters.go
@@ -5,7 +5,7 @@ import "github.com/iotaledger/hive.go/configuration"
 // Parameters contains the configuration parameters used by the message layer.
 var Parameters = struct {
 	// NetworkVersion defines the config flag of the network version.
-	NetworkVersion int `default:"29" usage:"autopeering network version"`
+	NetworkVersion int `default:"30" usage:"autopeering network version"`
 
 	// EntryNodes defines the config flag of the entry nodes.
 	EntryNodes []string `default:"2PV5487xMw5rasGBXXWeqSi4hLz7r19YBt8Y1TGAsQbj@ressims.iota.cafe:15626,5EDH4uY78EA6wrBkHHAVBWBMDt7EcksRq6pjzipoW15B@entryshimmer.tanglebay.com:14646" usage:"list of trusted entry nodes for auto peering"`

--- a/plugins/banner/plugin.go
+++ b/plugins/banner/plugin.go
@@ -17,7 +17,7 @@ var (
 	once   sync.Once
 
 	// AppVersion version number
-	AppVersion = "v0.6.1"
+	AppVersion = "v0.6.2"
 	// SimplifiedAppVersion is the version number without commit hash
 	SimplifiedAppVersion = simplifiedVersion(AppVersion)
 )

--- a/plugins/database/versioning.go
+++ b/plugins/database/versioning.go
@@ -11,7 +11,7 @@ import (
 const (
 	// DBVersion defines the version of the database schema this version of GoShimmer supports.
 	// Every time there's a breaking change regarding the stored data, this version flag should be adjusted.
-	DBVersion = 31
+	DBVersion = 32
 )
 
 var (


### PR DESCRIPTION
# v0.6.2 - 2021-05-24
* Add Congestion Control
* Add global snapshot
* Add Central Asset Registry to cli-wallet
* Switch to RocksDB instead of BadgerDB
* Enhance manual peering
* Improve gossip
* Improve APIs
* Fix several dashboard bugs
* Update lo latest hive.go
* Update snapshot file 
* **Breaking**: bumps network and database versions