### PR TITLE
Decrease mana event buffer size for dashboard

### DIFF
--- a/plugins/analysis/dashboard/frontend/src/app/stores/ManaStore.tsx
+++ b/plugins/analysis/dashboard/frontend/src/app/stores/ManaStore.tsx
@@ -45,10 +45,10 @@ class RevokeEvent extends ManaEvent{
 const emptyRow = (<tr><td colSpan={4}>There are no nodes to view with the current search parameters.</td></tr>)
 const emptyListItem = (<ListGroupItem>There are no events to view with the current search parameters.</ListGroupItem>)
 
-// every 10 seconds, a new value arrives, so this is roughly 166 mins
-const maxStoredManaValues = 1000;
+// every 10 seconds, a new value arrives, so this is roughly 17 mins
+const maxStoredManaValues = 100;
 // number of previous pledge/revoke events we keep track of. (/2 of plugins/dashboard/maxManaEventsBufferSize)
-const maxEventsStored = 1000;
+const maxEventsStored = 100;
 
 export class ManaStore {
     // mana values (total network)

--- a/plugins/dashboard/frontend/src/app/stores/ManaStore.tsx
+++ b/plugins/dashboard/frontend/src/app/stores/ManaStore.tsx
@@ -90,10 +90,10 @@ class RevokeEvent extends ManaEvent{
 const emptyRow = (<tr><td colSpan={4}>There are no nodes to view with the current search parameters.</td></tr>)
 const emptyListItem = (<ListGroupItem>There are no events to view with the current search parameters.</ListGroupItem>)
 
-// every 10 seconds, a new value arrives, so this is roughly 166 mins
-const maxStoredManaValues = 1000;
+// every 10 seconds, a new value arrives, so this is roughly 17 mins
+const maxStoredManaValues = 100;
 // number of previous pledge/revoke events we keep track of. (/2 of plugins/dashboard/maxManaEventsBufferSize)
-const maxEventsStored = 1000;
+const maxEventsStored = 100;
 
 export class ManaStore {
     // mana values

--- a/plugins/dashboard/manabuffer.go
+++ b/plugins/dashboard/manabuffer.go
@@ -12,9 +12,9 @@ import (
 const (
 	// the age of the oldest event depends on number of utxo inputs spent recently
 	// note, that this is aggregate for both access and consensus events.
-	maxManaEventsBufferSize = 2000
-	// oldest data is 10s * 1000 = 2.77 hours before dropping it
-	maxManaValuesBufferSize = 1000
+	maxManaEventsBufferSize = 200
+	// oldest data is 10s * 100 = 17 mins before dropping it
+	maxManaValuesBufferSize = 100
 )
 
 // ManaBuffer holds recent data related to mana in the dashboard. Used to fill frontend on page load/reload.


### PR DESCRIPTION
Loading/handling too many events slows done the page on less powerful machines.