### PR TITLE
Use markers equal in test instead of assert equal

### DIFF
--- a/packages/tangle/booker_test.go
+++ b/packages/tangle/booker_test.go
@@ -2277,7 +2277,8 @@ func checkIndividuallyMappedMessages(t *testing.T, testFramework *MessageTestFra
 func checkMarkers(t *testing.T, testFramework *MessageTestFramework, expectedMarkers map[string]*markers.Markers) {
 	for messageID, expectedMarkersOfMessage := range expectedMarkers {
 		assert.True(t, testFramework.tangle.Storage.MessageMetadata(testFramework.Message(messageID).ID()).Consume(func(messageMetadata *MessageMetadata) {
-			assert.Equal(t, expectedMarkersOfMessage, messageMetadata.StructureDetails().PastMarkers, "Markers of %s are wrong", messageID)
+			assert.True(t, expectedMarkersOfMessage.Equals(messageMetadata.StructureDetails().PastMarkers), "Markers of %s are wrong.\n"+
+				"Expected: %+v\nActual: %+v", messageID, expectedMarkersOfMessage, messageMetadata.StructureDetails().PastMarkers)
 		}))
 
 		// if we have only a single marker - check if the marker is mapped to this message (or its inherited past marker)


### PR DESCRIPTION
# Description of change

There is an issue that in `booker_test.go` the `checkMarkers` function intermittently gives this error:
```
Error:      	Not equal: 
        	            	expected: &markers.Markers{markers:map[markers.SequenceID]markers.Index{0x1:0x3, 0x3:0x3}, highestIndex:0x3, lowestIndex:0x3, markersMutex:sync.RWMutex{w:sync.Mutex{state:0, sema:0x0}, writerSem:0x0, readerSem:0x0, readerCount:0, readerWait:0}}
        	            	actual  : &markers.Markers{markers:map[markers.SequenceID]markers.Index{0x1:0x3, 0x3:0x3}, highestIndex:0x3, lowestIndex:0x3, markersMutex:sync.RWMutex{w:sync.Mutex{state:0, sema:0x0}, writerSem:0x0, readerSem:0x0, readerCount:0, readerWait:0}}
```

I am not sure of the underlying reason, but in the meanwhile instead of using `assert.Equals` I am using the markers built in `equals` function to overcome this issue.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Ran locally

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
