### PR TITLE
Simplify manual peering API

### DIFF
--- a/client/manualpeering.go
+++ b/client/manualpeering.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 
 	"github.com/cockroachdb/errors"
-	"github.com/iotaledger/hive.go/autopeering/peer"
 	"github.com/iotaledger/hive.go/crypto/ed25519"
 
 	"github.com/iotaledger/goshimmer/packages/manualpeering"
@@ -12,7 +11,7 @@ import (
 )
 
 // AddManualPeers adds the provided list of peers to the manual peering layer.
-func (api *GoShimmerAPI) AddManualPeers(peers []*peer.Peer) error {
+func (api *GoShimmerAPI) AddManualPeers(peers []*manualpeering.KnownPeerToAdd) error {
 	if err := api.do(http.MethodPost, plugin.RouteManualPeers, peers, nil); err != nil {
 		return errors.Wrap(err, "failed to add manual peers via the HTTP API")
 	}

--- a/packages/manualpeering/manualpeering.go
+++ b/packages/manualpeering/manualpeering.go
@@ -2,10 +2,13 @@ package manualpeering
 
 import (
 	"context"
+	"encoding/json"
+	"net"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/iotaledger/hive.go/autopeering/peer/service"
 	"github.com/iotaledger/hive.go/typeutils"
 
 	"github.com/iotaledger/goshimmer/packages/gossip"
@@ -41,10 +44,46 @@ const (
 	ConnStatusConnected ConnectionStatus = "connected"
 )
 
+// KnownPeerToAdd defines a type that is used in .AddPeer() method.
+type KnownPeerToAdd struct {
+	PublicKey ed25519.PublicKey
+	Address   string
+}
+
+type knownPeerToAdd struct {
+	PublicKey string `json:"publicKey"`
+	Address   string `json:"address"`
+}
+
+// MarshalJSON encodes KnownPeerToAdd to JSON.
+func (pta *KnownPeerToAdd) MarshalJSON() ([]byte, error) {
+	data := &knownPeerToAdd{
+		PublicKey: pta.PublicKey.String(),
+		Address:   pta.Address,
+	}
+	return json.Marshal(data)
+}
+
+// UnMarshalJSON decodes JSON into KnownPeerToAdd.
+func (pta *KnownPeerToAdd) UnMarshalJSON(b []byte) error {
+	data := &knownPeerToAdd{}
+	if err := json.Unmarshal(b, data); err != nil {
+		return err
+	}
+	pta.Address = data.Address
+
+	var err error
+	pta.PublicKey, err = ed25519.PublicKeyFromString(data.PublicKey)
+	if err != nil {
+		return errors.Wrap(err, "couldn't parse public key")
+	}
+	return nil
+}
+
 // KnownPeer defines a peer record in the manualpeering layer.
-// This type contains the actual peer reference, connection direction and the gossip connection status.
 type KnownPeer struct {
-	Peer          *peer.Peer          `json:"peer"`
+	PublicKey     ed25519.PublicKey   `json:"publicKey"`
+	Address       string              `json:"address"`
 	ConnDirection ConnectionDirection `json:"connectionDirection"`
 	ConnStatus    ConnectionStatus    `json:"connectionStatus"`
 }
@@ -89,7 +128,7 @@ func NewManager(gm *gossip.Manager, local *peer.Local, log *logger.Logger) *Mana
 }
 
 // AddPeer adds multiple peers to the list of known peers.
-func (m *Manager) AddPeer(peers ...*peer.Peer) error {
+func (m *Manager) AddPeer(peers ...*KnownPeerToAdd) error {
 	var resultErr error
 	for _, p := range peers {
 		if err := m.addPeer(p); err != nil {
@@ -153,7 +192,8 @@ func (m *Manager) GetKnownPeers(opts ...GetKnownPeersOption) []*KnownPeer {
 		connStatus := kp.getConnStatus()
 		if !conf.OnlyConnected || connStatus == ConnStatusConnected {
 			peers = append(peers, &KnownPeer{
-				Peer:          kp.peer,
+				PublicKey:     kp.peer.PublicKey(),
+				Address:       kp.peerAddress,
 				ConnDirection: kp.connDirection,
 				ConnStatus:    connStatus,
 			})
@@ -190,22 +230,31 @@ func (m *Manager) Stop() (err error) {
 
 type knownPeer struct {
 	peer          *peer.Peer
+	peerAddress   string
 	connDirection ConnectionDirection
 	connStatus    *atomic.Value
 	removeCh      chan struct{}
 	doneCh        chan struct{}
 }
 
-func newKnownPeer(p *peer.Peer, connDirection ConnectionDirection) *knownPeer {
+func newKnownPeer(p *KnownPeerToAdd, connDirection ConnectionDirection) (*knownPeer, error) {
+	tcpAddress, err := net.ResolveTCPAddr("tcp", p.Address)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to parse peer address")
+	}
+	services := service.New()
+	services.Update(service.PeeringKey, "tcp", 14626)
+	services.Update(service.GossipKey, tcpAddress.Network(), tcpAddress.Port)
 	kp := &knownPeer{
-		peer:          p,
+		peer:          peer.NewPeer(identity.New(p.PublicKey), tcpAddress.IP, services),
+		peerAddress:   p.Address,
 		connDirection: connDirection,
 		connStatus:    &atomic.Value{},
 		removeCh:      make(chan struct{}),
 		doneCh:        make(chan struct{}),
 	}
 	kp.setConnStatus(ConnStatusDisconnected)
-	return kp
+	return kp, nil
 }
 
 func (kp *knownPeer) getConnStatus() ConnectionStatus {
@@ -216,7 +265,7 @@ func (kp *knownPeer) setConnStatus(cs ConnectionStatus) {
 	kp.connStatus.Store(cs)
 }
 
-func (m *Manager) addPeer(p *peer.Peer) error {
+func (m *Manager) addPeer(p *KnownPeerToAdd) error {
 	if !m.isStarted.IsSet() {
 		return errors.New("manualpeering manager hasn't been started yet")
 	}
@@ -227,11 +276,14 @@ func (m *Manager) addPeer(p *peer.Peer) error {
 	}
 	m.knownPeersMutex.Lock()
 	defer m.knownPeersMutex.Unlock()
-	connDirection, err := m.connectionDirection(p)
+	connDirection, err := m.connectionDirection(p.PublicKey)
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	kp := newKnownPeer(p, connDirection)
+	kp, err := newKnownPeer(p, connDirection)
+	if err != nil {
+		return errors.WithStack(err)
+	}
 	if _, exists := m.knownPeers[kp.peer.ID()]; exists {
 		return nil
 	}
@@ -342,18 +394,18 @@ func (m *Manager) changeNeighborStatus(neighbor *gossip.Neighbor, connStatus Con
 	kp.setConnStatus(connStatus)
 }
 
-func (m *Manager) connectionDirection(p *peer.Peer) (ConnectionDirection, error) {
-	localPK := m.local.PublicKey().String()
-	peerPK := p.PublicKey().String()
-	if localPK < peerPK {
+func (m *Manager) connectionDirection(peerPK ed25519.PublicKey) (ConnectionDirection, error) {
+	localPKStr := m.local.PublicKey().String()
+	peerPKStr := peerPK.String()
+	if localPKStr < peerPKStr {
 		return ConnDirectionOutbound, nil
-	} else if localPK > peerPK {
+	} else if localPKStr > peerPKStr {
 		return ConnDirectionInbound, nil
 	} else {
 		return "", errors.Newf(
 			"manualpeering: provided neighbor public key %s is the same as the local %s: can't compare lexicographically",
-			peerPK,
-			localPK,
+			peerPKStr,
+			localPKStr,
 		)
 	}
 }

--- a/packages/manualpeering/manualpeering.go
+++ b/packages/manualpeering/manualpeering.go
@@ -6,7 +6,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/iotaledger/hive.go/autopeering/peer/service"
 	"github.com/iotaledger/hive.go/typeutils"
 
 	"github.com/iotaledger/goshimmer/packages/gossip"
@@ -218,9 +217,6 @@ func (kp *knownPeer) setConnStatus(cs ConnectionStatus) {
 }
 
 func (m *Manager) addPeer(p *peer.Peer) error {
-	services := p.Services().CreateRecord()
-	services.Update(service.PeeringKey, "tcp", 343)
-	p = peer.NewPeer(p.Identity, p.IP(), services)
 	if !m.isStarted.IsSet() {
 		return errors.New("manualpeering manager hasn't been started yet")
 	}

--- a/packages/manualpeering/manualpeering.go
+++ b/packages/manualpeering/manualpeering.go
@@ -6,6 +6,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/iotaledger/hive.go/autopeering/peer/service"
 	"github.com/iotaledger/hive.go/typeutils"
 
 	"github.com/iotaledger/goshimmer/packages/gossip"
@@ -217,6 +218,9 @@ func (kp *knownPeer) setConnStatus(cs ConnectionStatus) {
 }
 
 func (m *Manager) addPeer(p *peer.Peer) error {
+	services := p.Services().CreateRecord()
+	services.Update(service.PeeringKey, "tcp", 343)
+	p = peer.NewPeer(p.Identity, p.IP(), services)
 	if !m.isStarted.IsSet() {
 		return errors.New("manualpeering manager hasn't been started yet")
 	}

--- a/packages/manualpeering/manualpeering.go
+++ b/packages/manualpeering/manualpeering.go
@@ -243,6 +243,8 @@ func newKnownPeer(p *KnownPeerToAdd, connDirection ConnectionDirection) (*knownP
 		return nil, errors.Wrap(err, "failed to parse peer address")
 	}
 	services := service.New()
+	// Peering key is required in order to initialize a peer,
+	// but it's not used in both manualpeering and gossip layers so we just specify the default one.
 	services.Update(service.PeeringKey, "tcp", 14626)
 	services.Update(service.GossipKey, tcpAddress.Network(), tcpAddress.Port)
 	kp := &knownPeer{

--- a/packages/manualpeering/manualpeering.go
+++ b/packages/manualpeering/manualpeering.go
@@ -64,8 +64,8 @@ func (pta *KnownPeerToAdd) MarshalJSON() ([]byte, error) {
 	return json.Marshal(data)
 }
 
-// UnMarshalJSON decodes JSON into KnownPeerToAdd.
-func (pta *KnownPeerToAdd) UnMarshalJSON(b []byte) error {
+// UnmarshalJSON decodes JSON into KnownPeerToAdd.
+func (pta *KnownPeerToAdd) UnmarshalJSON(b []byte) error {
 	data := &knownPeerToAdd{}
 	if err := json.Unmarshal(b, data); err != nil {
 		return err

--- a/packages/manualpeering/manualpeering.go
+++ b/packages/manualpeering/manualpeering.go
@@ -1,6 +1,7 @@
 package manualpeering
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net"
@@ -397,17 +398,16 @@ func (m *Manager) changeNeighborStatus(neighbor *gossip.Neighbor, connStatus Con
 }
 
 func (m *Manager) connectionDirection(peerPK ed25519.PublicKey) (ConnectionDirection, error) {
-	localPKStr := m.local.PublicKey().String()
-	peerPKStr := peerPK.String()
-	if localPKStr < peerPKStr {
+	result := bytes.Compare(m.local.PublicKey().Bytes(), peerPK.Bytes())
+	if result < 0 {
 		return ConnDirectionOutbound, nil
-	} else if localPKStr > peerPKStr {
+	} else if result > 0 {
 		return ConnDirectionInbound, nil
 	} else {
 		return "", errors.Newf(
 			"manualpeering: provided neighbor public key %s is the same as the local %s: can't compare lexicographically",
-			peerPKStr,
-			localPKStr,
+			peerPK,
+			m.local.PublicKey(),
 		)
 	}
 }

--- a/plugins/manualpeering/plugin.go
+++ b/plugins/manualpeering/plugin.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/cockroachdb/errors"
 
-	"github.com/iotaledger/hive.go/autopeering/peer"
-
 	"github.com/iotaledger/goshimmer/plugins/config"
 
 	"github.com/iotaledger/hive.go/daemon"
@@ -84,14 +82,14 @@ func addPeersFromConfigToManager(mgr *manualpeering.Manager) {
 	}
 }
 
-func getKnownPeersFromConfig() ([]*peer.Peer, error) {
+func getKnownPeersFromConfig() ([]*manualpeering.KnownPeerToAdd, error) {
 	rawMap := config.Node().Get(CfgManualpeeringKnownPeers)
 	// This is a hack to transform a map from config into peer.Peer struct.
 	jsonData, err := json.Marshal(rawMap)
 	if err != nil {
 		return nil, errors.Wrap(err, "can't marshal known peers map from config into json data")
 	}
-	var peers []*peer.Peer
+	var peers []*manualpeering.KnownPeerToAdd
 	if err := json.Unmarshal(jsonData, &peers); err != nil {
 		return nil, errors.Wrap(err, "can't parse peers from json")
 	}

--- a/plugins/manualpeering/webapi.go
+++ b/plugins/manualpeering/webapi.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cockroachdb/errors"
 
-	"github.com/iotaledger/hive.go/autopeering/peer"
 	"github.com/iotaledger/hive.go/crypto/ed25519"
 	"github.com/labstack/echo"
 
@@ -28,22 +27,12 @@ An example of the HTTP JSON request:
 [
     {
         "publicKey": "EYsaGXnUVA9aTYL9FwYEvoQ8d1HCJveQVL7vogu6pqCP",
-        "ip": "172.19.0.3",
-        "services": {
-            "peering":{
-                "network":"TCP",
-                "port":14626
-            },
-            "gossip": {
-                "network": "TCP",
-                "port": 14666
-            }
-        }
+        "address": "172.19.0.3:14666"
     }
 ]
 */
 func addPeersHandler(c echo.Context) error {
-	var peers []*peer.Peer
+	var peers []*manualpeering.KnownPeerToAdd
 	if err := webapi.ParseJSONRequest(c, &peers); err != nil {
 		plugin.Logger().Errorw("Failed to parse peers from the request", "err", err)
 		return c.JSON(

--- a/tools/integration-tests/tester/framework/network.go
+++ b/tools/integration-tests/tester/framework/network.go
@@ -300,7 +300,7 @@ func (n *Network) DoManualPeering(peers ...*Peer) error {
 		allOtherPeers := make([]*Peer, 0, len(peers)-1)
 		allOtherPeers = append(allOtherPeers, peers[:idx]...)
 		allOtherPeers = append(allOtherPeers, peers[idx+1:]...)
-		peersToAdd := ToPeerModels(allOtherPeers)
+		peersToAdd := ToKnownPeers(allOtherPeers)
 		if err := p.AddManualPeers(peersToAdd); err != nil {
 			return errors.Wrap(err, "failed to add manual peers via API")
 		}

--- a/tools/integration-tests/tester/framework/peer.go
+++ b/tools/integration-tests/tester/framework/peer.go
@@ -2,16 +2,14 @@ package framework
 
 import (
 	"fmt"
-	"net"
 	"net/http"
 	"time"
 
-	"github.com/iotaledger/hive.go/autopeering/peer"
-	"github.com/iotaledger/hive.go/autopeering/peer/service"
 	"github.com/iotaledger/hive.go/identity"
 
 	"github.com/iotaledger/goshimmer/client"
 	walletseed "github.com/iotaledger/goshimmer/client/wallet/packages/seed"
+	"github.com/iotaledger/goshimmer/packages/manualpeering"
 )
 
 // Peer represents a GoShimmer node inside the Docker network
@@ -67,21 +65,17 @@ func (p *Peer) SetNeighborsNumber(number int) {
 	p.neighborsNumber = number
 }
 
-func (p *Peer) ToPeerModel() *peer.Peer {
-	services := service.New()
-	const defaultFPCPort = 10895
-	services.Update(service.FPCKey, "TCP", defaultFPCPort)
-	const defaultPeeringPort = 14626
-	services.Update(service.PeeringKey, "TCP", defaultPeeringPort)
-	const defaultGossipPort = 14666
-	services.Update(service.GossipKey, "TCP", defaultGossipPort)
-	return peer.NewPeer(p.Identity, net.ParseIP(p.ip), services)
+func (p *Peer) ToKnownPeer() *manualpeering.KnownPeerToAdd {
+	return &manualpeering.KnownPeerToAdd{
+		PublicKey: p.PublicKey(),
+		Address:   fmt.Sprintf("%s:14666", p.ip),
+	}
 }
 
-func ToPeerModels(peers []*Peer) []*peer.Peer {
-	models := make([]*peer.Peer, len(peers))
+func ToKnownPeers(peers []*Peer) []*manualpeering.KnownPeerToAdd {
+	models := make([]*manualpeering.KnownPeerToAdd, len(peers))
 	for i, p := range peers {
-		models[i] = p.ToPeerModel()
+		models[i] = p.ToKnownPeer()
 	}
 	return models
 }


### PR DESCRIPTION
This PR hides the complexity of the `peer.Peer` structure from the end-user of the manual peering module. Now the web API request to add known peers looks like that:
```json
[
    {
      "publicKey": "EYsaGXnUVA9aTYL9FwYEvoQ8d1HCJveQVL7vogu6pqCP",
      "address": "172.19.0.3:14666"
    }
]
```
Instead of the previous one:
```json
[
    {
      "publicKey": "EYsaGXnUVA9aTYL9FwYEvoQ8d1HCJveQVL7vogu6pqCP",
      "ip": "172.19.0.3",
      "services": {
        "peering":{
          "network":"TCP",
          "port":14626
        },
        "gossip": {
          "network": "TCP",
          "port": 14666
        }
      }
    }
]
```
We no longer require the "peering" service port, because it's not needed in both manual peering and gossip. And it might have confused the user.