### PR TITLE
Add time range check in wallet lib

### DIFF
--- a/client/wallet/packages/constants/constants.go
+++ b/client/wallet/packages/constants/constants.go
@@ -1,0 +1,16 @@
+package constants
+
+import (
+	"math"
+	"time"
+)
+
+// MinInt64 is the smallest number representable as int64.
+const MinInt64 = -math.MaxInt64 - 1
+
+var (
+	// MaxRepresentableTime is the greatest time that doesn't overflow when converted to unix nanoseconds.
+	MaxRepresentableTime = time.Unix(0, math.MaxInt64)
+	// MinRepresentableTime is the smallest time that doesn't overflow when converted to unix nanoseconds.
+	MinRepresentableTime = time.Unix(0, MinInt64)
+)

--- a/client/wallet/packages/delegateoptions/options.go
+++ b/client/wallet/packages/delegateoptions/options.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cockroachdb/errors"
 
 	"github.com/iotaledger/goshimmer/client/wallet/packages/address"
+	"github.com/iotaledger/goshimmer/client/wallet/packages/constants"
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 )
 
@@ -44,6 +45,9 @@ func DelegateUntil(until time.Time) DelegateFundsOption {
 	return func(options *DelegateFundsOptions) error {
 		if until.Before(time.Now()) {
 			return errors.Errorf("can't delegate funds in the past")
+		}
+		if until.After(constants.MaxRepresentableTime) {
+			return errors.Errorf("delegation is only supported until %s", constants.MaxRepresentableTime)
 		}
 		options.DelegateUntil = until
 		return nil

--- a/client/wallet/packages/sendoptions/options.go
+++ b/client/wallet/packages/sendoptions/options.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cockroachdb/errors"
 
 	"github.com/iotaledger/goshimmer/client/wallet/packages/address"
+	"github.com/iotaledger/goshimmer/client/wallet/packages/constants"
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 )
 
@@ -94,6 +95,10 @@ func LockUntil(until time.Time) SendFundsOption {
 		if until.Before(time.Now()) {
 			return errors.Errorf("can't timelock funds in the past")
 		}
+		if until.After(constants.MaxRepresentableTime) {
+			return errors.Errorf("invalid timelock: %s is later, than max representable time %s",
+				until.String(), constants.MaxRepresentableTime.String())
+		}
 		options.LockUntil = until
 		return nil
 	}
@@ -108,6 +113,10 @@ func Fallback(addy ledgerstate.Address, deadline time.Time) SendFundsOption {
 		}
 		if deadline.Before(time.Now()) {
 			return errors.Errorf("invalid fallback deadline: %s is in the past", deadline.String())
+		}
+		if deadline.After(constants.MaxRepresentableTime) {
+			return errors.Errorf("invalid fallback deadline: %s is later, than max representable time %s",
+				deadline.String(), constants.MaxRepresentableTime.String())
 		}
 		options.FallbackAddress = addy
 		options.FallbackDeadline = deadline


### PR DESCRIPTION
Fix #1388

# Description of change

Wallet lib performs time range checks on provided time inputs, as GoShimmer currently only handles timestamps in the range of [ 1677-09-21 00:12:43.145224192 +0000 UTC, 2262-04-11 23:47:16.854775807 +0000 UTC].
