### PR TITLE
Fix Snapshot Bug + Update Global Snapshot

### DIFF
--- a/packages/tangle/ledgerstate.go
+++ b/packages/tangle/ledgerstate.go
@@ -219,9 +219,9 @@ func (l *LedgerState) SnapshotUTXO() (snapshot *ledgerstate.Snapshot) {
 					unspentOutputs[i] = true
 					includeTransaction = true
 				} else {
-					tx := copyLedgerState[outputMetadata.ConfirmedConsumer()]
+					tx, exist := copyLedgerState[outputMetadata.ConfirmedConsumer()]
 					// ignore consumers that are not confirmed long enough or even in the future.
-					if startSnapshot.Sub(tx.Essence().Timestamp()) < minAge {
+					if !exist || startSnapshot.Sub(tx.Essence().Timestamp()) < minAge {
 						unspentOutputs[i] = true
 						includeTransaction = true
 					}


### PR DESCRIPTION
# Description of change

- Fix bug in snapshot creation tool. When calculating the snapshot takes longer time, transactions that confirm in the meantime were not handled correctly leading to nil pointer dereference.
- Update Global Snapshot to **Tue 15 Jun 2021 09:09:03 AM UTC**
