### PR TITLE
Fix Mana Dashboard Feed Workerpool Deadlock

### DIFF
--- a/packages/mana/consensusbasevector.go
+++ b/packages/mana/consensusbasevector.go
@@ -139,8 +139,7 @@ func (c *ConsensusBaseManaVector) Book(txInfo *TxInfo) {
 			oldMana := *c.vector[pledgeNodeID]
 			// revoke BM1
 			err := c.vector[pledgeNodeID].revoke(inputInfo.Amount)
-			switch err {
-			case ErrBaseManaNegative:
+			if errors.Is(err, ErrBaseManaNegative) {
 				panic(fmt.Sprintf("Revoking %f base mana 1 from node %s results in negative balance", inputInfo.Amount, pledgeNodeID.String()))
 			}
 			// save events for later triggering

--- a/packages/mana/consensusbasevector.go
+++ b/packages/mana/consensusbasevector.go
@@ -119,53 +119,69 @@ func (c *ConsensusBaseManaVector) LoadSnapshot(snapshot map[identity.ID]Snapshot
 
 // Book books mana for a transaction.
 func (c *ConsensusBaseManaVector) Book(txInfo *TxInfo) {
-	c.Lock()
-	defer c.Unlock()
-	// first, revoke mana from previous owners
-	for _, inputInfo := range txInfo.InputInfos {
-		// which node did the input pledge mana to?
-		pledgeNodeID := inputInfo.PledgeID[c.Type()]
+	// gather events to be triggered once the lock is lifted
+	var revokeEvents []*RevokedEvent
+	var pledgeEvents []*PledgedEvent
+	var updateEvents []*UpdatedEvent
+	// only lock mana vector while we are working with it
+	func() {
+		c.Lock()
+		defer c.Unlock()
+		// first, revoke mana from previous owners
+		for _, inputInfo := range txInfo.InputInfos {
+			// which node did the input pledge mana to?
+			pledgeNodeID := inputInfo.PledgeID[c.Type()]
+			if _, exist := c.vector[pledgeNodeID]; !exist {
+				// first time we see this node
+				c.vector[pledgeNodeID] = &ConsensusBaseMana{}
+			}
+			// save old mana
+			oldMana := *c.vector[pledgeNodeID]
+			// revoke BM1
+			err := c.vector[pledgeNodeID].revoke(inputInfo.Amount)
+			switch err {
+			case ErrBaseManaNegative:
+				panic(fmt.Sprintf("Revoking %f base mana 1 from node %s results in negative balance", inputInfo.Amount, pledgeNodeID.String()))
+			}
+			// save events for later triggering
+			revokeEvents = append(revokeEvents, &RevokedEvent{pledgeNodeID, inputInfo.Amount, txInfo.TimeStamp, c.Type(), txInfo.TransactionID, inputInfo.InputID})
+			updateEvents = append(updateEvents, &UpdatedEvent{pledgeNodeID, &oldMana, c.vector[pledgeNodeID], c.Type()})
+		}
+		// second, pledge mana to new nodes
+		pledgeNodeID := txInfo.PledgeID[c.Type()]
 		if _, exist := c.vector[pledgeNodeID]; !exist {
 			// first time we see this node
 			c.vector[pledgeNodeID] = &ConsensusBaseMana{}
 		}
-		// save old mana
+		// save it for proper event trigger
 		oldMana := *c.vector[pledgeNodeID]
-		// revoke BM1
-		err := c.vector[pledgeNodeID].revoke(inputInfo.Amount)
-		switch err {
-		case ErrBaseManaNegative:
-			panic(fmt.Sprintf("Revoking %f base mana 1 from node %s results in negative balance", inputInfo.Amount, pledgeNodeID.String()))
-		}
-		// trigger events
-		Events().Revoked.Trigger(&RevokedEvent{pledgeNodeID, inputInfo.Amount, txInfo.TimeStamp, c.Type(), txInfo.TransactionID, inputInfo.InputID})
-		Events().Updated.Trigger(&UpdatedEvent{pledgeNodeID, &oldMana, c.vector[pledgeNodeID], c.Type()})
-	}
-	// second, pledge mana to new nodes
-	pledgeNodeID := txInfo.PledgeID[c.Type()]
-	if _, exist := c.vector[pledgeNodeID]; !exist {
-		// first time we see this node
-		c.vector[pledgeNodeID] = &ConsensusBaseMana{}
-	}
-	// save it for proper event trigger
-	oldMana := *c.vector[pledgeNodeID]
-	// actually pledge and update
-	pledged := c.vector[pledgeNodeID].pledge(txInfo)
+		// actually pledge and update
+		pledged := c.vector[pledgeNodeID].pledge(txInfo)
+		pledgeEvents = append(pledgeEvents, &PledgedEvent{
+			NodeID:        pledgeNodeID,
+			Amount:        pledged,
+			Time:          txInfo.TimeStamp,
+			ManaType:      c.Type(),
+			TransactionID: txInfo.TransactionID,
+		})
+		updateEvents = append(updateEvents, &UpdatedEvent{
+			NodeID:   pledgeNodeID,
+			OldMana:  &oldMana,
+			NewMana:  c.vector[pledgeNodeID],
+			ManaType: c.Type(),
+		})
+	}()
 
-	// trigger events
-	Events().Pledged.Trigger(&PledgedEvent{
-		NodeID:        pledgeNodeID,
-		Amount:        pledged,
-		Time:          txInfo.TimeStamp,
-		ManaType:      c.Type(),
-		TransactionID: txInfo.TransactionID,
-	})
-	Events().Updated.Trigger(&UpdatedEvent{
-		NodeID:   pledgeNodeID,
-		OldMana:  &oldMana,
-		NewMana:  c.vector[pledgeNodeID],
-		ManaType: c.Type(),
-	})
+	// trigger the events once we released the lock on the mana vector
+	for _, ev := range revokeEvents {
+		Events().Revoked.Trigger(ev)
+	}
+	for _, ev := range pledgeEvents {
+		Events().Pledged.Trigger(ev)
+	}
+	for _, ev := range updateEvents {
+		Events().Updated.Trigger(ev)
+	}
 }
 
 // Update updates the mana entries for a particular node wrt time.

--- a/plugins/dashboard/manafeed.go
+++ b/plugins/dashboard/manafeed.go
@@ -55,10 +55,10 @@ func configureManaFeed() {
 
 func runManaFeed() {
 	notifyManaPledge := events.NewClosure(func(ev *mana.PledgedEvent) {
-		manaFeedWorkerPool.Submit(MsgTypeManaPledge, ev)
+		manaFeedWorkerPool.TrySubmit(MsgTypeManaPledge, ev)
 	})
 	notifyManaRevoke := events.NewClosure(func(ev *mana.RevokedEvent) {
-		manaFeedWorkerPool.Submit(MsgTypeManaRevoke, ev)
+		manaFeedWorkerPool.TrySubmit(MsgTypeManaRevoke, ev)
 	})
 	if err := daemon.BackgroundWorker("Dashboard[ManaUpdater]", func(shutdownSignal <-chan struct{}) {
 		mana.Events().Pledged.Attach(notifyManaPledge)
@@ -74,9 +74,9 @@ func runManaFeed() {
 				log.Info("Stopping Dashboard[ManaUpdater] ... done")
 				return
 			case <-manaTicker.C:
-				manaFeedWorkerPool.Submit(MsgTypeManaValue)
-				manaFeedWorkerPool.Submit(MsgTypeManaMapOverall)
-				manaFeedWorkerPool.Submit(MsgTypeManaMapOnline)
+				manaFeedWorkerPool.TrySubmit(MsgTypeManaValue)
+				manaFeedWorkerPool.TrySubmit(MsgTypeManaMapOverall)
+				manaFeedWorkerPool.TrySubmit(MsgTypeManaMapOnline)
 			}
 		}
 	}, shutdown.PriorityDashboard); err != nil {

--- a/plugins/dashboard/manafeed.go
+++ b/plugins/dashboard/manafeed.go
@@ -21,7 +21,7 @@ import (
 
 var (
 	manaFeedWorkerCount     = 1
-	manaFeedWorkerQueueSize = 50
+	manaFeedWorkerQueueSize = 500
 	manaFeedWorkerPool      *workerpool.WorkerPool
 	manaBuffer              *ManaBuffer
 	manaBufferOnce          sync.Once


### PR DESCRIPTION
# Description of change

 - Mana events were triggered while holding the lock of the base mana vectors. Dashboard mana updater listened to these events, and in turn tried to fetch values from the mana vector. Such tasks in the workerpool are blocked. In the unlikely scenario when the rather small queue of the mana updater workerpool is full with such tasks that are waiting for the lock, `Submit()` is blocking because it is waiting for the queue to be exhausted. Therefore, when a regular msg booker routine reached the mana booking while the worker pool is blocked, essentially the whole node is deadlocked, nothing can be booked.


