### PR TITLE
'nectar' as default asset registry network

### DIFF
--- a/client/wallet/wallet.go
+++ b/client/wallet/wallet.go
@@ -38,7 +38,7 @@ const (
 	DefaultConfirmationTimeout = 150000 // in ms
 	milliSeconds               = 1000   // miliseconds in a second
 	// DefaultAssetRegistryNetwork is the default asset registry network.
-	DefaultAssetRegistryNetwork = "test"
+	DefaultAssetRegistryNetwork = "nectar"
 )
 
 // ErrTooManyOutputs is an error returned when the number of outputs/inputs exceeds the protocol wide constant

--- a/tools/cli-wallet/config.go
+++ b/tools/cli-wallet/config.go
@@ -28,7 +28,7 @@ var configJSON = `{
 	},
 	"reuse_addresses": false,
 	"faucetPowDifficulty": 25,
-	"assetRegistryNetwork": "test"
+	"assetRegistryNetwork": "nectar"
 }`
 
 // load the config file


### PR DESCRIPTION
# Description of change

- Wallet library and cli-wallet use `nectar` as asset registry network by default.
