### PR TITLE
Add `ConfirmedConsumer` field to output metadata api

### DIFF
--- a/packages/jsonmodels/ledgerstate.go
+++ b/packages/jsonmodels/ledgerstate.go
@@ -485,6 +485,7 @@ type OutputMetadata struct {
 	SolidificationTime int64     `json:"solidificationTime"`
 	ConsumerCount      int       `json:"consumerCount"`
 	FirstConsumer      string    `json:"firstConsumer,omitempty"`
+	ConfirmedConsumer  string    `json:"confirmedConsumer,omitempty"`
 	Finalized          bool      `json:"finalized"`
 }
 
@@ -495,6 +496,11 @@ func NewOutputMetadata(outputMetadata *ledgerstate.OutputMetadata) *OutputMetada
 	if outputMetadata.FirstConsumer().Base58() != ledgerstate.GenesisTransactionID.Base58() {
 		firstConsumer = outputMetadata.FirstConsumer().Base58()
 	}
+	confirmedConsumer := ""
+	// omit confirmedConsumer field if it hasn't been consumed yet by a confirmed transaction
+	if outputMetadata.ConfirmedConsumer().Base58() != ledgerstate.GenesisTransactionID.Base58() {
+		confirmedConsumer = outputMetadata.ConfirmedConsumer().Base58()
+	}
 	return &OutputMetadata{
 		OutputID:           NewOutputID(outputMetadata.ID()),
 		BranchID:           outputMetadata.BranchID().Base58(),
@@ -502,6 +508,7 @@ func NewOutputMetadata(outputMetadata *ledgerstate.OutputMetadata) *OutputMetada
 		SolidificationTime: outputMetadata.SolidificationTime().Unix(),
 		ConsumerCount:      outputMetadata.ConsumerCount(),
 		FirstConsumer:      firstConsumer,
+		ConfirmedConsumer:  confirmedConsumer,
 		Finalized:          outputMetadata.Finalized(),
 	}
 }

--- a/plugins/dashboard/frontend/src/app/components/ExplorerAddressResult.tsx
+++ b/plugins/dashboard/frontend/src/app/components/ExplorerAddressResult.tsx
@@ -247,6 +247,7 @@ class OutputMeta extends React.Component<omProps, any> {
                 <ListGroup.Item>Solidification Time: {new Date(metadata.solidificationTime * 1000).toLocaleString()}</ListGroup.Item>
                 <ListGroup.Item>Consumer Count: {metadata.consumerCount}</ListGroup.Item>
                 { metadata.firstConsumer && <ListGroup.Item>First Consumer: <a href={`/explorer/transaction/${metadata.firstConsumer}`}>{metadata.firstConsumer}</a> </ListGroup.Item>}
+                { metadata.confirmedConsumer && <ListGroup.Item>Confirmed Consumer: <a href={`/explorer/transaction/${metadata.confirmedConsumer}`}>{metadata.confirmedConsumer}</a> </ListGroup.Item>}
             </ListGroup>
         );
     }

--- a/plugins/dashboard/frontend/src/app/components/ExplorerOutputQueryResult.tsx
+++ b/plugins/dashboard/frontend/src/app/components/ExplorerOutputQueryResult.tsx
@@ -79,6 +79,7 @@ export class ExplorerOutputQueryResult extends React.Component<Props, any> {
                         <ListGroup.Item>Solidification Time: {new Date(outputMetadata.solidificationTime * 1000).toLocaleString()}</ListGroup.Item>
                         <ListGroup.Item>Consumer Count: {outputMetadata.consumerCount}</ListGroup.Item>
                         <ListGroup.Item>First Consumer: <a href={`/explorer/transaction/${outputMetadata.firstConsumer}`}>{outputMetadata.firstConsumer}</a> </ListGroup.Item>
+                        <ListGroup.Item>Confirmed Consumer: <a href={`/explorer/transaction/${outputMetadata.confirmedConsumer}`}>{outputMetadata.confirmedConsumer}</a> </ListGroup.Item>
                         <ListGroup.Item>Finalized: {outputMetadata.finalized.toString()}</ListGroup.Item>
                     </ListGroup>
                 </div>}

--- a/plugins/dashboard/frontend/src/app/stores/ExplorerStore.tsx
+++ b/plugins/dashboard/frontend/src/app/stores/ExplorerStore.tsx
@@ -71,7 +71,8 @@ export class OutputMetadata {
     solid: boolean;
     solidificationTime: number;
     consumerCount: number;
-    firstConsumer: string; //tx id
+    firstConsumer: string; // tx id of first consumer (can be unconfirmed)
+    confirmedConsumer: string // tx id of confirmed consumer
     finalized: boolean;
 }
 

--- a/plugins/dashboard/frontend/src/app/utils/output.tsx
+++ b/plugins/dashboard/frontend/src/app/utils/output.tsx
@@ -33,6 +33,10 @@ export function totalBalanceFromExplorerOutputs(outputs: Array<ExplorerOutput>, 
     if (outputs.length === 0) {return totalBalance;}
     for (let i = 0; i < outputs.length; i++) {
         let o = outputs[i];
+        if (o.inclusionState.finalized !== true) {
+            // ignore all unconfirmed balances
+            continue
+        }
         switch (o.output.type) {
             case "SigLockedSingleOutputType":
                 let single = o.output.output as SigLockedSingleOutput;


### PR DESCRIPTION
# Description of change

- Add `ConfirmedConsumer` field to output metadata api
- Fix balance calculation on address result page (dashboard)

Note: this is just cosmetics atm, can wait until the release
