### PR TITLE
Improve message requester

### DIFF
--- a/packages/gossip/manager.go
+++ b/packages/gossip/manager.go
@@ -211,6 +211,7 @@ func (m *Manager) getRandomNeighbors(amount int) []*Neighbor {
 	}
 	return sample
 }
+
 func (m *Manager) getNeighborsByID(ids []identity.ID) []*Neighbor {
 	result := make([]*Neighbor, 0, len(ids))
 	m.neighborsMutex.RLock()

--- a/packages/tangle/requester.go
+++ b/packages/tangle/requester.go
@@ -12,7 +12,7 @@ const (
 	DefaultRetryInterval = 10 * time.Second
 
 	// the maximum amount of requests before we abort
-	maxRequestThreshold = 500
+	maxRequestThreshold = 50
 )
 
 // RequesterOptions holds options for a message requester.
@@ -22,7 +22,7 @@ type RequesterOptions struct {
 
 func newRequesterOptions(optionalOptions []RequesterOption) *RequesterOptions {
 	result := &RequesterOptions{
-		retryInterval: 10 * time.Second,
+		retryInterval: DefaultRetryInterval,
 	}
 
 	for _, optionalOption := range optionalOptions {

--- a/plugins/webapi/ledgerstate/plugin.go
+++ b/plugins/webapi/ledgerstate/plugin.go
@@ -425,10 +425,8 @@ func branchIDFromContext(c echo.Context) (branchID ledgerstate.BranchID, err err
 
 const maxBookedAwaitTime = 5 * time.Second
 
-var (
-	// ErrNotAllowedToPledgeManaToNode defines an unsupported node to pledge mana to.
-	ErrNotAllowedToPledgeManaToNode = errors.New("not allowed to pledge mana to node")
-)
+// ErrNotAllowedToPledgeManaToNode defines an unsupported node to pledge mana to.
+var ErrNotAllowedToPledgeManaToNode = errors.New("not allowed to pledge mana to node")
 
 // PostTransaction sends a transaction.
 func PostTransaction(c echo.Context) error {


### PR DESCRIPTION
Now we request messages only from 3 random neighbors, not all neighbors as it was before.
I also reduced the maxim amount of attempts from 500 to 50.

I decided to not change the `time.AfterFunc()` goroutines logic because it feels like a micro-optimization and not worth it.

Fixes: https://github.com/iotaledger/goshimmer/issues/566