### PR TITLE
Add test mains and test helper

### DIFF
--- a/docs/teamresources/guidelines.md
+++ b/docs/teamresources/guidelines.md
@@ -75,3 +75,26 @@ func main() {
     }
 }
 ```
+
+## Tests
+
+Every folder that has a unit test should have a `test_main.go` file inside. This allows to easily add local setup and
+teardown functions. The `test_main.go` should also reference functions from a `testhelper.go` that provides logic to
+the tests that should be global to the project. A `test_main.go` should look like this:
+
+```go
+import (
+	"os"
+	"testing"
+
+	. "github.com/iotaledger/goshimmer/packages/testhelper"
+)
+
+// TestMain will setup and teardown any unit test
+func TestMain(m *testing.M) {
+	GlobalSetup()
+	code := m.Run()
+	GlobalTeardown()
+	os.Exit(code)
+}
+```

--- a/packages/clock/main_test.go
+++ b/packages/clock/main_test.go
@@ -1,0 +1,16 @@
+package clock
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/iotaledger/goshimmer/packages/testhelper"
+)
+
+// TestMain will setup and teardown any unit test
+func TestMain(m *testing.M) {
+	GlobalSetup()
+	code := m.Run()
+	GlobalTeardown()
+	os.Exit(code)
+}

--- a/packages/clock/main_test.go
+++ b/packages/clock/main_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/iotaledger/goshimmer/packages/testhelper"
+	"github.com/iotaledger/goshimmer/packages/testhelper"
 )
 
 // TestMain will setup and teardown any unit test

--- a/packages/clock/main_test.go
+++ b/packages/clock/main_test.go
@@ -9,8 +9,8 @@ import (
 
 // TestMain will setup and teardown any unit test
 func TestMain(m *testing.M) {
-	GlobalSetup()
+	testhelper.GlobalSetup()
 	code := m.Run()
-	GlobalTeardown()
+	testhelper.GlobalTeardown()
 	os.Exit(code)
 }

--- a/packages/consensus/fcob/main_test.go
+++ b/packages/consensus/fcob/main_test.go
@@ -1,0 +1,16 @@
+package fcob
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/iotaledger/goshimmer/packages/testhelper"
+)
+
+// TestMain will setup and teardown any unit test
+func TestMain(m *testing.M) {
+	GlobalSetup()
+	code := m.Run()
+	GlobalTeardown()
+	os.Exit(code)
+}

--- a/packages/consensus/fcob/main_test.go
+++ b/packages/consensus/fcob/main_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/iotaledger/goshimmer/packages/testhelper"
+	"github.com/iotaledger/goshimmer/packages/testhelper"
 )
 
 // TestMain will setup and teardown any unit test

--- a/packages/consensus/fcob/main_test.go
+++ b/packages/consensus/fcob/main_test.go
@@ -9,8 +9,8 @@ import (
 
 // TestMain will setup and teardown any unit test
 func TestMain(m *testing.M) {
-	GlobalSetup()
+	testhelper.GlobalSetup()
 	code := m.Run()
-	GlobalTeardown()
+	testhelper.GlobalTeardown()
 	os.Exit(code)
 }

--- a/packages/consensus/main_test.go
+++ b/packages/consensus/main_test.go
@@ -1,0 +1,16 @@
+package consensus
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/iotaledger/goshimmer/packages/testhelper"
+)
+
+// TestMain will setup and teardown any unit test
+func TestMain(m *testing.M) {
+	GlobalSetup()
+	code := m.Run()
+	GlobalTeardown()
+	os.Exit(code)
+}

--- a/packages/consensus/main_test.go
+++ b/packages/consensus/main_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/iotaledger/goshimmer/packages/testhelper"
+	"github.com/iotaledger/goshimmer/packages/testhelper"
 )
 
 // TestMain will setup and teardown any unit test

--- a/packages/consensus/main_test.go
+++ b/packages/consensus/main_test.go
@@ -9,8 +9,8 @@ import (
 
 // TestMain will setup and teardown any unit test
 func TestMain(m *testing.M) {
-	GlobalSetup()
+	testhelper.GlobalSetup()
 	code := m.Run()
-	GlobalTeardown()
+	testhelper.GlobalTeardown()
 	os.Exit(code)
 }

--- a/packages/database/main_test.go
+++ b/packages/database/main_test.go
@@ -1,0 +1,16 @@
+package database
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/iotaledger/goshimmer/packages/testhelper"
+)
+
+// TestMain will setup and teardown any unit test
+func TestMain(m *testing.M) {
+	GlobalSetup()
+	code := m.Run()
+	GlobalTeardown()
+	os.Exit(code)
+}

--- a/packages/database/main_test.go
+++ b/packages/database/main_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/iotaledger/goshimmer/packages/testhelper"
+	"github.com/iotaledger/goshimmer/packages/testhelper"
 )
 
 // TestMain will setup and teardown any unit test

--- a/packages/database/main_test.go
+++ b/packages/database/main_test.go
@@ -9,8 +9,8 @@ import (
 
 // TestMain will setup and teardown any unit test
 func TestMain(m *testing.M) {
-	GlobalSetup()
+	testhelper.GlobalSetup()
 	code := m.Run()
-	GlobalTeardown()
+	testhelper.GlobalTeardown()
 	os.Exit(code)
 }

--- a/packages/drng/main_test.go
+++ b/packages/drng/main_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/iotaledger/goshimmer/packages/testhelper"
+	"github.com/iotaledger/goshimmer/packages/testhelper"
 )
 
 // TestMain will setup and teardown any unit test

--- a/packages/drng/main_test.go
+++ b/packages/drng/main_test.go
@@ -9,8 +9,8 @@ import (
 
 // TestMain will setup and teardown any unit test
 func TestMain(m *testing.M) {
-	GlobalSetup()
+	testhelper.GlobalSetup()
 	code := m.Run()
-	GlobalTeardown()
+	testhelper.GlobalTeardown()
 	os.Exit(code)
 }

--- a/packages/drng/main_test.go
+++ b/packages/drng/main_test.go
@@ -1,0 +1,16 @@
+package drng
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/iotaledger/goshimmer/packages/testhelper"
+)
+
+// TestMain will setup and teardown any unit test
+func TestMain(m *testing.M) {
+	GlobalSetup()
+	code := m.Run()
+	GlobalTeardown()
+	os.Exit(code)
+}

--- a/packages/faucet/main_test.go
+++ b/packages/faucet/main_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/iotaledger/goshimmer/packages/testhelper"
+	"github.com/iotaledger/goshimmer/packages/testhelper"
 )
 
 // TestMain will setup and teardown any unit test

--- a/packages/faucet/main_test.go
+++ b/packages/faucet/main_test.go
@@ -9,8 +9,8 @@ import (
 
 // TestMain will setup and teardown any unit test
 func TestMain(m *testing.M) {
-	GlobalSetup()
+	testhelper.GlobalSetup()
 	code := m.Run()
-	GlobalTeardown()
+	testhelper.GlobalTeardown()
 	os.Exit(code)
 }

--- a/packages/faucet/main_test.go
+++ b/packages/faucet/main_test.go
@@ -1,0 +1,16 @@
+package faucet
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/iotaledger/goshimmer/packages/testhelper"
+)
+
+// TestMain will setup and teardown any unit test
+func TestMain(m *testing.M) {
+	GlobalSetup()
+	code := m.Run()
+	GlobalTeardown()
+	os.Exit(code)
+}

--- a/packages/gossip/main_test.go
+++ b/packages/gossip/main_test.go
@@ -1,0 +1,16 @@
+package gossip
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/iotaledger/goshimmer/packages/testhelper"
+)
+
+// TestMain will setup and teardown any unit test
+func TestMain(m *testing.M) {
+	GlobalSetup()
+	code := m.Run()
+	GlobalTeardown()
+	os.Exit(code)
+}

--- a/packages/gossip/main_test.go
+++ b/packages/gossip/main_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/iotaledger/goshimmer/packages/testhelper"
+	"github.com/iotaledger/goshimmer/packages/testhelper"
 )
 
 // TestMain will setup and teardown any unit test

--- a/packages/gossip/main_test.go
+++ b/packages/gossip/main_test.go
@@ -9,8 +9,8 @@ import (
 
 // TestMain will setup and teardown any unit test
 func TestMain(m *testing.M) {
-	GlobalSetup()
+	testhelper.GlobalSetup()
 	code := m.Run()
-	GlobalTeardown()
+	testhelper.GlobalTeardown()
 	os.Exit(code)
 }

--- a/packages/gossip/proto/main_test.go
+++ b/packages/gossip/proto/main_test.go
@@ -1,0 +1,16 @@
+package proto
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/iotaledger/goshimmer/packages/testhelper"
+)
+
+// TestMain will setup and teardown any unit test
+func TestMain(m *testing.M) {
+	GlobalSetup()
+	code := m.Run()
+	GlobalTeardown()
+	os.Exit(code)
+}

--- a/packages/gossip/proto/main_test.go
+++ b/packages/gossip/proto/main_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/iotaledger/goshimmer/packages/testhelper"
+	"github.com/iotaledger/goshimmer/packages/testhelper"
 )
 
 // TestMain will setup and teardown any unit test

--- a/packages/gossip/proto/main_test.go
+++ b/packages/gossip/proto/main_test.go
@@ -9,8 +9,8 @@ import (
 
 // TestMain will setup and teardown any unit test
 func TestMain(m *testing.M) {
-	GlobalSetup()
+	testhelper.GlobalSetup()
 	code := m.Run()
-	GlobalTeardown()
+	testhelper.GlobalTeardown()
 	os.Exit(code)
 }

--- a/packages/gossip/server/main_test.go
+++ b/packages/gossip/server/main_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/iotaledger/goshimmer/packages/testhelper"
+	"github.com/iotaledger/goshimmer/packages/testhelper"
 )
 
 // TestMain will setup and teardown any unit test

--- a/packages/gossip/server/main_test.go
+++ b/packages/gossip/server/main_test.go
@@ -9,8 +9,8 @@ import (
 
 // TestMain will setup and teardown any unit test
 func TestMain(m *testing.M) {
-	GlobalSetup()
+	testhelper.GlobalSetup()
 	code := m.Run()
-	GlobalTeardown()
+	testhelper.GlobalTeardown()
 	os.Exit(code)
 }

--- a/packages/gossip/server/main_test.go
+++ b/packages/gossip/server/main_test.go
@@ -1,0 +1,16 @@
+package server
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/iotaledger/goshimmer/packages/testhelper"
+)
+
+// TestMain will setup and teardown any unit test
+func TestMain(m *testing.M) {
+	GlobalSetup()
+	code := m.Run()
+	GlobalTeardown()
+	os.Exit(code)
+}

--- a/packages/gossip/server/proto/main_test.go
+++ b/packages/gossip/server/proto/main_test.go
@@ -1,0 +1,16 @@
+package proto
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/iotaledger/goshimmer/packages/testhelper"
+)
+
+// TestMain will setup and teardown any unit test
+func TestMain(m *testing.M) {
+	GlobalSetup()
+	code := m.Run()
+	GlobalTeardown()
+	os.Exit(code)
+}

--- a/packages/gossip/server/proto/main_test.go
+++ b/packages/gossip/server/proto/main_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/iotaledger/goshimmer/packages/testhelper"
+	"github.com/iotaledger/goshimmer/packages/testhelper"
 )
 
 // TestMain will setup and teardown any unit test

--- a/packages/gossip/server/proto/main_test.go
+++ b/packages/gossip/server/proto/main_test.go
@@ -9,8 +9,8 @@ import (
 
 // TestMain will setup and teardown any unit test
 func TestMain(m *testing.M) {
-	GlobalSetup()
+	testhelper.GlobalSetup()
 	code := m.Run()
-	GlobalTeardown()
+	testhelper.GlobalTeardown()
 	os.Exit(code)
 }

--- a/packages/graph/main_test.go
+++ b/packages/graph/main_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/iotaledger/goshimmer/packages/testhelper"
+	"github.com/iotaledger/goshimmer/packages/testhelper"
 )
 
 // TestMain will setup and teardown any unit test

--- a/packages/graph/main_test.go
+++ b/packages/graph/main_test.go
@@ -9,8 +9,8 @@ import (
 
 // TestMain will setup and teardown any unit test
 func TestMain(m *testing.M) {
-	GlobalSetup()
+	testhelper.GlobalSetup()
 	code := m.Run()
-	GlobalTeardown()
+	testhelper.GlobalTeardown()
 	os.Exit(code)
 }

--- a/packages/graph/main_test.go
+++ b/packages/graph/main_test.go
@@ -1,0 +1,16 @@
+package graph
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/iotaledger/goshimmer/packages/testhelper"
+)
+
+// TestMain will setup and teardown any unit test
+func TestMain(m *testing.M) {
+	GlobalSetup()
+	code := m.Run()
+	GlobalTeardown()
+	os.Exit(code)
+}

--- a/packages/jsonmodels/main_test.go
+++ b/packages/jsonmodels/main_test.go
@@ -1,0 +1,16 @@
+package jsonmodels
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/iotaledger/goshimmer/packages/testhelper"
+)
+
+// TestMain will setup and teardown any unit test
+func TestMain(m *testing.M) {
+	GlobalSetup()
+	code := m.Run()
+	GlobalTeardown()
+	os.Exit(code)
+}

--- a/packages/jsonmodels/main_test.go
+++ b/packages/jsonmodels/main_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/iotaledger/goshimmer/packages/testhelper"
+	"github.com/iotaledger/goshimmer/packages/testhelper"
 )
 
 // TestMain will setup and teardown any unit test

--- a/packages/jsonmodels/main_test.go
+++ b/packages/jsonmodels/main_test.go
@@ -9,8 +9,8 @@ import (
 
 // TestMain will setup and teardown any unit test
 func TestMain(m *testing.M) {
-	GlobalSetup()
+	testhelper.GlobalSetup()
 	code := m.Run()
-	GlobalTeardown()
+	testhelper.GlobalTeardown()
 	os.Exit(code)
 }

--- a/packages/ledgerstate/main_test.go
+++ b/packages/ledgerstate/main_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/iotaledger/goshimmer/packages/testhelper"
+	"github.com/iotaledger/goshimmer/packages/testhelper"
 )
 
 // TestMain will setup and teardown any unit test

--- a/packages/ledgerstate/main_test.go
+++ b/packages/ledgerstate/main_test.go
@@ -1,0 +1,16 @@
+package ledgerstate
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/iotaledger/goshimmer/packages/testhelper"
+)
+
+// TestMain will setup and teardown any unit test
+func TestMain(m *testing.M) {
+	GlobalSetup()
+	code := m.Run()
+	GlobalTeardown()
+	os.Exit(code)
+}

--- a/packages/ledgerstate/main_test.go
+++ b/packages/ledgerstate/main_test.go
@@ -9,8 +9,8 @@ import (
 
 // TestMain will setup and teardown any unit test
 func TestMain(m *testing.M) {
-	GlobalSetup()
+	testhelper.GlobalSetup()
 	code := m.Run()
-	GlobalTeardown()
+	testhelper.GlobalTeardown()
 	os.Exit(code)
 }

--- a/packages/ledgerstate/utxodb/main_test.go
+++ b/packages/ledgerstate/utxodb/main_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/iotaledger/goshimmer/packages/testhelper"
+	"github.com/iotaledger/goshimmer/packages/testhelper"
 )
 
 // TestMain will setup and teardown any unit test

--- a/packages/ledgerstate/utxodb/main_test.go
+++ b/packages/ledgerstate/utxodb/main_test.go
@@ -9,8 +9,8 @@ import (
 
 // TestMain will setup and teardown any unit test
 func TestMain(m *testing.M) {
-	GlobalSetup()
+	testhelper.GlobalSetup()
 	code := m.Run()
-	GlobalTeardown()
+	testhelper.GlobalTeardown()
 	os.Exit(code)
 }

--- a/packages/ledgerstate/utxodb/main_test.go
+++ b/packages/ledgerstate/utxodb/main_test.go
@@ -1,0 +1,16 @@
+package utxodb
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/iotaledger/goshimmer/packages/testhelper"
+)
+
+// TestMain will setup and teardown any unit test
+func TestMain(m *testing.M) {
+	GlobalSetup()
+	code := m.Run()
+	GlobalTeardown()
+	os.Exit(code)
+}

--- a/packages/ledgerstate/utxotest/main_test.go
+++ b/packages/ledgerstate/utxotest/main_test.go
@@ -1,0 +1,16 @@
+package utxotest
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/iotaledger/goshimmer/packages/testhelper"
+)
+
+// TestMain will setup and teardown any unit test
+func TestMain(m *testing.M) {
+	GlobalSetup()
+	code := m.Run()
+	GlobalTeardown()
+	os.Exit(code)
+}

--- a/packages/ledgerstate/utxotest/main_test.go
+++ b/packages/ledgerstate/utxotest/main_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/iotaledger/goshimmer/packages/testhelper"
+	"github.com/iotaledger/goshimmer/packages/testhelper"
 )
 
 // TestMain will setup and teardown any unit test

--- a/packages/ledgerstate/utxotest/main_test.go
+++ b/packages/ledgerstate/utxotest/main_test.go
@@ -9,8 +9,8 @@ import (
 
 // TestMain will setup and teardown any unit test
 func TestMain(m *testing.M) {
-	GlobalSetup()
+	testhelper.GlobalSetup()
 	code := m.Run()
-	GlobalTeardown()
+	testhelper.GlobalTeardown()
 	os.Exit(code)
 }

--- a/packages/ledgerstate/utxoutil/main_test.go
+++ b/packages/ledgerstate/utxoutil/main_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/iotaledger/goshimmer/packages/testhelper"
+	"github.com/iotaledger/goshimmer/packages/testhelper"
 )
 
 // TestMain will setup and teardown any unit test

--- a/packages/ledgerstate/utxoutil/main_test.go
+++ b/packages/ledgerstate/utxoutil/main_test.go
@@ -1,0 +1,16 @@
+package utxoutil
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/iotaledger/goshimmer/packages/testhelper"
+)
+
+// TestMain will setup and teardown any unit test
+func TestMain(m *testing.M) {
+	GlobalSetup()
+	code := m.Run()
+	GlobalTeardown()
+	os.Exit(code)
+}

--- a/packages/ledgerstate/utxoutil/main_test.go
+++ b/packages/ledgerstate/utxoutil/main_test.go
@@ -9,8 +9,8 @@ import (
 
 // TestMain will setup and teardown any unit test
 func TestMain(m *testing.M) {
-	GlobalSetup()
+	testhelper.GlobalSetup()
 	code := m.Run()
-	GlobalTeardown()
+	testhelper.GlobalTeardown()
 	os.Exit(code)
 }

--- a/packages/main_test.go
+++ b/packages/main_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/iotaledger/goshimmer/packages/testhelper"
+	"github.com/iotaledger/goshimmer/packages/testhelper"
 )
 
 // TestMain will setup and teardown any unit test

--- a/packages/main_test.go
+++ b/packages/main_test.go
@@ -9,8 +9,8 @@ import (
 
 // TestMain will setup and teardown any unit test
 func TestMain(m *testing.M) {
-	GlobalSetup()
+	testhelper.GlobalSetup()
 	code := m.Run()
-	GlobalTeardown()
+	testhelper.GlobalTeardown()
 	os.Exit(code)
 }

--- a/packages/main_test.go
+++ b/packages/main_test.go
@@ -1,0 +1,16 @@
+package drng
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/iotaledger/goshimmer/packages/testhelper"
+)
+
+// TestMain will setup and teardown any unit test
+func TestMain(m *testing.M) {
+	GlobalSetup()
+	code := m.Run()
+	GlobalTeardown()
+	os.Exit(code)
+}

--- a/packages/mana/main_test.go
+++ b/packages/mana/main_test.go
@@ -1,0 +1,16 @@
+package mana
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/iotaledger/goshimmer/packages/testhelper"
+)
+
+// TestMain will setup and teardown any unit test
+func TestMain(m *testing.M) {
+	GlobalSetup()
+	code := m.Run()
+	GlobalTeardown()
+	os.Exit(code)
+}

--- a/packages/mana/main_test.go
+++ b/packages/mana/main_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/iotaledger/goshimmer/packages/testhelper"
+	"github.com/iotaledger/goshimmer/packages/testhelper"
 )
 
 // TestMain will setup and teardown any unit test

--- a/packages/mana/main_test.go
+++ b/packages/mana/main_test.go
@@ -9,8 +9,8 @@ import (
 
 // TestMain will setup and teardown any unit test
 func TestMain(m *testing.M) {
-	GlobalSetup()
+	testhelper.GlobalSetup()
 	code := m.Run()
-	GlobalTeardown()
+	testhelper.GlobalTeardown()
 	os.Exit(code)
 }

--- a/packages/manualpeering/main_test.go
+++ b/packages/manualpeering/main_test.go
@@ -1,0 +1,16 @@
+package manualpeering
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/iotaledger/goshimmer/packages/testhelper"
+)
+
+// TestMain will setup and teardown any unit test
+func TestMain(m *testing.M) {
+	GlobalSetup()
+	code := m.Run()
+	GlobalTeardown()
+	os.Exit(code)
+}

--- a/packages/manualpeering/main_test.go
+++ b/packages/manualpeering/main_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/iotaledger/goshimmer/packages/testhelper"
+	"github.com/iotaledger/goshimmer/packages/testhelper"
 )
 
 // TestMain will setup and teardown any unit test

--- a/packages/manualpeering/main_test.go
+++ b/packages/manualpeering/main_test.go
@@ -9,8 +9,8 @@ import (
 
 // TestMain will setup and teardown any unit test
 func TestMain(m *testing.M) {
-	GlobalSetup()
+	testhelper.GlobalSetup()
 	code := m.Run()
-	GlobalTeardown()
+	testhelper.GlobalTeardown()
 	os.Exit(code)
 }

--- a/packages/markers/main_test.go
+++ b/packages/markers/main_test.go
@@ -1,0 +1,16 @@
+package markers
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/iotaledger/goshimmer/packages/testhelper"
+)
+
+// TestMain will setup and teardown any unit test
+func TestMain(m *testing.M) {
+	GlobalSetup()
+	code := m.Run()
+	GlobalTeardown()
+	os.Exit(code)
+}

--- a/packages/markers/main_test.go
+++ b/packages/markers/main_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/iotaledger/goshimmer/packages/testhelper"
+	"github.com/iotaledger/goshimmer/packages/testhelper"
 )
 
 // TestMain will setup and teardown any unit test

--- a/packages/markers/main_test.go
+++ b/packages/markers/main_test.go
@@ -9,8 +9,8 @@ import (
 
 // TestMain will setup and teardown any unit test
 func TestMain(m *testing.M) {
-	GlobalSetup()
+	testhelper.GlobalSetup()
 	code := m.Run()
-	GlobalTeardown()
+	testhelper.GlobalTeardown()
 	os.Exit(code)
 }

--- a/packages/metrics/main_test.go
+++ b/packages/metrics/main_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/iotaledger/goshimmer/packages/testhelper"
+	"github.com/iotaledger/goshimmer/packages/testhelper"
 )
 
 // TestMain will setup and teardown any unit test

--- a/packages/metrics/main_test.go
+++ b/packages/metrics/main_test.go
@@ -9,8 +9,8 @@ import (
 
 // TestMain will setup and teardown any unit test
 func TestMain(m *testing.M) {
-	GlobalSetup()
+	testhelper.GlobalSetup()
 	code := m.Run()
-	GlobalTeardown()
+	testhelper.GlobalTeardown()
 	os.Exit(code)
 }

--- a/packages/metrics/main_test.go
+++ b/packages/metrics/main_test.go
@@ -1,0 +1,16 @@
+package metrics
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/iotaledger/goshimmer/packages/testhelper"
+)
+
+// TestMain will setup and teardown any unit test
+func TestMain(m *testing.M) {
+	GlobalSetup()
+	code := m.Run()
+	GlobalTeardown()
+	os.Exit(code)
+}

--- a/packages/pow/main_test.go
+++ b/packages/pow/main_test.go
@@ -1,0 +1,16 @@
+package pow
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/iotaledger/goshimmer/packages/testhelper"
+)
+
+// TestMain will setup and teardown any unit test
+func TestMain(m *testing.M) {
+	GlobalSetup()
+	code := m.Run()
+	GlobalTeardown()
+	os.Exit(code)
+}

--- a/packages/pow/main_test.go
+++ b/packages/pow/main_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/iotaledger/goshimmer/packages/testhelper"
+	"github.com/iotaledger/goshimmer/packages/testhelper"
 )
 
 // TestMain will setup and teardown any unit test

--- a/packages/pow/main_test.go
+++ b/packages/pow/main_test.go
@@ -9,8 +9,8 @@ import (
 
 // TestMain will setup and teardown any unit test
 func TestMain(m *testing.M) {
-	GlobalSetup()
+	testhelper.GlobalSetup()
 	code := m.Run()
-	GlobalTeardown()
+	testhelper.GlobalTeardown()
 	os.Exit(code)
 }

--- a/packages/prng/main_test.go
+++ b/packages/prng/main_test.go
@@ -1,0 +1,16 @@
+package prng
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/iotaledger/goshimmer/packages/testhelper"
+)
+
+// TestMain will setup and teardown any unit test
+func TestMain(m *testing.M) {
+	GlobalSetup()
+	code := m.Run()
+	GlobalTeardown()
+	os.Exit(code)
+}

--- a/packages/prng/main_test.go
+++ b/packages/prng/main_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/iotaledger/goshimmer/packages/testhelper"
+	"github.com/iotaledger/goshimmer/packages/testhelper"
 )
 
 // TestMain will setup and teardown any unit test

--- a/packages/prng/main_test.go
+++ b/packages/prng/main_test.go
@@ -9,8 +9,8 @@ import (
 
 // TestMain will setup and teardown any unit test
 func TestMain(m *testing.M) {
-	GlobalSetup()
+	testhelper.GlobalSetup()
 	code := m.Run()
-	GlobalTeardown()
+	testhelper.GlobalTeardown()
 	os.Exit(code)
 }

--- a/packages/remotelogmetrics/main_test.go
+++ b/packages/remotelogmetrics/main_test.go
@@ -1,0 +1,16 @@
+package remotelogmetrics
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/iotaledger/goshimmer/packages/testhelper"
+)
+
+// TestMain will setup and teardown any unit test
+func TestMain(m *testing.M) {
+	GlobalSetup()
+	code := m.Run()
+	GlobalTeardown()
+	os.Exit(code)
+}

--- a/packages/remotelogmetrics/main_test.go
+++ b/packages/remotelogmetrics/main_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/iotaledger/goshimmer/packages/testhelper"
+	"github.com/iotaledger/goshimmer/packages/testhelper"
 )
 
 // TestMain will setup and teardown any unit test

--- a/packages/remotelogmetrics/main_test.go
+++ b/packages/remotelogmetrics/main_test.go
@@ -9,8 +9,8 @@ import (
 
 // TestMain will setup and teardown any unit test
 func TestMain(m *testing.M) {
-	GlobalSetup()
+	testhelper.GlobalSetup()
 	code := m.Run()
-	GlobalTeardown()
+	testhelper.GlobalTeardown()
 	os.Exit(code)
 }

--- a/packages/shutdown/main_test.go
+++ b/packages/shutdown/main_test.go
@@ -1,0 +1,16 @@
+package shutdown
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/iotaledger/goshimmer/packages/testhelper"
+)
+
+// TestMain will setup and teardown any unit test
+func TestMain(m *testing.M) {
+	GlobalSetup()
+	code := m.Run()
+	GlobalTeardown()
+	os.Exit(code)
+}

--- a/packages/shutdown/main_test.go
+++ b/packages/shutdown/main_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/iotaledger/goshimmer/packages/testhelper"
+	"github.com/iotaledger/goshimmer/packages/testhelper"
 )
 
 // TestMain will setup and teardown any unit test

--- a/packages/shutdown/main_test.go
+++ b/packages/shutdown/main_test.go
@@ -9,8 +9,8 @@ import (
 
 // TestMain will setup and teardown any unit test
 func TestMain(m *testing.M) {
-	GlobalSetup()
+	testhelper.GlobalSetup()
 	code := m.Run()
-	GlobalTeardown()
+	testhelper.GlobalTeardown()
 	os.Exit(code)
 }

--- a/packages/spammer/main_test.go
+++ b/packages/spammer/main_test.go
@@ -1,0 +1,16 @@
+package spammer
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/iotaledger/goshimmer/packages/testhelper"
+)
+
+// TestMain will setup and teardown any unit test
+func TestMain(m *testing.M) {
+	GlobalSetup()
+	code := m.Run()
+	GlobalTeardown()
+	os.Exit(code)
+}

--- a/packages/spammer/main_test.go
+++ b/packages/spammer/main_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/iotaledger/goshimmer/packages/testhelper"
+	"github.com/iotaledger/goshimmer/packages/testhelper"
 )
 
 // TestMain will setup and teardown any unit test

--- a/packages/spammer/main_test.go
+++ b/packages/spammer/main_test.go
@@ -9,8 +9,8 @@ import (
 
 // TestMain will setup and teardown any unit test
 func TestMain(m *testing.M) {
-	GlobalSetup()
+	testhelper.GlobalSetup()
 	code := m.Run()
-	GlobalTeardown()
+	testhelper.GlobalTeardown()
 	os.Exit(code)
 }

--- a/packages/tangle/images/main_test.go
+++ b/packages/tangle/images/main_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/iotaledger/goshimmer/packages/testhelper"
+	"github.com/iotaledger/goshimmer/packages/testhelper"
 )
 
 // TestMain will setup and teardown any unit test

--- a/packages/tangle/images/main_test.go
+++ b/packages/tangle/images/main_test.go
@@ -9,8 +9,8 @@ import (
 
 // TestMain will setup and teardown any unit test
 func TestMain(m *testing.M) {
-	GlobalSetup()
+	testhelper.GlobalSetup()
 	code := m.Run()
-	GlobalTeardown()
+	testhelper.GlobalTeardown()
 	os.Exit(code)
 }

--- a/packages/tangle/images/main_test.go
+++ b/packages/tangle/images/main_test.go
@@ -1,0 +1,16 @@
+package drng
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/iotaledger/goshimmer/packages/testhelper"
+)
+
+// TestMain will setup and teardown any unit test
+func TestMain(m *testing.M) {
+	GlobalSetup()
+	code := m.Run()
+	GlobalTeardown()
+	os.Exit(code)
+}

--- a/packages/tangle/main_test.go
+++ b/packages/tangle/main_test.go
@@ -1,0 +1,16 @@
+package tangle
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/iotaledger/goshimmer/packages/testhelper"
+)
+
+// TestMain will setup and teardown any unit test
+func TestMain(m *testing.M) {
+	GlobalSetup()
+	code := m.Run()
+	GlobalTeardown()
+	os.Exit(code)
+}

--- a/packages/tangle/main_test.go
+++ b/packages/tangle/main_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/iotaledger/goshimmer/packages/testhelper"
+	"github.com/iotaledger/goshimmer/packages/testhelper"
 )
 
 // TestMain will setup and teardown any unit test

--- a/packages/tangle/main_test.go
+++ b/packages/tangle/main_test.go
@@ -9,8 +9,8 @@ import (
 
 // TestMain will setup and teardown any unit test
 func TestMain(m *testing.M) {
-	GlobalSetup()
+	testhelper.GlobalSetup()
 	code := m.Run()
-	GlobalTeardown()
+	testhelper.GlobalTeardown()
 	os.Exit(code)
 }

--- a/packages/tangle/payload/main_test.go
+++ b/packages/tangle/payload/main_test.go
@@ -1,0 +1,16 @@
+package payload
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/iotaledger/goshimmer/packages/testhelper"
+)
+
+// TestMain will setup and teardown any unit test
+func TestMain(m *testing.M) {
+	GlobalSetup()
+	code := m.Run()
+	GlobalTeardown()
+	os.Exit(code)
+}

--- a/packages/tangle/payload/main_test.go
+++ b/packages/tangle/payload/main_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/iotaledger/goshimmer/packages/testhelper"
+	"github.com/iotaledger/goshimmer/packages/testhelper"
 )
 
 // TestMain will setup and teardown any unit test

--- a/packages/tangle/payload/main_test.go
+++ b/packages/tangle/payload/main_test.go
@@ -9,8 +9,8 @@ import (
 
 // TestMain will setup and teardown any unit test
 func TestMain(m *testing.M) {
-	GlobalSetup()
+	testhelper.GlobalSetup()
 	code := m.Run()
-	GlobalTeardown()
+	testhelper.GlobalTeardown()
 	os.Exit(code)
 }

--- a/packages/tangle/schedulerutils/main_test.go
+++ b/packages/tangle/schedulerutils/main_test.go
@@ -1,0 +1,16 @@
+package schedulerutils
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/iotaledger/goshimmer/packages/testhelper"
+)
+
+// TestMain will setup and teardown any unit test
+func TestMain(m *testing.M) {
+	GlobalSetup()
+	code := m.Run()
+	GlobalTeardown()
+	os.Exit(code)
+}

--- a/packages/tangle/schedulerutils/main_test.go
+++ b/packages/tangle/schedulerutils/main_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/iotaledger/goshimmer/packages/testhelper"
+	"github.com/iotaledger/goshimmer/packages/testhelper"
 )
 
 // TestMain will setup and teardown any unit test

--- a/packages/tangle/schedulerutils/main_test.go
+++ b/packages/tangle/schedulerutils/main_test.go
@@ -9,8 +9,8 @@ import (
 
 // TestMain will setup and teardown any unit test
 func TestMain(m *testing.M) {
-	GlobalSetup()
+	testhelper.GlobalSetup()
 	code := m.Run()
-	GlobalTeardown()
+	testhelper.GlobalTeardown()
 	os.Exit(code)
 }

--- a/packages/testhelper/testhelper.go
+++ b/packages/testhelper/testhelper.go
@@ -1,0 +1,11 @@
+package testhelper
+
+// TestSetup setups global environment and parameters for any unit test
+func GlobalSetup() {
+	// To be implemented
+}
+
+// TestTeardown resets all the changes the test made
+func GlobalTeardown() {
+	// To be implemented
+}

--- a/packages/testhelper/testhelper.go
+++ b/packages/testhelper/testhelper.go
@@ -1,11 +1,11 @@
 package testhelper
 
-// TestSetup setups global environment and parameters for any unit test
+// GlobalSetup setups global environment and parameters for any unit test
 func GlobalSetup() {
 	// To be implemented
 }
 
-// TestTeardown resets all the changes the test made
+// GlobalTeardown resets all the changes the test made
 func GlobalTeardown() {
 	// To be implemented
 }

--- a/packages/txstream/chopper/main_test.go
+++ b/packages/txstream/chopper/main_test.go
@@ -1,0 +1,16 @@
+package chopper
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/iotaledger/goshimmer/packages/testhelper"
+)
+
+// TestMain will setup and teardown any unit test
+func TestMain(m *testing.M) {
+	GlobalSetup()
+	code := m.Run()
+	GlobalTeardown()
+	os.Exit(code)
+}

--- a/packages/txstream/chopper/main_test.go
+++ b/packages/txstream/chopper/main_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/iotaledger/goshimmer/packages/testhelper"
+	"github.com/iotaledger/goshimmer/packages/testhelper"
 )
 
 // TestMain will setup and teardown any unit test

--- a/packages/txstream/chopper/main_test.go
+++ b/packages/txstream/chopper/main_test.go
@@ -9,8 +9,8 @@ import (
 
 // TestMain will setup and teardown any unit test
 func TestMain(m *testing.M) {
-	GlobalSetup()
+	testhelper.GlobalSetup()
 	code := m.Run()
-	GlobalTeardown()
+	testhelper.GlobalTeardown()
 	os.Exit(code)
 }

--- a/packages/txstream/client/main_test.go
+++ b/packages/txstream/client/main_test.go
@@ -1,0 +1,16 @@
+package client
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/iotaledger/goshimmer/packages/testhelper"
+)
+
+// TestMain will setup and teardown any unit test
+func TestMain(m *testing.M) {
+	GlobalSetup()
+	code := m.Run()
+	GlobalTeardown()
+	os.Exit(code)
+}

--- a/packages/txstream/client/main_test.go
+++ b/packages/txstream/client/main_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/iotaledger/goshimmer/packages/testhelper"
+	"github.com/iotaledger/goshimmer/packages/testhelper"
 )
 
 // TestMain will setup and teardown any unit test

--- a/packages/txstream/client/main_test.go
+++ b/packages/txstream/client/main_test.go
@@ -9,8 +9,8 @@ import (
 
 // TestMain will setup and teardown any unit test
 func TestMain(m *testing.M) {
-	GlobalSetup()
+	testhelper.GlobalSetup()
 	code := m.Run()
-	GlobalTeardown()
+	testhelper.GlobalTeardown()
 	os.Exit(code)
 }

--- a/packages/txstream/main_test.go
+++ b/packages/txstream/main_test.go
@@ -1,0 +1,16 @@
+package txstream
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/iotaledger/goshimmer/packages/testhelper"
+)
+
+// TestMain will setup and teardown any unit test
+func TestMain(m *testing.M) {
+	GlobalSetup()
+	code := m.Run()
+	GlobalTeardown()
+	os.Exit(code)
+}

--- a/packages/txstream/main_test.go
+++ b/packages/txstream/main_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/iotaledger/goshimmer/packages/testhelper"
+	"github.com/iotaledger/goshimmer/packages/testhelper"
 )
 
 // TestMain will setup and teardown any unit test

--- a/packages/txstream/main_test.go
+++ b/packages/txstream/main_test.go
@@ -9,8 +9,8 @@ import (
 
 // TestMain will setup and teardown any unit test
 func TestMain(m *testing.M) {
-	GlobalSetup()
+	testhelper.GlobalSetup()
 	code := m.Run()
-	GlobalTeardown()
+	testhelper.GlobalTeardown()
 	os.Exit(code)
 }

--- a/packages/txstream/server/main_test.go
+++ b/packages/txstream/server/main_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/iotaledger/goshimmer/packages/testhelper"
+	"github.com/iotaledger/goshimmer/packages/testhelper"
 )
 
 // TestMain will setup and teardown any unit test

--- a/packages/txstream/server/main_test.go
+++ b/packages/txstream/server/main_test.go
@@ -9,8 +9,8 @@ import (
 
 // TestMain will setup and teardown any unit test
 func TestMain(m *testing.M) {
-	GlobalSetup()
+	testhelper.GlobalSetup()
 	code := m.Run()
-	GlobalTeardown()
+	testhelper.GlobalTeardown()
 	os.Exit(code)
 }

--- a/packages/txstream/server/main_test.go
+++ b/packages/txstream/server/main_test.go
@@ -1,0 +1,16 @@
+package server
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/iotaledger/goshimmer/packages/testhelper"
+)
+
+// TestMain will setup and teardown any unit test
+func TestMain(m *testing.M) {
+	GlobalSetup()
+	code := m.Run()
+	GlobalTeardown()
+	os.Exit(code)
+}

--- a/packages/txstream/tangleledger/main_test.go
+++ b/packages/txstream/tangleledger/main_test.go
@@ -1,0 +1,16 @@
+package tangleledger
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/iotaledger/goshimmer/packages/testhelper"
+)
+
+// TestMain will setup and teardown any unit test
+func TestMain(m *testing.M) {
+	GlobalSetup()
+	code := m.Run()
+	GlobalTeardown()
+	os.Exit(code)
+}

--- a/packages/txstream/tangleledger/main_test.go
+++ b/packages/txstream/tangleledger/main_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/iotaledger/goshimmer/packages/testhelper"
+	"github.com/iotaledger/goshimmer/packages/testhelper"
 )
 
 // TestMain will setup and teardown any unit test

--- a/packages/txstream/tangleledger/main_test.go
+++ b/packages/txstream/tangleledger/main_test.go
@@ -9,8 +9,8 @@ import (
 
 // TestMain will setup and teardown any unit test
 func TestMain(m *testing.M) {
-	GlobalSetup()
+	testhelper.GlobalSetup()
 	code := m.Run()
-	GlobalTeardown()
+	testhelper.GlobalTeardown()
 	os.Exit(code)
 }

--- a/packages/txstream/utxodbledger/main_test.go
+++ b/packages/txstream/utxodbledger/main_test.go
@@ -1,0 +1,16 @@
+package utxodbledger
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/iotaledger/goshimmer/packages/testhelper"
+)
+
+// TestMain will setup and teardown any unit test
+func TestMain(m *testing.M) {
+	GlobalSetup()
+	code := m.Run()
+	GlobalTeardown()
+	os.Exit(code)
+}

--- a/packages/txstream/utxodbledger/main_test.go
+++ b/packages/txstream/utxodbledger/main_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/iotaledger/goshimmer/packages/testhelper"
+	"github.com/iotaledger/goshimmer/packages/testhelper"
 )
 
 // TestMain will setup and teardown any unit test

--- a/packages/txstream/utxodbledger/main_test.go
+++ b/packages/txstream/utxodbledger/main_test.go
@@ -9,8 +9,8 @@ import (
 
 // TestMain will setup and teardown any unit test
 func TestMain(m *testing.M) {
-	GlobalSetup()
+	testhelper.GlobalSetup()
 	code := m.Run()
-	GlobalTeardown()
+	testhelper.GlobalTeardown()
 	os.Exit(code)
 }

--- a/packages/vote/fpc/main_test.go
+++ b/packages/vote/fpc/main_test.go
@@ -1,0 +1,16 @@
+package fpc
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/iotaledger/goshimmer/packages/testhelper"
+)
+
+// TestMain will setup and teardown any unit test
+func TestMain(m *testing.M) {
+	GlobalSetup()
+	code := m.Run()
+	GlobalTeardown()
+	os.Exit(code)
+}

--- a/packages/vote/fpc/main_test.go
+++ b/packages/vote/fpc/main_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/iotaledger/goshimmer/packages/testhelper"
+	"github.com/iotaledger/goshimmer/packages/testhelper"
 )
 
 // TestMain will setup and teardown any unit test

--- a/packages/vote/fpc/main_test.go
+++ b/packages/vote/fpc/main_test.go
@@ -9,8 +9,8 @@ import (
 
 // TestMain will setup and teardown any unit test
 func TestMain(m *testing.M) {
-	GlobalSetup()
+	testhelper.GlobalSetup()
 	code := m.Run()
-	GlobalTeardown()
+	testhelper.GlobalTeardown()
 	os.Exit(code)
 }

--- a/packages/vote/main_test.go
+++ b/packages/vote/main_test.go
@@ -1,0 +1,16 @@
+package vote
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/iotaledger/goshimmer/packages/testhelper"
+)
+
+// TestMain will setup and teardown any unit test
+func TestMain(m *testing.M) {
+	GlobalSetup()
+	code := m.Run()
+	GlobalTeardown()
+	os.Exit(code)
+}

--- a/packages/vote/main_test.go
+++ b/packages/vote/main_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/iotaledger/goshimmer/packages/testhelper"
+	"github.com/iotaledger/goshimmer/packages/testhelper"
 )
 
 // TestMain will setup and teardown any unit test

--- a/packages/vote/main_test.go
+++ b/packages/vote/main_test.go
@@ -9,8 +9,8 @@ import (
 
 // TestMain will setup and teardown any unit test
 func TestMain(m *testing.M) {
-	GlobalSetup()
+	testhelper.GlobalSetup()
 	code := m.Run()
-	GlobalTeardown()
+	testhelper.GlobalTeardown()
 	os.Exit(code)
 }

--- a/packages/vote/net/main_test.go
+++ b/packages/vote/net/main_test.go
@@ -1,0 +1,16 @@
+package net
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/iotaledger/goshimmer/packages/testhelper"
+)
+
+// TestMain will setup and teardown any unit test
+func TestMain(m *testing.M) {
+	GlobalSetup()
+	code := m.Run()
+	GlobalTeardown()
+	os.Exit(code)
+}

--- a/packages/vote/net/main_test.go
+++ b/packages/vote/net/main_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/iotaledger/goshimmer/packages/testhelper"
+	"github.com/iotaledger/goshimmer/packages/testhelper"
 )
 
 // TestMain will setup and teardown any unit test

--- a/packages/vote/net/main_test.go
+++ b/packages/vote/net/main_test.go
@@ -9,8 +9,8 @@ import (
 
 // TestMain will setup and teardown any unit test
 func TestMain(m *testing.M) {
-	GlobalSetup()
+	testhelper.GlobalSetup()
 	code := m.Run()
-	GlobalTeardown()
+	testhelper.GlobalTeardown()
 	os.Exit(code)
 }

--- a/packages/vote/opinion/main_test.go
+++ b/packages/vote/opinion/main_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/iotaledger/goshimmer/packages/testhelper"
+	"github.com/iotaledger/goshimmer/packages/testhelper"
 )
 
 // TestMain will setup and teardown any unit test

--- a/packages/vote/opinion/main_test.go
+++ b/packages/vote/opinion/main_test.go
@@ -9,8 +9,8 @@ import (
 
 // TestMain will setup and teardown any unit test
 func TestMain(m *testing.M) {
-	GlobalSetup()
+	testhelper.GlobalSetup()
 	code := m.Run()
-	GlobalTeardown()
+	testhelper.GlobalTeardown()
 	os.Exit(code)
 }

--- a/packages/vote/opinion/main_test.go
+++ b/packages/vote/opinion/main_test.go
@@ -1,0 +1,16 @@
+package opinion
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/iotaledger/goshimmer/packages/testhelper"
+)
+
+// TestMain will setup and teardown any unit test
+func TestMain(m *testing.M) {
+	GlobalSetup()
+	code := m.Run()
+	GlobalTeardown()
+	os.Exit(code)
+}

--- a/packages/vote/statement/main_test.go
+++ b/packages/vote/statement/main_test.go
@@ -1,0 +1,16 @@
+package statement
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/iotaledger/goshimmer/packages/testhelper"
+)
+
+// TestMain will setup and teardown any unit test
+func TestMain(m *testing.M) {
+	GlobalSetup()
+	code := m.Run()
+	GlobalTeardown()
+	os.Exit(code)
+}

--- a/packages/vote/statement/main_test.go
+++ b/packages/vote/statement/main_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/iotaledger/goshimmer/packages/testhelper"
+	"github.com/iotaledger/goshimmer/packages/testhelper"
 )
 
 // TestMain will setup and teardown any unit test

--- a/packages/vote/statement/main_test.go
+++ b/packages/vote/statement/main_test.go
@@ -9,8 +9,8 @@ import (
 
 // TestMain will setup and teardown any unit test
 func TestMain(m *testing.M) {
-	GlobalSetup()
+	testhelper.GlobalSetup()
 	code := m.Run()
-	GlobalTeardown()
+	testhelper.GlobalTeardown()
 	os.Exit(code)
 }


### PR DESCRIPTION
# Description of change

Add a main_test.go to every folder in packages that points to global `Setup` and `Tearup`.
This provides a good framework for current tests.

The motivation for this PR was to easily inject a global cache time for #1109 

## Type of change

- Enhancement (a non-breaking change which adds functionality)
- Documentation Fix

## How the change has been tested

Saw in debug that test_main.go is being invoked

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
