### PR TITLE
Local double spend filter in webAPI

### DIFF
--- a/plugins/webapi/ledgerstate/doublespend_filter.go
+++ b/plugins/webapi/ledgerstate/doublespend_filter.go
@@ -99,7 +99,7 @@ func (d *DoubleSpendFilter) CleanUp() {
 func (d *DoubleSpendFilter) remove(txID ledgerstate.TransactionID) {
 	// remove all outputs
 	for outputID, storedTxID := range d.recentMap {
-		if bytes.Compare(txID.Bytes(), storedTxID.Bytes()) == 0 {
+		if bytes.Equal(txID.Bytes(), storedTxID.Bytes()) {
 			log.Infof("Removing output %s", outputID.Base58())
 			delete(d.recentMap, outputID)
 		}

--- a/plugins/webapi/ledgerstate/doublespend_filter.go
+++ b/plugins/webapi/ledgerstate/doublespend_filter.go
@@ -1,0 +1,125 @@
+package ledgerstate
+
+import (
+	"bytes"
+	"sync"
+	"time"
+
+	"github.com/iotaledger/goshimmer/packages/clock"
+	"github.com/iotaledger/goshimmer/packages/ledgerstate"
+)
+
+// DoubleSpendFilter keeps a log of recently submitted transactions and their consumed outputs.
+type DoubleSpendFilter struct {
+	recentMap map[ledgerstate.OutputID]ledgerstate.TransactionID
+	addedAt   map[ledgerstate.TransactionID]time.Time
+	mutex     sync.RWMutex
+}
+
+// NewDoubleSpendFilter creates a new doubleSpendFilter worker.
+func NewDoubleSpendFilter() *DoubleSpendFilter {
+	return &DoubleSpendFilter{
+		recentMap: map[ledgerstate.OutputID]ledgerstate.TransactionID{},
+		addedAt:   map[ledgerstate.TransactionID]time.Time{},
+	}
+}
+
+// Add adds a transaction and it's consumed inputs to the doubleSpendFilter.
+func (d *DoubleSpendFilter) Add(tx *ledgerstate.Transaction) {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+	now := clock.SyncedTime()
+	for _, input := range tx.Essence().Inputs() {
+		if input.Type() != ledgerstate.UTXOInputType {
+			continue
+		}
+		casted := input.(*ledgerstate.UTXOInput)
+		if casted == nil {
+			continue
+		}
+		d.recentMap[casted.ReferencedOutputID()] = tx.ID()
+		d.addedAt[tx.ID()] = now
+		log.Infof("Added output %s", casted.ReferencedOutputID().Base58())
+	}
+	log.Infof("added tx %s", tx.ID())
+}
+
+// Remove removes all outputs associated to the given transaction ID.
+func (d *DoubleSpendFilter) Remove(txID ledgerstate.TransactionID) {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+	if len(d.recentMap) == 0 {
+		return
+	}
+	if _, has := d.addedAt[txID]; !has {
+		return
+	}
+	d.remove(txID)
+	d.shrinkMaps()
+}
+
+// HasConflict returns if there is a conflicting output in the internal map wrt to the provided inputs (outputIDs).
+func (d *DoubleSpendFilter) HasConflict(outputs ledgerstate.Inputs) (bool, ledgerstate.TransactionID) {
+	d.mutex.RLock()
+	defer d.mutex.RUnlock()
+
+	for _, input := range outputs {
+		if input.Type() != ledgerstate.UTXOInputType {
+			continue
+		}
+		casted := input.(*ledgerstate.UTXOInput)
+		if casted == nil {
+			continue
+		}
+		if txID, has := d.recentMap[casted.ReferencedOutputID()]; has {
+			return true, txID
+		}
+	}
+	return false, ledgerstate.TransactionID{}
+}
+
+// CleanUp removes transactions from the DoubleSpendFilter if they were added more, than 30s ago.
+func (d *DoubleSpendFilter) CleanUp() {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+	// early return if there is nothing to be cleaned up
+	if len(d.addedAt) == 0 {
+		return
+	}
+	now := clock.SyncedTime()
+	for txID, addedTime := range d.addedAt {
+		if now.Sub(addedTime) > DoubleSpendFilterCleanupInterval {
+			d.remove(txID)
+		}
+	}
+	d.shrinkMaps()
+}
+
+// remove is a non-concurrency safe internal method.
+func (d *DoubleSpendFilter) remove(txID ledgerstate.TransactionID) {
+	// remove all outputs
+	for outputID, storedTxID := range d.recentMap {
+		if bytes.Compare(txID.Bytes(), storedTxID.Bytes()) == 0 {
+			log.Infof("Removing output %s", outputID.Base58())
+			delete(d.recentMap, outputID)
+		}
+	}
+	log.Infof("Removing tx %s", txID.Base58())
+	delete(d.addedAt, txID)
+}
+
+// shrinkMaps is a non-concurrency safe internal method.
+func (d *DoubleSpendFilter) shrinkMaps() {
+	shrunkRecent := map[ledgerstate.OutputID]ledgerstate.TransactionID{}
+	shrunkAddedAt := map[ledgerstate.TransactionID]time.Time{}
+
+	for key, value := range d.recentMap {
+		shrunkRecent[key] = value
+	}
+	for key, value := range d.addedAt {
+		shrunkAddedAt[key] = value
+	}
+
+	d.recentMap = shrunkRecent
+	d.addedAt = shrunkAddedAt
+}

--- a/plugins/webapi/ledgerstate/doublespend_filter.go
+++ b/plugins/webapi/ledgerstate/doublespend_filter.go
@@ -39,9 +39,7 @@ func (d *DoubleSpendFilter) Add(tx *ledgerstate.Transaction) {
 		}
 		d.recentMap[casted.ReferencedOutputID()] = tx.ID()
 		d.addedAt[tx.ID()] = now
-		log.Infof("Added output %s", casted.ReferencedOutputID().Base58())
 	}
-	log.Infof("added tx %s", tx.ID())
 }
 
 // Remove removes all outputs associated to the given transaction ID.
@@ -100,11 +98,9 @@ func (d *DoubleSpendFilter) remove(txID ledgerstate.TransactionID) {
 	// remove all outputs
 	for outputID, storedTxID := range d.recentMap {
 		if bytes.Equal(txID.Bytes(), storedTxID.Bytes()) {
-			log.Infof("Removing output %s", outputID.Base58())
 			delete(d.recentMap, outputID)
 		}
 	}
-	log.Infof("Removing tx %s", txID.Base58())
 	delete(d.addedAt, txID)
 }
 

--- a/plugins/webapi/ledgerstate/plugin.go
+++ b/plugins/webapi/ledgerstate/plugin.go
@@ -7,6 +7,9 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
+	"github.com/iotaledger/hive.go/daemon"
+	"github.com/iotaledger/hive.go/events"
+	"github.com/iotaledger/hive.go/logger"
 	"github.com/iotaledger/hive.go/node"
 	"github.com/labstack/echo"
 
@@ -15,6 +18,7 @@ import (
 	"github.com/iotaledger/goshimmer/packages/jsonmodels"
 	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 	"github.com/iotaledger/goshimmer/packages/mana"
+	"github.com/iotaledger/goshimmer/packages/shutdown"
 	"github.com/iotaledger/goshimmer/packages/tangle"
 	"github.com/iotaledger/goshimmer/plugins/messagelayer"
 	"github.com/iotaledger/goshimmer/plugins/webapi"
@@ -22,37 +26,89 @@ import (
 
 // region Plugin ///////////////////////////////////////////////////////////////////////////////////////////////////////
 
+// PluginName is the name of the web API plugin.
+const (
+	PluginName                       = "WebAPI ledgerstate Endpoint"
+	DoubleSpendFilterCleanupInterval = 10 * time.Second
+)
+
 var (
 	// plugin holds the singleton instance of the plugin.
 	plugin *node.Plugin
 
 	// pluginOnce is used to ensure that the plugin is a singleton.
-	pluginOnce sync.Once
+	pluginOnce                    sync.Once
+	log                           *logger.Logger
+	doubleSpendFilter             *DoubleSpendFilter
+	monitorOnce                   sync.Once
+	onTransactionConfirmedClosure *events.Closure
 )
 
 // Plugin returns the plugin as a singleton.
 func Plugin() *node.Plugin {
 	pluginOnce.Do(func() {
-		plugin = node.NewPlugin("WebAPI ledgerstate Endpoint", node.Enabled, func(*node.Plugin) {
-			webapi.Server().GET("ledgerstate/addresses/:address", GetAddress)
-			webapi.Server().GET("ledgerstate/addresses/:address/unspentOutputs", GetAddressUnspentOutputs)
-			webapi.Server().POST("ledgerstate/addresses/unspentOutputs", PostAddressUnspentOutputs)
-			webapi.Server().GET("ledgerstate/branches/:branchID", GetBranch)
-			webapi.Server().GET("ledgerstate/branches/:branchID/children", GetBranchChildren)
-			webapi.Server().GET("ledgerstate/branches/:branchID/conflicts", GetBranchConflicts)
-			webapi.Server().GET("ledgerstate/outputs/:outputID", GetOutput)
-			webapi.Server().GET("ledgerstate/outputs/:outputID/consumers", GetOutputConsumers)
-			webapi.Server().GET("ledgerstate/outputs/:outputID/metadata", GetOutputMetadata)
-			webapi.Server().GET("ledgerstate/transactions/:transactionID", GetTransaction)
-			webapi.Server().GET("ledgerstate/transactions/:transactionID/metadata", GetTransactionMetadata)
-			webapi.Server().GET("ledgerstate/transactions/:transactionID/inclusionState", GetTransactionInclusionState)
-			webapi.Server().GET("ledgerstate/transactions/:transactionID/consensus", GetTransactionConsensusMetadata)
-			webapi.Server().GET("ledgerstate/transactions/:transactionID/attachments", GetTransactionAttachments)
-			webapi.Server().POST("ledgerstate/transactions", PostTransaction)
-		})
+		plugin = node.NewPlugin(PluginName, node.Enabled, configure, run)
 	})
 
 	return plugin
+}
+
+// Filter returns the double spend filter singleton.
+func Filter() *DoubleSpendFilter {
+	monitorOnce.Do(func() {
+		doubleSpendFilter = NewDoubleSpendFilter()
+	})
+	return doubleSpendFilter
+}
+
+func configure(*node.Plugin) {
+	doubleSpendFilter = Filter()
+	onTransactionConfirmedClosure = events.NewClosure(func(transactionID ledgerstate.TransactionID) {
+		doubleSpendFilter.Remove(transactionID)
+	})
+	messagelayer.Tangle().LedgerState.UTXODAG.Events.TransactionConfirmed.Attach(onTransactionConfirmedClosure)
+	log = logger.NewLogger(PluginName)
+}
+
+func run(*node.Plugin) {
+	if err := daemon.BackgroundWorker("WebAPI Double Spend Filter", worker, shutdown.PriorityWebAPI); err != nil {
+		log.Panicf("Failed to start as daemon: %s", err)
+	}
+
+	// register endpoints
+	webapi.Server().GET("ledgerstate/addresses/:address", GetAddress)
+	webapi.Server().GET("ledgerstate/addresses/:address/unspentOutputs", GetAddressUnspentOutputs)
+	webapi.Server().POST("ledgerstate/addresses/unspentOutputs", PostAddressUnspentOutputs)
+	webapi.Server().GET("ledgerstate/branches/:branchID", GetBranch)
+	webapi.Server().GET("ledgerstate/branches/:branchID/children", GetBranchChildren)
+	webapi.Server().GET("ledgerstate/branches/:branchID/conflicts", GetBranchConflicts)
+	webapi.Server().GET("ledgerstate/outputs/:outputID", GetOutput)
+	webapi.Server().GET("ledgerstate/outputs/:outputID/consumers", GetOutputConsumers)
+	webapi.Server().GET("ledgerstate/outputs/:outputID/metadata", GetOutputMetadata)
+	webapi.Server().GET("ledgerstate/transactions/:transactionID", GetTransaction)
+	webapi.Server().GET("ledgerstate/transactions/:transactionID/metadata", GetTransactionMetadata)
+	webapi.Server().GET("ledgerstate/transactions/:transactionID/inclusionState", GetTransactionInclusionState)
+	webapi.Server().GET("ledgerstate/transactions/:transactionID/consensus", GetTransactionConsensusMetadata)
+	webapi.Server().GET("ledgerstate/transactions/:transactionID/attachments", GetTransactionAttachments)
+	webapi.Server().POST("ledgerstate/transactions", PostTransaction)
+}
+
+func worker(shutdownSignal <-chan struct{}) {
+	defer log.Infof("Stopping %s ... done", PluginName)
+	func() {
+		ticker := time.NewTicker(DoubleSpendFilterCleanupInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-shutdownSignal:
+				return
+			case <-ticker.C:
+				doubleSpendFilter.CleanUp()
+			}
+		}
+	}()
+	log.Infof("Stopping %s ...", PluginName)
+	messagelayer.Tangle().LedgerState.UTXODAG.Events.TransactionConfirmed.Detach(onTransactionConfirmedClosure)
 }
 
 // endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -421,7 +477,7 @@ func branchIDFromContext(c echo.Context) (branchID ledgerstate.BranchID, err err
 
 // endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-// region postTransaction //////////////////////////////////////////////////////////////////////////////////////////////
+// region PostTransaction //////////////////////////////////////////////////////////////////////////////////////////////
 
 const maxBookedAwaitTime = 5 * time.Second
 
@@ -438,6 +494,13 @@ func PostTransaction(c echo.Context) error {
 	// parse tx
 	tx, _, err := ledgerstate.TransactionFromBytes(request.TransactionBytes)
 	if err != nil {
+		return c.JSON(http.StatusBadRequest, &jsonmodels.PostTransactionResponse{Error: err.Error()})
+	}
+
+	// check if it would introduce a double spend known to the node locally
+	has, conflictingID := doubleSpendFilter.HasConflict(tx.Essence().Inputs())
+	if has {
+		err = errors.Errorf("transaction is conflicting with previously submitted transaction %s", conflictingID.Base58())
 		return c.JSON(http.StatusBadRequest, &jsonmodels.PostTransactionResponse{Error: err.Error()})
 	}
 
@@ -481,7 +544,11 @@ func PostTransaction(c echo.Context) error {
 		return messagelayer.Tangle().IssuePayload(tx)
 	}
 
+	// add tx to double spend doubleSpendFilter
+	doubleSpendFilter.Add(tx)
 	if _, err := messagelayer.AwaitMessageToBeBooked(issueTransaction, tx.ID(), maxBookedAwaitTime); err != nil {
+		// if we failed to issue the transaction, we remove it
+		doubleSpendFilter.Remove(tx.ID())
 		return c.JSON(http.StatusBadRequest, jsonmodels.PostTransactionResponse{Error: err.Error()})
 	}
 	return c.JSON(http.StatusOK, &jsonmodels.PostTransactionResponse{TransactionID: tx.ID().Base58()})

--- a/plugins/webapi/ledgerstate/plugin.go
+++ b/plugins/webapi/ledgerstate/plugin.go
@@ -37,11 +37,19 @@ var (
 	plugin *node.Plugin
 
 	// pluginOnce is used to ensure that the plugin is a singleton.
-	pluginOnce                    sync.Once
-	log                           *logger.Logger
-	doubleSpendFilter             *DoubleSpendFilter
-	monitorOnce                   sync.Once
+	pluginOnce sync.Once
+
+	// doubleSpendFilter helps to filter out double spends locally.
+	doubleSpendFilter *DoubleSpendFilter
+
+	// doubleSpendFilterOnce ensures that doubleSpendFilter is a singleton.
+	doubleSpendFilterOnce sync.Once
+
+	// closure to be executed on transaction confirmation.
 	onTransactionConfirmedClosure *events.Closure
+
+	// logger
+	log *logger.Logger
 )
 
 // Plugin returns the plugin as a singleton.
@@ -55,7 +63,7 @@ func Plugin() *node.Plugin {
 
 // Filter returns the double spend filter singleton.
 func Filter() *DoubleSpendFilter {
-	monitorOnce.Do(func() {
+	doubleSpendFilterOnce.Do(func() {
 		doubleSpendFilter = NewDoubleSpendFilter()
 	})
 	return doubleSpendFilter


### PR DESCRIPTION
# Description of change

Nodes keep a log of transactions submitted through their webapi endpoints. If a conflicting transaction is submitted within 30 seconds, it is discarded immediately without trying to discover the conflict upon booking.

Notes:
 - 30 seconds should be enough for the network to set initial opinion `Like` on the first transaction, and then let the consensus mechanism resolve potential  future conflicts.
 - The filter essentially helps nodes to choose a winner (the first tx) if the conflicts were submitted through the same node. This can happen due to misbehaving client implementations.

