### PR TITLE
Fix Genesis Loaded Transaction View

### DIFF
--- a/plugins/dashboard/frontend/src/app/components/SigLockedSingleOutputComponent.tsx
+++ b/plugins/dashboard/frontend/src/app/components/SigLockedSingleOutputComponent.tsx
@@ -10,6 +10,8 @@ interface Props {
 
 export class SigLockedSingleOutputComponent extends React.Component<Props, any> {
     render() {
+        let o = this.props.output;
+        let id = this.props.id;
         return (
             <div className={"mb-2"} key={this.props.id.base58}>
                 <ListGroup>
@@ -17,13 +19,13 @@ export class SigLockedSingleOutputComponent extends React.Component<Props, any> 
                     <ListGroup.Item>
                         Balances:
                         <div>
-                            <div><Badge variant="success">{new Intl.NumberFormat().format(this.props.output.balance)} IOTA</Badge></div>
+                            <div><Badge variant="success">{new Intl.NumberFormat().format(o.balance)} IOTA</Badge></div>
                         </div>
                     </ListGroup.Item>
-                    <ListGroup.Item>OutputID: <a href={`/explorer/output/${this.props.id.base58}`}>{this.props.id.base58}</a></ListGroup.Item>
-                    <ListGroup.Item>Address: <a href={`/explorer/address/${this.props.output.address}`}> {this.props.output.address}</a></ListGroup.Item>
-                <ListGroup.Item>Transaction: <a href={`/explorer/transaction/${this.props.id.transactionID}`}> {this.props.id.transactionID}</a></ListGroup.Item>
-                <ListGroup.Item>Output Index: {this.props.id.outputIndex}</ListGroup.Item>
+                    <ListGroup.Item>OutputID: <a href={`/explorer/output/${id.base58}`}>{id.base58}</a></ListGroup.Item>
+                    <ListGroup.Item>Address: <a href={`/explorer/address/${o.address}`}> {o.address}</a></ListGroup.Item>
+                <ListGroup.Item>Transaction: <a href={`/explorer/transaction/${id.transactionID}`}> {id.transactionID}</a></ListGroup.Item>
+                <ListGroup.Item>Output Index: {id.outputIndex}</ListGroup.Item>
                 </ListGroup>
             </div>
         );

--- a/plugins/dashboard/frontend/src/app/stores/ExplorerStore.tsx
+++ b/plugins/dashboard/frontend/src/app/stores/ExplorerStore.tsx
@@ -8,13 +8,14 @@ import {
     PayloadType,
     TransactionPayload,
     getPayloadType,
-    Output
+    Output, SigLockedSingleOutput
 } from "app/misc/Payload";
 import * as React from "react";
 import {Link} from 'react-router-dom';
 import {RouterStore} from "mobx-react-router";
 
 export const GenesisMessageID = "1111111111111111111111111111111111111111111111111111111111111111";
+export const GenesisTransactionID = "11111111111111111111111111111111";
 
 export class Message {
     id: string;
@@ -266,6 +267,16 @@ export class ExplorerStore {
             }
             let tx = await res.json()
             for(let i = 0; i < tx.inputs.length; i++) {
+                if (tx.inputs[i].referencedOutputID.transactionID === GenesisTransactionID) {
+                    let genOutput = new Output();
+                    genOutput.output = new SigLockedSingleOutput();
+                    genOutput.output.balance = 0;
+                    genOutput.output.address = "GENESIS";
+                    genOutput.type = "SigLockedSingleOutputType";
+                    genOutput.outputID = tx.inputs[i].referencedOutputID;
+                    tx.inputs[i].output = genOutput;
+                    continue;
+                }
                 let inputID = tx.inputs[i] ? tx.inputs[i].referencedOutputID.base58 : GenesisMessageID
                 try{
                     let referencedOutputRes = await fetch(`/api/output/${inputID}`)


### PR DESCRIPTION
Fix #1296 

# Description of change

 - When a `genesis output` is referenced in a transaction (basically any tx loaded from the snapshot), fill out output info in frontend manually instead of trying to fetch the non-existent output from the node.
 - For such "virtual outputs", balance is always `0`, address is always `GENESIS`.

![image](https://user-images.githubusercontent.com/32927267/121877574-0bb9ea80-cd0b-11eb-8cb5-1de8e9424433.png)

