### PR TITLE
Add Client Library Import Check

### DIFF
--- a/.github/workflows/client-import.yml
+++ b/.github/workflows/client-import.yml
@@ -1,0 +1,27 @@
+name: Client Lib Import Check
+
+on:
+  push:
+    paths-ignore:
+      - 'docs/**'
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+
+jobs:
+
+  build:
+    name: Import Check
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Setup Go 1.16.3
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.16.3
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Run Import Check Script
+        run: ./scripts/client_import_check.sh

--- a/client/diagnostics.go
+++ b/client/diagnostics.go
@@ -4,8 +4,32 @@ import (
 	"encoding/csv"
 	"fmt"
 	"net/http"
+)
 
-	"github.com/iotaledger/goshimmer/plugins/webapi/tools"
+const (
+	routeDiagnostics = "tools/diagnostic"
+	// RouteDiagnosticMessages is the API route for message diagnostics
+	RouteDiagnosticMessages = routeDiagnostics + "/messages"
+	// RouteDiagnosticsFirstWeakMessageReferences is the API route for first weak message diagnostics
+	RouteDiagnosticsFirstWeakMessageReferences = RouteDiagnosticMessages + "/firstweakreferences"
+	// RouteDiagnosticsMessageRank is the API route for message diagnostics with a rank filter
+	RouteDiagnosticsMessageRank = RouteDiagnosticMessages + "/rank/:rank"
+	// RouteDiagnosticsUtxoDag is the API route for Utxo Dag diagnostics
+	RouteDiagnosticsUtxoDag = routeDiagnostics + "/utxodag"
+	// RouteDiagnosticsBranches is the API route for branches diagnostics
+	RouteDiagnosticsBranches = routeDiagnostics + "/branches"
+	// RouteDiagnosticsLazyBookedBranches is the API route for booked branches diagnostics
+	RouteDiagnosticsLazyBookedBranches = RouteDiagnosticsBranches + "/lazybooked"
+	// RouteDiagnosticsInvalidBranches is the API route for invalid branches diagnostics
+	RouteDiagnosticsInvalidBranches = RouteDiagnosticsBranches + "/invalid"
+	// RouteDiagnosticsTips is the API route for tips diagnostics
+	RouteDiagnosticsTips = routeDiagnostics + "/tips"
+	// RouteDiagnosticsStrongTips is the API route for strong tips diagnostics
+	RouteDiagnosticsStrongTips = RouteDiagnosticsTips + "/strong"
+	// RouteDiagnosticsWeakTips is the API route for weak tips diagnostics
+	RouteDiagnosticsWeakTips = RouteDiagnosticsTips + "/weak"
+	// RouteDiagnosticsDRNG is the API route for DRNG diagnostics
+	RouteDiagnosticsDRNG = routeDiagnostics + "/drng"
 )
 
 // GetDiagnosticsMessages runs full message diagnostics
@@ -17,7 +41,7 @@ import (
 //	PayloadOpinionFormed TimestampOpinionFormed MessageOpinionFormed MessageOpinionTriggered TimestampOpinion
 //	TimestampLoK
 func (api *GoShimmerAPI) GetDiagnosticsMessages() (*csv.Reader, error) {
-	return api.diagnose(tools.RouteDiagnosticMessages)
+	return api.diagnose(RouteDiagnosticMessages)
 }
 
 // GetDiagnosticsFirstWeakMessageReferences runs diagnostics over weak references only.
@@ -29,7 +53,7 @@ func (api *GoShimmerAPI) GetDiagnosticsMessages() (*csv.Reader, error) {
 //	PayloadOpinionFormed TimestampOpinionFormed MessageOpinionFormed MessageOpinionTriggered TimestampOpinion
 //	TimestampLoK
 func (api *GoShimmerAPI) GetDiagnosticsFirstWeakMessageReferences() (*csv.Reader, error) {
-	return api.diagnose(tools.RouteDiagnosticsFirstWeakMessageReferences)
+	return api.diagnose(RouteDiagnosticsFirstWeakMessageReferences)
 }
 
 // GetDiagnosticsMessagesByRank run diagnostics for messages whose markers are equal or above a certain rank
@@ -41,7 +65,7 @@ func (api *GoShimmerAPI) GetDiagnosticsFirstWeakMessageReferences() (*csv.Reader
 //	PayloadOpinionFormed TimestampOpinionFormed MessageOpinionFormed MessageOpinionTriggered TimestampOpinion
 //	TimestampLoK
 func (api *GoShimmerAPI) GetDiagnosticsMessagesByRank(rank uint64) (*csv.Reader, error) {
-	return api.diagnose(fmt.Sprintf("%s?rank=%d", tools.RouteDiagnosticMessages, rank))
+	return api.diagnose(fmt.Sprintf("%s?rank=%d", RouteDiagnosticMessages, rank))
 }
 
 // GetDiagnosticsUtxoDag runs diagnostics over utxo dag.
@@ -51,7 +75,7 @@ func (api *GoShimmerAPI) GetDiagnosticsMessagesByRank(rank uint64) (*csv.Reader,
 //	BranchID,BranchLiked,BranchMonotonicallyLiked,Conflicting,InclusionState,Finalized,LazyBooked,Liked,LoK,FCOB1Time,
 //	FCOB2Time
 func (api *GoShimmerAPI) GetDiagnosticsUtxoDag() (*csv.Reader, error) {
-	return api.diagnose(tools.RouteDiagnosticsUtxoDag)
+	return api.diagnose(RouteDiagnosticsUtxoDag)
 }
 
 // GetDiagnosticsBranches runs diagnostics over branches.
@@ -60,7 +84,7 @@ func (api *GoShimmerAPI) GetDiagnosticsUtxoDag() (*csv.Reader, error) {
 //	ID,ConflictSet,IssuanceTime,SolidTime,OpinionFormedTime,Liked,MonotonicallyLiked,InclusionState,Finalized,
 //	LazyBooked,TransactionLiked
 func (api *GoShimmerAPI) GetDiagnosticsBranches() (*csv.Reader, error) {
-	return api.diagnose(tools.RouteDiagnosticsBranches)
+	return api.diagnose(RouteDiagnosticsBranches)
 }
 
 // GetDiagnosticsLazyBookedBranches runs diagnostics over lazy booked branches.
@@ -69,7 +93,7 @@ func (api *GoShimmerAPI) GetDiagnosticsBranches() (*csv.Reader, error) {
 //	ID,ConflictSet,IssuanceTime,SolidTime,OpinionFormedTime,Liked,MonotonicallyLiked,InclusionState,Finalized,
 //	LazyBooked,TransactionLiked
 func (api *GoShimmerAPI) GetDiagnosticsLazyBookedBranches() (*csv.Reader, error) {
-	return api.diagnose(tools.RouteDiagnosticsLazyBookedBranches)
+	return api.diagnose(RouteDiagnosticsLazyBookedBranches)
 }
 
 // GetDiagnosticsInvalidBranches runs diagnostics over invalid branches.
@@ -78,7 +102,7 @@ func (api *GoShimmerAPI) GetDiagnosticsLazyBookedBranches() (*csv.Reader, error)
 //	ID,ConflictSet,IssuanceTime,SolidTime,OpinionFormedTime,Liked,MonotonicallyLiked,InclusionState,Finalized,
 //	LazyBooked,TransactionLiked
 func (api *GoShimmerAPI) GetDiagnosticsInvalidBranches() (*csv.Reader, error) {
-	return api.diagnose(tools.RouteDiagnosticsInvalidBranches)
+	return api.diagnose(RouteDiagnosticsInvalidBranches)
 }
 
 // GetDiagnosticsTips runs diagnostics over tips
@@ -89,7 +113,7 @@ func (api *GoShimmerAPI) GetDiagnosticsInvalidBranches() (*csv.Reader, error) {
 //	Eligible,Invalid,Finalized,Rank,IsPastMarker,PastMarkers,PMHI,PMLI,FutureMarkers,FMHI,FMLI,PayloadType,TransactionID,
 //	PayloadOpinionFormed,TimestampOpinionFormed,MessageOpinionFormed,MessageOpinionTriggered,TimestampOpinion,TimestampLoK
 func (api *GoShimmerAPI) GetDiagnosticsTips() (*csv.Reader, error) {
-	return api.diagnose(tools.RouteDiagnosticsTips)
+	return api.diagnose(RouteDiagnosticsTips)
 }
 
 // GetDiagnosticsStrongTips runs diagnostics over strong tips
@@ -100,7 +124,7 @@ func (api *GoShimmerAPI) GetDiagnosticsTips() (*csv.Reader, error) {
 //	Eligible,Invalid,Finalized,Rank,IsPastMarker,PastMarkers,PMHI,PMLI,FutureMarkers,FMHI,FMLI,PayloadType,TransactionID,
 //	PayloadOpinionFormed,TimestampOpinionFormed,MessageOpinionFormed,MessageOpinionTriggered,TimestampOpinion,TimestampLoK
 func (api *GoShimmerAPI) GetDiagnosticsStrongTips() (*csv.Reader, error) {
-	return api.diagnose(tools.RouteDiagnosticsStrongTips)
+	return api.diagnose(RouteDiagnosticsStrongTips)
 }
 
 // GetDiagnosticsWeakTips runs diagnostics over weak tips
@@ -111,7 +135,7 @@ func (api *GoShimmerAPI) GetDiagnosticsStrongTips() (*csv.Reader, error) {
 //	Eligible,Invalid,Finalized,Rank,IsPastMarker,PastMarkers,PMHI,PMLI,FutureMarkers,FMHI,FMLI,PayloadType,TransactionID,
 //	PayloadOpinionFormed,TimestampOpinionFormed,MessageOpinionFormed,MessageOpinionTriggered,TimestampOpinion,TimestampLoK
 func (api *GoShimmerAPI) GetDiagnosticsWeakTips() (*csv.Reader, error) {
-	return api.diagnose(tools.RouteDiagnosticsWeakTips)
+	return api.diagnose(RouteDiagnosticsWeakTips)
 }
 
 // GetDiagnosticsDRNG runs diagnostics for DRNG
@@ -120,7 +144,7 @@ func (api *GoShimmerAPI) GetDiagnosticsWeakTips() (*csv.Reader, error) {
 // 	ID,IssuerID,IssuerPublicKey,IssuanceTime,ArrivalTime,SolidTime,ScheduledTime,BookedTime,OpinionFormedTime,
 //	dRNGPayloadType,InstanceID,Round,PreviousSignature,Signature,DistributedPK
 func (api *GoShimmerAPI) GetDiagnosticsDRNG() (*csv.Reader, error) {
-	return api.diagnose(tools.RouteDiagnosticsDRNG)
+	return api.diagnose(RouteDiagnosticsDRNG)
 }
 
 // run an api call on a certain route and return a csv

--- a/client/diagnostics.go
+++ b/client/diagnostics.go
@@ -3,7 +3,6 @@ package client
 import (
 	"encoding/csv"
 	"fmt"
-	"github.com/iotaledger/goshimmer/plugins/webapi/tools"
 	"net/http"
 )
 
@@ -42,7 +41,7 @@ const (
 //	PayloadOpinionFormed TimestampOpinionFormed MessageOpinionFormed MessageOpinionTriggered TimestampOpinion
 //	TimestampLoK
 func (api *GoShimmerAPI) GetDiagnosticsMessages() (*csv.Reader, error) {
-	return api.diagnose(tools.RouteDiagnosticMessages)
+	return api.diagnose(RouteDiagnosticMessages)
 }
 
 // GetDiagnosticsFirstWeakMessageReferences runs diagnostics over weak references only.

--- a/client/diagnostics.go
+++ b/client/diagnostics.go
@@ -3,6 +3,7 @@ package client
 import (
 	"encoding/csv"
 	"fmt"
+	"github.com/iotaledger/goshimmer/plugins/webapi/tools"
 	"net/http"
 )
 
@@ -41,7 +42,7 @@ const (
 //	PayloadOpinionFormed TimestampOpinionFormed MessageOpinionFormed MessageOpinionTriggered TimestampOpinion
 //	TimestampLoK
 func (api *GoShimmerAPI) GetDiagnosticsMessages() (*csv.Reader, error) {
-	return api.diagnose(RouteDiagnosticMessages)
+	return api.diagnose(tools.RouteDiagnosticMessages)
 }
 
 // GetDiagnosticsFirstWeakMessageReferences runs diagnostics over weak references only.

--- a/scripts/client_import_check.sh
+++ b/scripts/client_import_check.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# This script is intended to be run from the root of the repo!
+# It checks if any client library file imports explicitly or implicitly a goshimmer plugin.
+FORBIDDEN_IMPORT="goshimmer/plugins"
+
+cd client
+OUTPUT=$(go list -f '{{.ImportPath}}|{{.Imports}}' ./...)
+if [[ "$OUTPUT" =~ .*"$FORBIDDEN_IMPORT".* ]]; then
+  echo "ERROR: client library imports a goshimmer plugin"
+  exit 1
+fi


### PR DESCRIPTION
# Description of change

#1345 reintroduced the problem described in #1366.

 - Remove code that imports any goshimmer plugin from the client lib.
 - Add GH Workflow to check for possible future forbidden imports in the client lib. This check should prevent any changes to be merged into develop that would reintroduce aforementioned issue.