### PR TITLE
Add action to manually trigger Docker builds

### DIFF
--- a/.github/workflows/docker-testing.yml
+++ b/.github/workflows/docker-testing.yml
@@ -1,0 +1,21 @@
+name: Manually Triggered Docker Image
+
+on: workflow_dispatch
+
+jobs:
+
+  docker:
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_BUILDKIT: 1
+    steps:
+      -   name: Checkout repository
+          uses: actions/checkout@v2
+
+      -   name: Publish to Docker Hub
+          uses: docker/build-push-action@92e71463491f2d026a477188b8ad3a0fdd9d672c
+          with:
+            repository: iotaledger/goshimmer
+            username: '${{ secrets.IOTALEDGER_HUB_DOCKER_LOGIN }}'
+            password: '${{ secrets.IOTALEDGER_HUB_DOCKER_PASSWORD }}'
+            tags: testing


### PR DESCRIPTION
Once merged, this PR adds the `Manually Triggered Docker Image` Action that can then manually be triggered using the Actions tab on GitHub, GitHub CLI, or the REST API. It publishes a new Docker images of the provided branch on Docker Hub under the `testing` label. 