### PR TITLE
Replace builtin hash map with a sorted set

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/cockroachdb/errors v1.8.4
 	github.com/drand/drand v1.1.1
 	github.com/drand/kyber v1.1.2
+	github.com/emirpasic/gods v1.12.0
 	github.com/gin-gonic/gin v1.6.3
 	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/go-resty/resty/v2 v2.6.0


### PR DESCRIPTION
# Description of change

`requestedMsgs` map might contain a lot of records when the node starts and since the Go builtin hash map is ever-growing such nodes will consume a lot of memory and will never free it. 
We switch to a sorted map instead which frees up the memory comlitlly on element removal.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Unit tests & integration tests

