### PR TITLE
Add run callback to database plugin

### DIFF
--- a/plugins/database/plugin.go
+++ b/plugins/database/plugin.go
@@ -34,7 +34,7 @@ var (
 // Plugin gets the plugin instance.
 func Plugin() *node.Plugin {
 	pluginOnce.Do(func() {
-		plugin = node.NewPlugin(PluginName, node.Enabled, configure)
+		plugin = node.NewPlugin(PluginName, node.Enabled, configure, run)
 	})
 	return plugin
 }
@@ -101,6 +101,10 @@ func configure(_ *node.Plugin) {
 
 	// run GC up on startup
 	runDatabaseGC()
+}
+
+func run(*node.Plugin) {
+	// placeholder
 }
 
 // manageDBLifetime takes care of managing the lifetime of the database. It marks the database as dirty up on


### PR DESCRIPTION
# Description of change

This adds an empty `run` callback to the database plugin. It ensures that the `config` callback will be indeed called at the correct time.

This PR was created while working on #1109. It allows to configure the cache time before anything else it ran
 
## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Node has been run locally

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
