### PR TITLE
reduce activity message parentCount parameter for experimental setup

### DIFF
--- a/plugins/activity/parameters.go
+++ b/plugins/activity/parameters.go
@@ -6,6 +6,10 @@ import "github.com/iotaledger/hive.go/configuration"
 var Parameters = struct {
 	// BroadcastIntervalSec is the interval in seconds at which the node broadcasts its activity message.
 	BroadcastIntervalSec int `default:"3" usage:"the interval at which the node will broadcast its activity message"`
+	// ParentsCount is the number of parents that node will choose for its activity messages.
+	ParentsCount int `default:"8" usage:"the number of parents that node will choose for its activity messages"`
+	// DelayOffset is the maximum for random initial time delay before sending the activity message.
+	DelayOffset int `default:"10" usage:"the maximum for random initial time delay before sending the activity message"`
 }{}
 
 func init() {

--- a/plugins/activity/plugin.go
+++ b/plugins/activity/plugin.go
@@ -14,11 +14,6 @@ import (
 	"github.com/iotaledger/goshimmer/plugins/messagelayer"
 )
 
-const (
-	delayOffset                 = 10 // time between activity messages
-	parentsCountActivityMessage = 2  // number of parents (if possible) of the activity messages
-)
-
 var (
 	// plugin is the plugin instance of the activity plugin.
 	plugin *node.Plugin
@@ -41,7 +36,7 @@ func configure(_ *node.Plugin) {
 // broadcastActivityMessage broadcasts a sync beacon via communication layer.
 func broadcastActivityMessage() {
 	activityPayload := payload.NewGenericDataPayload([]byte("activity"))
-	msg, err := messagelayer.Tangle().IssuePayload(activityPayload, parentsCountActivityMessage)
+	msg, err := messagelayer.Tangle().IssuePayload(activityPayload, Parameters.ParentsCount)
 	if err != nil {
 		plugin.LogWarnf("error issuing activity message: %s", err)
 		return

--- a/plugins/activity/plugin.go
+++ b/plugins/activity/plugin.go
@@ -15,8 +15,8 @@ import (
 )
 
 const (
-	delayOffset  = 10
-	parentsCount = 8
+	delayOffset                 = 10 // time between activity messages
+	parentsCountActivityMessage = 2  // number of parents (if possible) of the activity messages
 )
 
 var (
@@ -41,7 +41,7 @@ func configure(_ *node.Plugin) {
 // broadcastActivityMessage broadcasts a sync beacon via communication layer.
 func broadcastActivityMessage() {
 	activityPayload := payload.NewGenericDataPayload([]byte("activity"))
-	msg, err := messagelayer.Tangle().IssuePayload(activityPayload, parentsCount)
+	msg, err := messagelayer.Tangle().IssuePayload(activityPayload, parentsCountActivityMessage)
 	if err != nil {
 		plugin.LogWarnf("error issuing activity message: %s", err)
 		return

--- a/plugins/activity/plugin.go
+++ b/plugins/activity/plugin.go
@@ -49,7 +49,7 @@ func run(_ *node.Plugin) {
 	if err := daemon.BackgroundWorker("Activity-plugin", func(shutdownSignal <-chan struct{}) {
 		// start with initial delay
 		rand.NewSource(time.Now().UnixNano())
-		initialDelay := rand.Intn(delayOffset)
+		initialDelay := rand.Intn(Parameters.DelayOffset)
 		time.Sleep(time.Duration(initialDelay) * time.Second)
 
 		if Parameters.BroadcastIntervalSec > 0 {


### PR DESCRIPTION
# Description of change
Temporarily reduce the parentCountAcitivtyMessage number from 8 to 2 for experimental purposes.

## Type of change
- Parameter change

## Checks
- [x ] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
