### PR TITLE
Get rid of JSON wrappers around ed25519.PublicKey

### DIFF
--- a/client/manualpeering.go
+++ b/client/manualpeering.go
@@ -26,7 +26,7 @@ func (api *GoShimmerAPI) AddManualPeers(peers []*manualpeering.KnownPeerToAdd) e
 func (api *GoShimmerAPI) RemoveManualPeers(keys []ed25519.PublicKey) error {
 	peersToRemove := make([]*jsonmodels.PeerToRemove, len(keys))
 	for i, key := range keys {
-		peersToRemove[i] = &jsonmodels.PeerToRemove{PublicKey: key.String()}
+		peersToRemove[i] = &jsonmodels.PeerToRemove{PublicKey: key}
 	}
 	if err := api.do(http.MethodDelete, routeManualPeers, peersToRemove, nil); err != nil {
 		return errors.Wrap(err, "failed to remove manual peers via the HTTP API")

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/go-resty/resty/v2 v2.6.0
 	github.com/golang/protobuf v1.4.3
 	github.com/gorilla/websocket v1.4.2
-	github.com/iotaledger/hive.go v0.0.0-20210523190624-62dd208e10b0
+	github.com/iotaledger/hive.go v0.0.0-20210528084758-64316bc539bb
 	github.com/labstack/echo v3.3.10+incompatible
 	github.com/labstack/gommon v0.3.0
 	github.com/linxGnu/grocksdb v1.6.35 // indirect

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/go-resty/resty/v2 v2.6.0
 	github.com/golang/protobuf v1.4.3
 	github.com/gorilla/websocket v1.4.2
-	github.com/iotaledger/hive.go v0.0.0-20210528084758-64316bc539bb
+	github.com/iotaledger/hive.go v0.0.0-20210528180853-73ecfbb76bd7
 	github.com/labstack/echo v3.3.10+incompatible
 	github.com/labstack/gommon v0.3.0
 	github.com/linxGnu/grocksdb v1.6.35 // indirect

--- a/go.sum
+++ b/go.sum
@@ -409,6 +409,8 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/iotaledger/hive.go v0.0.0-20210523190624-62dd208e10b0 h1:Lzgcy6m+Zaf6aR0HjQMzTnboL7UI8A5qGsrPunMrTHw=
 github.com/iotaledger/hive.go v0.0.0-20210523190624-62dd208e10b0/go.mod h1:NyBg/Ny7FFAdDs59zdwTVoysU2ZbJVQnRwyLIDFKJYA=
+github.com/iotaledger/hive.go v0.0.0-20210528084758-64316bc539bb h1:C3wPgyrD0YZbFTh40Mr5yio7zhh+d2/yD/rLpinD7Bw=
+github.com/iotaledger/hive.go v0.0.0-20210528084758-64316bc539bb/go.mod h1:NyBg/Ny7FFAdDs59zdwTVoysU2ZbJVQnRwyLIDFKJYA=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.2/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.3/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=

--- a/go.sum
+++ b/go.sum
@@ -407,10 +407,8 @@ github.com/hydrogen18/memlistener v0.0.0-20141126152155-54553eb933fb/go.mod h1:q
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/iotaledger/hive.go v0.0.0-20210523190624-62dd208e10b0 h1:Lzgcy6m+Zaf6aR0HjQMzTnboL7UI8A5qGsrPunMrTHw=
-github.com/iotaledger/hive.go v0.0.0-20210523190624-62dd208e10b0/go.mod h1:NyBg/Ny7FFAdDs59zdwTVoysU2ZbJVQnRwyLIDFKJYA=
-github.com/iotaledger/hive.go v0.0.0-20210528084758-64316bc539bb h1:C3wPgyrD0YZbFTh40Mr5yio7zhh+d2/yD/rLpinD7Bw=
-github.com/iotaledger/hive.go v0.0.0-20210528084758-64316bc539bb/go.mod h1:NyBg/Ny7FFAdDs59zdwTVoysU2ZbJVQnRwyLIDFKJYA=
+github.com/iotaledger/hive.go v0.0.0-20210528180853-73ecfbb76bd7 h1:fidetnahXOAJdKzwBDeSaNe3/6y3C0r51KsTHVxJWy8=
+github.com/iotaledger/hive.go v0.0.0-20210528180853-73ecfbb76bd7/go.mod h1:NyBg/Ny7FFAdDs59zdwTVoysU2ZbJVQnRwyLIDFKJYA=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.2/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.3/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=

--- a/packages/jsonmodels/manualpeering.go
+++ b/packages/jsonmodels/manualpeering.go
@@ -1,7 +1,9 @@
 package jsonmodels
 
+import "github.com/iotaledger/hive.go/crypto/ed25519"
+
 // PeerToRemove holds the data that uniquely identifies the peer to be removed, e.g. public key or ID.
 // Only public key is supported for now.
 type PeerToRemove struct {
-	PublicKey string `json:"publicKey"`
+	PublicKey ed25519.PublicKey `json:"publicKey"`
 }

--- a/packages/manualpeering/manualpeering.go
+++ b/packages/manualpeering/manualpeering.go
@@ -3,7 +3,6 @@ package manualpeering
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -47,38 +46,8 @@ const (
 
 // KnownPeerToAdd defines a type that is used in .AddPeer() method.
 type KnownPeerToAdd struct {
-	PublicKey ed25519.PublicKey
-	Address   string
-}
-
-type knownPeerToAdd struct {
-	PublicKey string `json:"publicKey"`
+	PublicKey ed25519.PublicKey `json:"publicKey"`
 	Address   string `json:"address"`
-}
-
-// MarshalJSON encodes KnownPeerToAdd to JSON.
-func (pta *KnownPeerToAdd) MarshalJSON() ([]byte, error) {
-	data := &knownPeerToAdd{
-		PublicKey: pta.PublicKey.String(),
-		Address:   pta.Address,
-	}
-	return json.Marshal(data)
-}
-
-// UnmarshalJSON decodes JSON into KnownPeerToAdd.
-func (pta *KnownPeerToAdd) UnmarshalJSON(b []byte) error {
-	data := &knownPeerToAdd{}
-	if err := json.Unmarshal(b, data); err != nil {
-		return err
-	}
-	pta.Address = data.Address
-
-	var err error
-	pta.PublicKey, err = ed25519.PublicKeyFromString(data.PublicKey)
-	if err != nil {
-		return errors.Wrap(err, "couldn't parse public key")
-	}
-	return nil
 }
 
 // KnownPeer defines a peer record in the manualpeering layer.

--- a/plugins/manualpeering/webapi.go
+++ b/plugins/manualpeering/webapi.go
@@ -78,12 +78,8 @@ func removePeersHandler(c echo.Context) error {
 
 func removePeers(peers []*jsonmodels.PeerToRemove) error {
 	keys := make([]ed25519.PublicKey, len(peers))
-	for i, ntd := range peers {
-		publicKey, err := ed25519.PublicKeyFromString(ntd.PublicKey)
-		if err != nil {
-			return errors.Wrapf(err, "failed to parse public key %s from HTTP request", publicKey)
-		}
-		keys[i] = publicKey
+	for i, p := range peers {
+		keys[i] = p.PublicKey
 	}
 	if err := Manager().RemovePeer(keys...); err != nil {
 		return errors.Wrap(err, "manualpeering manager failed to remove some peers")

--- a/tools/integration-tests/tester/go.mod
+++ b/tools/integration-tests/tester/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/drand/drand v1.1.1
 	github.com/iotaledger/goshimmer v0.1.3
-	github.com/iotaledger/hive.go v0.0.0-20210528084758-64316bc539bb
+	github.com/iotaledger/hive.go v0.0.0-20210528180853-73ecfbb76bd7
 	github.com/mr-tron/base58 v1.2.0
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/stretchr/testify v1.7.0

--- a/tools/integration-tests/tester/go.mod
+++ b/tools/integration-tests/tester/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/drand/drand v1.1.1
 	github.com/iotaledger/goshimmer v0.1.3
-	github.com/iotaledger/hive.go v0.0.0-20210523190624-62dd208e10b0
+	github.com/iotaledger/hive.go v0.0.0-20210528084758-64316bc539bb
 	github.com/mr-tron/base58 v1.2.0
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/stretchr/testify v1.7.0

--- a/tools/integration-tests/tester/go.sum
+++ b/tools/integration-tests/tester/go.sum
@@ -149,7 +149,6 @@ github.com/dgraph-io/badger/v2 v2.0.3/go.mod h1:3KY8+bsP8wI0OEnQJAKpd4wIJW/Mm32y
 github.com/dgraph-io/ristretto v0.0.2-0.20200115201040-8f368f2f2ab3/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
 github.com/dgraph-io/ristretto v0.0.2 h1:a5WaUrDa0qm0YrAAS1tUykT5El3kt62KNZZeMxQn3po=
 github.com/dgraph-io/ristretto v0.0.2/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-farm v0.0.0-20190104051053-3adb47b1fb0f/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
@@ -407,10 +406,8 @@ github.com/hydrogen18/memlistener v0.0.0-20141126152155-54553eb933fb/go.mod h1:q
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/iotaledger/hive.go v0.0.0-20210523190624-62dd208e10b0 h1:Lzgcy6m+Zaf6aR0HjQMzTnboL7UI8A5qGsrPunMrTHw=
-github.com/iotaledger/hive.go v0.0.0-20210523190624-62dd208e10b0/go.mod h1:NyBg/Ny7FFAdDs59zdwTVoysU2ZbJVQnRwyLIDFKJYA=
-github.com/iotaledger/hive.go v0.0.0-20210528084758-64316bc539bb h1:C3wPgyrD0YZbFTh40Mr5yio7zhh+d2/yD/rLpinD7Bw=
-github.com/iotaledger/hive.go v0.0.0-20210528084758-64316bc539bb/go.mod h1:NyBg/Ny7FFAdDs59zdwTVoysU2ZbJVQnRwyLIDFKJYA=
+github.com/iotaledger/hive.go v0.0.0-20210528180853-73ecfbb76bd7 h1:fidetnahXOAJdKzwBDeSaNe3/6y3C0r51KsTHVxJWy8=
+github.com/iotaledger/hive.go v0.0.0-20210528180853-73ecfbb76bd7/go.mod h1:NyBg/Ny7FFAdDs59zdwTVoysU2ZbJVQnRwyLIDFKJYA=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.2/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.3/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=

--- a/tools/integration-tests/tester/go.sum
+++ b/tools/integration-tests/tester/go.sum
@@ -409,6 +409,8 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/iotaledger/hive.go v0.0.0-20210523190624-62dd208e10b0 h1:Lzgcy6m+Zaf6aR0HjQMzTnboL7UI8A5qGsrPunMrTHw=
 github.com/iotaledger/hive.go v0.0.0-20210523190624-62dd208e10b0/go.mod h1:NyBg/Ny7FFAdDs59zdwTVoysU2ZbJVQnRwyLIDFKJYA=
+github.com/iotaledger/hive.go v0.0.0-20210528084758-64316bc539bb h1:C3wPgyrD0YZbFTh40Mr5yio7zhh+d2/yD/rLpinD7Bw=
+github.com/iotaledger/hive.go v0.0.0-20210528084758-64316bc539bb/go.mod h1:NyBg/Ny7FFAdDs59zdwTVoysU2ZbJVQnRwyLIDFKJYA=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.2/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.3/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=

--- a/tools/rand-seed/go.mod
+++ b/tools/rand-seed/go.mod
@@ -3,7 +3,7 @@ module rand-seed
 go 1.16
 
 require (
-	github.com/iotaledger/hive.go v0.0.0-20210413130158-dd81d09e2d6e
+	github.com/iotaledger/hive.go v0.0.0-20210528084758-64316bc539bb
 	github.com/mr-tron/base58 v1.2.0
 	golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f // indirect
 )

--- a/tools/rand-seed/go.mod
+++ b/tools/rand-seed/go.mod
@@ -3,7 +3,7 @@ module rand-seed
 go 1.16
 
 require (
-	github.com/iotaledger/hive.go v0.0.0-20210528084758-64316bc539bb
+	github.com/iotaledger/hive.go v0.0.0-20210528180853-73ecfbb76bd7
 	github.com/mr-tron/base58 v1.2.0
 	golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f // indirect
 )

--- a/tools/rand-seed/go.sum
+++ b/tools/rand-seed/go.sum
@@ -129,6 +129,8 @@ github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/C
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/iotaledger/hive.go v0.0.0-20210413130158-dd81d09e2d6e h1:VIN2mUiiQhoHyB27Cm5vSSl/BBLS0M4EgWmfBTuhmw8=
 github.com/iotaledger/hive.go v0.0.0-20210413130158-dd81d09e2d6e/go.mod h1:NyBg/Ny7FFAdDs59zdwTVoysU2ZbJVQnRwyLIDFKJYA=
+github.com/iotaledger/hive.go v0.0.0-20210528084758-64316bc539bb h1:C3wPgyrD0YZbFTh40Mr5yio7zhh+d2/yD/rLpinD7Bw=
+github.com/iotaledger/hive.go v0.0.0-20210528084758-64316bc539bb/go.mod h1:NyBg/Ny7FFAdDs59zdwTVoysU2ZbJVQnRwyLIDFKJYA=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=
 github.com/iris-contrib/go.uuid v2.0.0+incompatible/go.mod h1:iz2lgM/1UnEf1kP0L/+fafWORmlnuysV2EMP8MW+qe0=
 github.com/iris-contrib/i18n v0.0.0-20171121225848-987a633949d0/go.mod h1:pMCz62A0xJL6I+umB2YTlFRwWXaDFA0jy+5HzGiJjqI=

--- a/tools/rand-seed/go.sum
+++ b/tools/rand-seed/go.sum
@@ -127,10 +127,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/hydrogen18/memlistener v0.0.0-20141126152155-54553eb933fb/go.mod h1:qEIFzExnS6016fRpRfxrExeVn2gbClQA99gQhnIcdhE=
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/iotaledger/hive.go v0.0.0-20210413130158-dd81d09e2d6e h1:VIN2mUiiQhoHyB27Cm5vSSl/BBLS0M4EgWmfBTuhmw8=
-github.com/iotaledger/hive.go v0.0.0-20210413130158-dd81d09e2d6e/go.mod h1:NyBg/Ny7FFAdDs59zdwTVoysU2ZbJVQnRwyLIDFKJYA=
-github.com/iotaledger/hive.go v0.0.0-20210528084758-64316bc539bb h1:C3wPgyrD0YZbFTh40Mr5yio7zhh+d2/yD/rLpinD7Bw=
-github.com/iotaledger/hive.go v0.0.0-20210528084758-64316bc539bb/go.mod h1:NyBg/Ny7FFAdDs59zdwTVoysU2ZbJVQnRwyLIDFKJYA=
+github.com/iotaledger/hive.go v0.0.0-20210528180853-73ecfbb76bd7 h1:fidetnahXOAJdKzwBDeSaNe3/6y3C0r51KsTHVxJWy8=
+github.com/iotaledger/hive.go v0.0.0-20210528180853-73ecfbb76bd7/go.mod h1:NyBg/Ny7FFAdDs59zdwTVoysU2ZbJVQnRwyLIDFKJYA=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=
 github.com/iris-contrib/go.uuid v2.0.0+incompatible/go.mod h1:iz2lgM/1UnEf1kP0L/+fafWORmlnuysV2EMP8MW+qe0=
 github.com/iris-contrib/i18n v0.0.0-20171121225848-987a633949d0/go.mod h1:pMCz62A0xJL6I+umB2YTlFRwWXaDFA0jy+5HzGiJjqI=


### PR DESCRIPTION
When https://github.com/iotaledger/hive.go/pull/267 is merged we no longer need to use wrappers around `ed25519.PublicKey` to marshal/unmarshal to JSON and we can clean up unnecessary types.