### PR TITLE
Faucet Improvements

### DIFF
--- a/plugins/faucet/plugin.go
+++ b/plugins/faucet/plugin.go
@@ -45,7 +45,7 @@ const (
 	// An address for which a funding was done in the past is added to the blacklist and eventually is removed from it.
 	CfgFaucetBlacklistCapacity = "faucet.blacklistCapacity"
 	// CfgFaucetPreparedOutputsCount is the number of outputs the faucet prepares for requests.
-	CfgFaucetPreparedOutputsCount = "faucet.preparedOutputsCounts"
+	CfgFaucetPreparedOutputsCount = "faucet.preparedOutputsCount"
 	// CfgFaucetStartIndex defines from which address index the faucet should start gathering outputs.
 	CfgFaucetStartIndex = "faucet.startIndex"
 )

--- a/tools/integration-tests/tester/framework/docker.go
+++ b/tools/integration-tests/tester/framework/docker.go
@@ -88,7 +88,7 @@ func (d *DockerContainer) CreateGoShimmerPeer(config GoShimmerConfig) error {
 			fmt.Sprintf("--node.enablePlugins=%s", config.EnabledPlugins),
 			fmt.Sprintf("--pow.difficulty=%d", ParaPoWDifficulty),
 			fmt.Sprintf("--faucet.powDifficulty=%d", ParaPoWFaucetDifficulty),
-			fmt.Sprintf("--faucet.preparedOutputsCounts=%d", ParaFaucetPreparedOutputsCount),
+			fmt.Sprintf("--faucet.preparedOutputsCount=%d", ParaFaucetPreparedOutputsCount),
 			fmt.Sprintf("--gracefulshutdown.waitToKillTime=%d", ParaWaitToKill),
 			fmt.Sprintf("--node.enablePlugins=%s", func() string {
 				var plugins []string


### PR DESCRIPTION
Fix #1416

# Description of change
 - Faucet dynamically fetches its remainder output before creating a splitting tx.
 - Renamed config parameter `faucet.preparedOutputsCounts` -> `faucet.preparedOutputsCount`
 - Increase splitting tx confirmation timeout to reduce the possibility of issuing a double spend when original tx in not confirmed fast enough.
