### PR TITLE
Release v0.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# v0.6.4 - 2021-05-29
+* Add simple chat dApp
+* Improve client lib
+* Improve manual peering and add tutorial
+* Improve docs and tutorials
+* Improve congestion control
+* Fix mana dashboard deadlock
+* Fix several bugs
+* Update snapshot file with Pollen UTXO at 2021-05-29 10:22 UTC
+* Update JS dependencies
+* Update lo latest hive.go
+* **Breaking**: bumps network and database versions
+
 # v0.6.3 - 2021-05-25
 * Improve congestion control
 * Fix builds

--- a/plugins/autopeering/discovery/parameters.go
+++ b/plugins/autopeering/discovery/parameters.go
@@ -5,7 +5,7 @@ import "github.com/iotaledger/hive.go/configuration"
 // Parameters contains the configuration parameters used by the message layer.
 var Parameters = struct {
 	// NetworkVersion defines the config flag of the network version.
-	NetworkVersion int `default:"31" usage:"autopeering network version"`
+	NetworkVersion int `default:"32" usage:"autopeering network version"`
 
 	// EntryNodes defines the config flag of the entry nodes.
 	EntryNodes []string `default:"2PV5487xMw5rasGBXXWeqSi4hLz7r19YBt8Y1TGAsQbj@ressims.iota.cafe:15626,5EDH4uY78EA6wrBkHHAVBWBMDt7EcksRq6pjzipoW15B@entryshimmer.tanglebay.com:14646" usage:"list of trusted entry nodes for auto peering"`

--- a/plugins/banner/plugin.go
+++ b/plugins/banner/plugin.go
@@ -17,7 +17,7 @@ var (
 	once   sync.Once
 
 	// AppVersion version number
-	AppVersion = "v0.6.3"
+	AppVersion = "v0.6.4"
 	// SimplifiedAppVersion is the version number without commit hash
 	SimplifiedAppVersion = simplifiedVersion(AppVersion)
 )

--- a/plugins/chat/plugin.go
+++ b/plugins/chat/plugin.go
@@ -60,6 +60,5 @@ func onReceiveMessageFromMessageLayer(messageID tangle.MessageID) {
 		return
 	}
 
-	app.LogInfo(chatEvent)
 	Events.MessageReceived.Trigger(chatEvent)
 }

--- a/plugins/database/versioning.go
+++ b/plugins/database/versioning.go
@@ -11,7 +11,7 @@ import (
 const (
 	// DBVersion defines the version of the database schema this version of GoShimmer supports.
 	// Every time there's a breaking change regarding the stored data, this version flag should be adjusted.
-	DBVersion = 33
+	DBVersion = 34
 )
 
 var (


### PR DESCRIPTION
# v0.6.4 - 2021-05-29
* Add simple chat dApp
* Improve client lib
* Improve manual peering and add tutorial
* Improve docs and tutorials
* Improve congestion control
* Fix mana dashboard deadlock
* Fix several bugs
* Update snapshot file with Pollen UTXO at 2021-05-29 10:22 UTC
* Update JS dependencies
* Update lo latest hive.go
* **Breaking**: bumps network and database versions