### PR TITLE
Fix memory leak in pow plugin/pkg

### DIFF
--- a/client/faucet.go
+++ b/client/faucet.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"crypto"
 	"net/http"
 
 	"github.com/cockroachdb/errors"
@@ -22,7 +21,7 @@ const (
 
 var (
 	defaultPOWTarget = 25
-	powWorker        = pow.New(crypto.BLAKE2b_512, 1)
+	powWorker        = pow.New(1)
 )
 
 // SendFaucetRequest requests funds from faucet nodes by sending a faucet request payload message.

--- a/packages/pow/pow_test.go
+++ b/packages/pow/pow_test.go
@@ -2,7 +2,6 @@ package pow
 
 import (
 	"context"
-	"crypto"
 	"math"
 	"sync"
 	"sync/atomic"
@@ -19,7 +18,7 @@ const (
 	target  = 10
 )
 
-var testWorker = New(crypto.BLAKE2b_512, workers)
+var testWorker = New(workers)
 
 func TestWorker_Work(t *testing.T) {
 	nonce, err := testWorker.Mine(context.Background(), nil, target)
@@ -41,7 +40,7 @@ func TestWorker_Validate(t *testing.T) {
 		{msg: make([]byte, 10240), nonce: 0, expLeadingZeros: 1, expErr: nil},
 	}
 
-	w := &Worker{hash: crypto.BLAKE2b_512}
+	w := &Worker{}
 	for _, tt := range tests {
 		zeros, err := w.LeadingZerosWithNonce(tt.msg, tt.nonce)
 		assert.Equal(t, tt.expLeadingZeros, zeros)

--- a/packages/tangle/messagefactory_test.go
+++ b/packages/tangle/messagefactory_test.go
@@ -2,7 +2,6 @@ package tangle
 
 import (
 	"context"
-	"crypto"
 	"crypto/ed25519"
 	"crypto/rand"
 	"sync"
@@ -130,7 +129,7 @@ func TestMessageFactory_POW(t *testing.T) {
 	)
 	defer msgFactory.Shutdown()
 
-	worker := pow.New(crypto.BLAKE2b_512, 1)
+	worker := pow.New(1)
 
 	msgFactory.SetWorker(WorkerFunc(func(msgBytes []byte) (uint64, error) {
 		content := msgBytes[:len(msgBytes)-ed25519.SignatureSize-8]

--- a/packages/tangle/parser_test.go
+++ b/packages/tangle/parser_test.go
@@ -2,7 +2,6 @@ package tangle
 
 import (
 	"context"
-	"crypto"
 	"strconv"
 	"testing"
 	"time"
@@ -64,7 +63,7 @@ func TestMessageParser_ParseMessage(t *testing.T) {
 
 var (
 	testPeer       *peer.Peer
-	testWorker     = pow.New(crypto.BLAKE2b_512, 1)
+	testWorker     = pow.New(1)
 	testDifficulty = 10
 )
 

--- a/packages/tangle/tangle_test.go
+++ b/packages/tangle/tangle_test.go
@@ -2,7 +2,6 @@ package tangle
 
 import (
 	"context"
-	"crypto"
 	"fmt"
 	"math/rand"
 	"net"
@@ -362,7 +361,7 @@ func TestTangle_Flow(t *testing.T) {
 
 	var (
 		totalMsgCount = solidMsgCount + invalidMsgCount
-		testWorker    = pow.New(crypto.BLAKE2b_512, 1)
+		testWorker    = pow.New(1)
 		// same as gossip manager
 		messageWorkerCount     = runtime.GOMAXPROCS(0) * 4
 		messageWorkerQueueSize = 1000

--- a/plugins/faucet/plugin.go
+++ b/plugins/faucet/plugin.go
@@ -1,7 +1,6 @@
 package faucet
 
 import (
-	"crypto"
 	"runtime"
 	"sync"
 	"time"
@@ -67,7 +66,7 @@ var (
 	_faucet                *StateManager
 	faucetOnce             sync.Once
 	log                    *logger.Logger
-	powVerifier            = pow.New(crypto.BLAKE2b_512)
+	powVerifier            = pow.New()
 	fundingWorkerPool      *workerpool.WorkerPool
 	fundingWorkerCount     = runtime.GOMAXPROCS(0)
 	fundingWorkerQueueSize = 500

--- a/plugins/pow/pow.go
+++ b/plugins/pow/pow.go
@@ -46,7 +46,7 @@ func Worker() *pow.Worker {
 		timeout = config.Node().Duration(CfgPOWTimeout)
 		parentsRefreshInterval = config.Node().Duration(CfgPOWParentsRefreshInterval)
 		// create the worker
-		worker = pow.New(hash, numWorkers)
+		worker = pow.New(numWorkers)
 	})
 	return worker
 }

--- a/plugins/webapi/faucet/plugin.go
+++ b/plugins/webapi/faucet/plugin.go
@@ -1,7 +1,6 @@
 package faucet
 
 import (
-	"crypto"
 	"fmt"
 	"net/http"
 	"sync"
@@ -25,7 +24,7 @@ var (
 	// plugin is the plugin instance of the web API info endpoint plugin.
 	plugin              *node.Plugin
 	once                sync.Once
-	powVerifier         = pow.New(crypto.BLAKE2b_512)
+	powVerifier         = pow.New()
 	targetPoWDifficulty int
 )
 


### PR DESCRIPTION
# Description of change

`hash.New()` implementation  failed to release memory when computing pow for messages.