### PR TITLE
refactor: Remove mana related settings from integration tests

### DIFF
--- a/tools/integration-tests/tester/framework/docker.go
+++ b/tools/integration-tests/tester/framework/docker.go
@@ -98,9 +98,6 @@ func (d *DockerContainer) CreateGoShimmerPeer(config GoShimmerConfig) error {
 				if config.ActivityPlugin {
 					plugins = append(plugins, "activity")
 				}
-				if config.Mana {
-					plugins = append(plugins, "Mana")
-				}
 				return strings.Join(plugins[:], ",")
 			}()),
 			// define the faucet seed in case the faucet dApp is enabled

--- a/tools/integration-tests/tester/framework/drngnetwork.go
+++ b/tools/integration-tests/tester/framework/drngnetwork.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/docker/docker/client"
 	"github.com/drand/drand/net"
-	walletseed "github.com/iotaledger/goshimmer/client/wallet/packages/seed"
 	"github.com/iotaledger/hive.go/crypto/ed25519"
 	"github.com/iotaledger/hive.go/identity"
 )
@@ -49,15 +48,6 @@ func (n *DRNGNetwork) CreatePeer(c GoShimmerConfig, publicKey ed25519.PublicKey)
 		config.FPCTotalRoundsFinalization = 10
 	}
 
-	// create wallet
-	var nodeSeed *walletseed.Seed
-	if c.Faucet {
-		nodeSeed = walletseed.NewSeed(genesisSeed)
-		fmt.Println("faucet here! ")
-	} else {
-		nodeSeed = walletseed.NewSeed()
-	}
-
 	// create Docker container
 	container := NewDockerContainer(n.network.dockerClient)
 	err := container.CreateGoShimmerPeer(config)
@@ -73,7 +63,7 @@ func (n *DRNGNetwork) CreatePeer(c GoShimmerConfig, publicKey ed25519.PublicKey)
 		return nil, err
 	}
 
-	peer, err := newPeer(name, identity.New(publicKey), container, nodeSeed, n.network)
+	peer, err := newPeer(name, identity.New(publicKey), container, nil, n.network)
 	if err != nil {
 		return nil, err
 	}

--- a/tools/integration-tests/tester/framework/framework.go
+++ b/tools/integration-tests/tester/framework/framework.go
@@ -293,14 +293,7 @@ func (f *Framework) CreateDRNGNetwork(name string, members, peers int) (*DRNGNet
 	// create peers/GoShimmer nodes
 	for i := 0; i < peers; i++ {
 		config.Seed = privKeys[i].Seed().String()
-		if _, e := drng.CreatePeer(func() GoShimmerConfig {
-			if i == 0 {
-				faucetConfig := config
-				faucetConfig.Faucet = true
-				return faucetConfig
-			}
-			return config
-		}(), pubKeys[i]); e != nil {
+		if _, e := drng.CreatePeer(config, pubKeys[i]); e != nil {
 			return nil, e
 		}
 	}
@@ -310,22 +303,6 @@ func (f *Framework) CreateDRNGNetwork(name string, members, peers int) (*DRNGNet
 	err = drng.network.DoManualPeeringAndWait(drng.network.peers...)
 	if err != nil {
 		return nil, errors.WithStack(err)
-	}
-
-	// get mana from faucet
-	for i := 1; i < peers; i++ {
-		peer := drng.network.peers[i]
-		addr := peer.Seed.Address(uint64(0)).Address()
-		ID := base58.Encode(peer.ID().Bytes())
-		_, err := drng.network.peers[0].SendFaucetRequest(addr.Base58(), ParaPoWFaucetDifficulty, ID, ID)
-		if err != nil {
-			return nil, fmt.Errorf("faucet request failed on peer %s: %w", peer.ID(), err)
-		}
-		time.Sleep(2 * time.Second)
-	}
-	err = drng.network.WaitForMana(drng.network.peers[1:]...)
-	if err != nil {
-		return nil, err
 	}
 
 	return drng, nil

--- a/tools/integration-tests/tester/framework/framework.go
+++ b/tools/integration-tests/tester/framework/framework.go
@@ -103,13 +103,7 @@ func (f *Framework) CreateNetwork(name string, peers int, config CreateNetworkCo
 				}
 				return ""
 			}(i),
-			Faucet: config.Faucet && i == 0,
-			Mana: func(i int) bool {
-				if ParaManaOnEveryNode {
-					return true
-				}
-				return config.Mana && i == 0
-			}(i),
+			Faucet:                     config.Faucet && i == 0,
 			StartSynced:                config.StartSynced,
 			FPCRoundInterval:           ParaFPCRoundInterval,
 			FPCTotalRoundsFinalization: ParaFPCTotalRoundsFinalization,
@@ -183,7 +177,6 @@ func (f *Framework) CreateNetworkWithPartitions(name string, peers, partitions, 
 				return ""
 			}(i),
 			Faucet:                     config.Faucet && i == 0,
-			Mana:                       config.Mana,
 			FPCRoundInterval:           ParaFPCRoundInterval,
 			FPCTotalRoundsFinalization: ParaFPCTotalRoundsFinalization,
 			WaitForStatement:           ParaWaitForStatement,
@@ -294,7 +287,6 @@ func (f *Framework) CreateDRNGNetwork(name string, members, peers int) (*DRNGNet
 		DRNGThreshold: 3,
 		DRNGDistKey:   hex.EncodeToString(drng.distKey),
 		DRNGCommittee: drngCommittee,
-		Mana:          true,
 		StartSynced:   true,
 	}
 
@@ -344,9 +336,6 @@ func (f *Framework) CreateDRNGNetwork(name string, members, peers int) (*DRNGNet
 func (f *Framework) CreateNetworkWithMana(name string, peers int, config CreateNetworkConfig) (*Network, error) {
 	if !config.Faucet {
 		return nil, fmt.Errorf("faucet is required")
-	}
-	if !config.Mana {
-		return nil, fmt.Errorf("mana plugin is required to load mana snapshot")
 	}
 
 	n, err := f.CreateNetwork(name, peers, config)

--- a/tools/integration-tests/tester/framework/parameters.go
+++ b/tools/integration-tests/tester/framework/parameters.go
@@ -111,7 +111,6 @@ type GoShimmerConfig struct {
 	ActivityPlugin   bool
 	ActivityInterval int
 
-	Mana                              bool
 	ManaAllowedAccessFilterEnabled    bool
 	ManaAllowedConsensusFilterEnabled bool
 	ManaAllowedAccessPledge           []string
@@ -135,6 +134,5 @@ type NetworkConfig struct {
 // CreateNetworkConfig is the config for optional plugins passed through createNetwork.
 type CreateNetworkConfig struct {
 	Faucet      bool
-	Mana        bool
 	StartSynced bool
 }

--- a/tools/integration-tests/tester/tests/common/common_test.go
+++ b/tools/integration-tests/tester/tests/common/common_test.go
@@ -16,7 +16,7 @@ import (
 // and becomes synced again.
 func TestSynchronization(t *testing.T) {
 	initialPeers := 4
-	n, err := f.CreateNetworkWithMana("common_TestSynchronization", initialPeers, framework.CreateNetworkConfig{
+	n, err := f.CreateNetwork("common_TestSynchronization", initialPeers, framework.CreateNetworkConfig{
 		Faucet:      true,
 		StartSynced: true,
 	})
@@ -36,7 +36,7 @@ func TestSynchronization(t *testing.T) {
 
 	// 2. spawn peer without knowledge of previous messages
 	log.Println("Spawning new node to sync...")
-	newPeer, err := n.CreatePeerWithMana(framework.GoShimmerConfig{})
+	newPeer, err := n.CreatePeer(framework.GoShimmerConfig{})
 	require.NoError(t, err)
 	time.Sleep(2 * time.Second)
 	err = n.DoManualPeeringAndWait()

--- a/tools/integration-tests/tester/tests/common/common_test.go
+++ b/tools/integration-tests/tester/tests/common/common_test.go
@@ -18,7 +18,6 @@ func TestSynchronization(t *testing.T) {
 	initialPeers := 4
 	n, err := f.CreateNetworkWithMana("common_TestSynchronization", initialPeers, framework.CreateNetworkConfig{
 		Faucet:      true,
-		Mana:        true,
 		StartSynced: true,
 	})
 	require.NoError(t, err)
@@ -37,10 +36,10 @@ func TestSynchronization(t *testing.T) {
 
 	// 2. spawn peer without knowledge of previous messages
 	log.Println("Spawning new node to sync...")
-	newPeer, err := n.CreatePeerWithMana(framework.GoShimmerConfig{Mana: true})
+	newPeer, err := n.CreatePeerWithMana(framework.GoShimmerConfig{})
 	require.NoError(t, err)
-	time.Sleep(2*time.Second)
-	err=n.DoManualPeeringAndWait()
+	time.Sleep(2 * time.Second)
+	err = n.DoManualPeeringAndWait()
 	require.NoError(t, err)
 
 	// when the node has mana it must also be peered

--- a/tools/integration-tests/tester/tests/consensus/consensus_conflicts_test.go
+++ b/tools/integration-tests/tester/tests/consensus/consensus_conflicts_test.go
@@ -23,7 +23,7 @@ func TestConsensus(t *testing.T) {
 	const numberOfPeers = 6
 
 	// create two partitions with their own peers
-	n, err := f.CreateNetworkWithMana("conflict", numberOfPeers, framework.CreateNetworkConfig{Faucet: true, StartSynced: true})
+	n, err := f.CreateNetwork("conflict", numberOfPeers, framework.CreateNetworkConfig{Faucet: true, StartSynced: true})
 	require.NoError(t, err)
 	defer tests.ShutdownNetwork(t, n)
 

--- a/tools/integration-tests/tester/tests/consensus/consensus_conflicts_test.go
+++ b/tools/integration-tests/tester/tests/consensus/consensus_conflicts_test.go
@@ -23,7 +23,7 @@ func TestConsensus(t *testing.T) {
 	const numberOfPeers = 6
 
 	// create two partitions with their own peers
-	n, err := f.CreateNetworkWithMana("conflict", numberOfPeers, framework.CreateNetworkConfig{Faucet: true, Mana: true, StartSynced: true})
+	n, err := f.CreateNetworkWithMana("conflict", numberOfPeers, framework.CreateNetworkConfig{Faucet: true, StartSynced: true})
 	require.NoError(t, err)
 	defer tests.ShutdownNetwork(t, n)
 

--- a/tools/integration-tests/tester/tests/consensus/consensus_noconflicts_test.go
+++ b/tools/integration-tests/tester/tests/consensus/consensus_noconflicts_test.go
@@ -21,7 +21,7 @@ import (
 // TestConsensusNoConflicts issues valid non-conflicting value objects and then checks
 // whether the ledger of every peer reflects the same correct state.
 func TestConsensusNoConflicts(t *testing.T) {
-	n, err := f.CreateNetworkWithMana("consensus_TestConsensusNoConflicts", 4, framework.CreateNetworkConfig{Faucet: true, StartSynced: true})
+	n, err := f.CreateNetwork("consensus_TestConsensusNoConflicts", 4, framework.CreateNetworkConfig{Faucet: true, StartSynced: true})
 	require.NoError(t, err)
 	defer tests.ShutdownNetwork(t, n)
 

--- a/tools/integration-tests/tester/tests/consensus/consensus_noconflicts_test.go
+++ b/tools/integration-tests/tester/tests/consensus/consensus_noconflicts_test.go
@@ -21,7 +21,7 @@ import (
 // TestConsensusNoConflicts issues valid non-conflicting value objects and then checks
 // whether the ledger of every peer reflects the same correct state.
 func TestConsensusNoConflicts(t *testing.T) {
-	n, err := f.CreateNetworkWithMana("consensus_TestConsensusNoConflicts", 4, framework.CreateNetworkConfig{Mana: true, Faucet: true, StartSynced: true})
+	n, err := f.CreateNetworkWithMana("consensus_TestConsensusNoConflicts", 4, framework.CreateNetworkConfig{Faucet: true, StartSynced: true})
 	require.NoError(t, err)
 	defer tests.ShutdownNetwork(t, n)
 

--- a/tools/integration-tests/tester/tests/diagnostics/diagnostics_test.go
+++ b/tools/integration-tests/tester/tests/diagnostics/diagnostics_test.go
@@ -42,7 +42,7 @@ var (
 )
 
 func TestDiagnosticApis(t *testing.T) {
-	n, err := f.CreateNetwork("diagnostics_TestAPI", 1, framework.CreateNetworkConfig{Faucet: false, Mana: false})
+	n, err := f.CreateNetwork("diagnostics_TestAPI", 1, framework.CreateNetworkConfig{Faucet: false})
 	require.NoError(t, err)
 	defer tests.ShutdownNetwork(t, n)
 	time.Sleep(10 * time.Second)

--- a/tools/integration-tests/tester/tests/faucet/faucet_test.go
+++ b/tools/integration-tests/tester/tests/faucet/faucet_test.go
@@ -19,7 +19,6 @@ func TestFaucetPersistence(t *testing.T) {
 	}()
 	n, err := f.CreateNetworkWithMana("common_TestSynchronization", 5, framework.CreateNetworkConfig{
 		Faucet:      true,
-		Mana:        true,
 		StartSynced: true,
 	})
 	require.NoError(t, err)

--- a/tools/integration-tests/tester/tests/faucet/faucet_test.go
+++ b/tools/integration-tests/tester/tests/faucet/faucet_test.go
@@ -17,7 +17,7 @@ func TestFaucetPersistence(t *testing.T) {
 	defer func() {
 		framework.ParaPoWDifficulty = prevPoWDiff
 	}()
-	n, err := f.CreateNetworkWithMana("common_TestSynchronization", 5, framework.CreateNetworkConfig{
+	n, err := f.CreateNetwork("common_TestSynchronization", 5, framework.CreateNetworkConfig{
 		Faucet:      true,
 		StartSynced: true,
 	})

--- a/tools/integration-tests/tester/tests/faucet/faucetmoveallfunds_test.go
+++ b/tools/integration-tests/tester/tests/faucet/faucetmoveallfunds_test.go
@@ -22,7 +22,7 @@ func TestPrepareFaucet(t *testing.T) {
 		framework.ParaPoWDifficulty = prevPoWDiff
 		framework.ParaFaucetPreparedOutputsCount = prevFaucetPreparedOutputsCount
 	}()
-	n, err := f.CreateNetwork("faucet_testPrepareGenesis", 2, framework.CreateNetworkConfig{Faucet: true, Mana: true, StartSynced: true})
+	n, err := f.CreateNetwork("faucet_testPrepareGenesis", 2, framework.CreateNetworkConfig{Faucet: true, StartSynced: true})
 	require.NoError(t, err)
 	defer tests.ShutdownNetwork(t, n)
 

--- a/tools/integration-tests/tester/tests/mana/mana_test.go
+++ b/tools/integration-tests/tester/tests/mana/mana_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestManaPersistence(t *testing.T) {
-	n, err := f.CreateNetwork("mana_TestPersistence", 1, framework.CreateNetworkConfig{Faucet: true, Mana: true, StartSynced: true})
+	n, err := f.CreateNetwork("mana_TestPersistence", 1, framework.CreateNetworkConfig{Faucet: true, StartSynced: true})
 	require.NoError(t, err)
 	defer tests.ShutdownNetwork(t, n)
 
@@ -66,7 +66,6 @@ func TestPledgeFilter(t *testing.T) {
 	peers := make([]*framework.Peer, numPeers)
 	for i := 0; i < numPeers; i++ {
 		peer, err := n.CreatePeer(framework.GoShimmerConfig{
-			Mana:           true,
 			ActivityPlugin: true,
 			StartSynced:    true,
 		})
@@ -83,7 +82,6 @@ func TestPledgeFilter(t *testing.T) {
 	faucet, err := n.CreatePeer(framework.GoShimmerConfig{
 		Seed:                              "3YX6e7AL28hHihZewKdq6CMkEYVsTJBLgRiprUNiNq5E",
 		Faucet:                            true,
-		Mana:                              true,
 		ManaAllowedAccessFilterEnabled:    true,
 		ManaAllowedConsensusFilterEnabled: true,
 		ManaAllowedAccessPledge:           []string{accessPeerID},
@@ -148,7 +146,7 @@ func TestApis(t *testing.T) {
 	defer func() {
 		framework.ParaManaOnEveryNode = prevParaManaOnEveryNode
 	}()
-	n, err := f.CreateNetwork("mana_TestAPI", 4, framework.CreateNetworkConfig{Faucet: true, Mana: true, StartSynced: true})
+	n, err := f.CreateNetwork("mana_TestAPI", 4, framework.CreateNetworkConfig{Faucet: true, StartSynced: true})
 	require.NoError(t, err)
 	defer tests.ShutdownNetwork(t, n)
 

--- a/tools/integration-tests/tester/tests/message/message_test.go
+++ b/tools/integration-tests/tester/tests/message/message_test.go
@@ -12,7 +12,7 @@ import (
 
 // TestPersistence issues messages on random peers, restarts them and checks for persistence after restart.
 func TestPersistence(t *testing.T) {
-	n, err := f.CreateNetworkWithMana("message_TestPersistence", 4, framework.CreateNetworkConfig{
+	n, err := f.CreateNetwork("message_TestPersistence", 4, framework.CreateNetworkConfig{
 		Faucet:      true,
 		StartSynced: true,
 	})

--- a/tools/integration-tests/tester/tests/message/message_test.go
+++ b/tools/integration-tests/tester/tests/message/message_test.go
@@ -14,7 +14,6 @@ import (
 func TestPersistence(t *testing.T) {
 	n, err := f.CreateNetworkWithMana("message_TestPersistence", 4, framework.CreateNetworkConfig{
 		Faucet:      true,
-		Mana:        true,
 		StartSynced: true,
 	})
 	require.NoError(t, err)

--- a/tools/integration-tests/tester/tests/value/value_test.go
+++ b/tools/integration-tests/tester/tests/value/value_test.go
@@ -22,7 +22,7 @@ import (
 
 // TestTransactionPersistence issues messages on random peers, restarts them and checks for persistence after restart.
 func TestTransactionPersistence(t *testing.T) {
-	n, err := f.CreateNetwork("transaction_TestPersistence", 4, framework.CreateNetworkConfig{Faucet: true, Mana: true, StartSynced: true})
+	n, err := f.CreateNetwork("transaction_TestPersistence", 4, framework.CreateNetworkConfig{Faucet: true, StartSynced: true})
 	require.NoError(t, err)
 	defer tests.ShutdownNetwork(t, n)
 
@@ -92,7 +92,7 @@ func TestTransactionPersistence(t *testing.T) {
 
 // TestValueColoredPersistence issues colored tokens on random peers, restarts them and checks for persistence after restart.
 func TestValueColoredPersistence(t *testing.T) {
-	n, err := f.CreateNetwork("valueColor_TestPersistence", 4, framework.CreateNetworkConfig{Faucet: true, Mana: true, StartSynced: true})
+	n, err := f.CreateNetwork("valueColor_TestPersistence", 4, framework.CreateNetworkConfig{Faucet: true, StartSynced: true})
 	require.NoError(t, err)
 	defer tests.ShutdownNetwork(t, n)
 
@@ -163,7 +163,7 @@ func TestValueColoredPersistence(t *testing.T) {
 
 // TestAlias_Persistence creates an alias output, restarts all nodes, and checks whether the output is persisted.
 func TestAlias_Persistence(t *testing.T) {
-	n, err := f.CreateNetworkWithMana("alias_TestPersistence", 4, framework.CreateNetworkConfig{Faucet: true, Mana: true, StartSynced: true})
+	n, err := f.CreateNetworkWithMana("alias_TestPersistence", 4, framework.CreateNetworkConfig{Faucet: true, StartSynced: true})
 	require.NoError(t, err)
 	defer tests.ShutdownNetwork(t, n)
 
@@ -265,7 +265,7 @@ func TestAlias_Persistence(t *testing.T) {
 
 // TestAlias_Delegation tests if a delegation output can be used to refresh mana.
 func TestAlias_Delegation(t *testing.T) {
-	n, err := f.CreateNetworkWithMana("alias_TestDelegation", 4, framework.CreateNetworkConfig{Faucet: true, Mana: true, StartSynced: true})
+	n, err := f.CreateNetworkWithMana("alias_TestDelegation", 4, framework.CreateNetworkConfig{Faucet: true, StartSynced: true})
 	require.NoError(t, err)
 	defer tests.ShutdownNetwork(t, n)
 

--- a/tools/integration-tests/tester/tests/value/value_test.go
+++ b/tools/integration-tests/tester/tests/value/value_test.go
@@ -163,7 +163,7 @@ func TestValueColoredPersistence(t *testing.T) {
 
 // TestAlias_Persistence creates an alias output, restarts all nodes, and checks whether the output is persisted.
 func TestAlias_Persistence(t *testing.T) {
-	n, err := f.CreateNetworkWithMana("alias_TestPersistence", 4, framework.CreateNetworkConfig{Faucet: true, StartSynced: true})
+	n, err := f.CreateNetwork("alias_TestPersistence", 4, framework.CreateNetworkConfig{Faucet: true, StartSynced: true})
 	require.NoError(t, err)
 	defer tests.ShutdownNetwork(t, n)
 
@@ -265,7 +265,7 @@ func TestAlias_Persistence(t *testing.T) {
 
 // TestAlias_Delegation tests if a delegation output can be used to refresh mana.
 func TestAlias_Delegation(t *testing.T) {
-	n, err := f.CreateNetworkWithMana("alias_TestDelegation", 4, framework.CreateNetworkConfig{Faucet: true, StartSynced: true})
+	n, err := f.CreateNetwork("alias_TestDelegation", 4, framework.CreateNetworkConfig{Faucet: true, StartSynced: true})
 	require.NoError(t, err)
 	defer tests.ShutdownNetwork(t, n)
 


### PR DESCRIPTION
# Description of change

* Remove `mana` from Goshimmer config, since mana is enabled by default
* Replace `CreateNetworkWithMana` with `CreateNetwork`. bc each node has 1m to issue messages, no need to wait for faucet pledging mana.

## Type of change

- Enhancement

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
