### PR TITLE
Check synced state at least every sync time window interval

### DIFF
--- a/packages/tangle/tangle.go
+++ b/packages/tangle/tangle.go
@@ -26,6 +26,8 @@ import (
 const (
 	// DefaultGenesisTime is the default time (Unix in seconds) of the genesis, i.e., the start of the epochs at 2021-03-19 9:00:00 UTC.
 	DefaultGenesisTime int64 = 1616144400
+	// DefaultSyncTimeWindow is the default sync time window.
+	DefaultSyncTimeWindow = 2 * time.Minute
 )
 
 // region Tangle ///////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -140,6 +142,8 @@ func (t *Tangle) Setup() {
 	} else {
 		t.Scheduler.Start()
 	}
+
+	t.TimeManager.Start()
 
 	// pass solid messages to the scheduler
 	t.Solidifier.Events.MessageSolid.Attach(events.NewClosure(t.schedule))

--- a/packages/tangle/timemanager.go
+++ b/packages/tangle/timemanager.go
@@ -242,7 +242,7 @@ type TimeManagerEvents struct {
 	SyncChanged *events.Event
 }
 
-// SyncChangedEvent represents a syn changed event.
+// SyncChangedEvent represents a sync changed event.
 type SyncChangedEvent struct {
 	Synced bool
 }


### PR DESCRIPTION
# Description of change

The `TimeManager` keeps a flag `lastSynced` representing the synced state of the node. This flag only ever gets updated when a corresponding `MarkerConfirmation` event is triggered leading to the flag never being updated in relation to the sync time window if no marker gets confirmed; this means a node might think that it is synced, even if it did not confirm any new marker within the sync time window (which is our definition of being "synced").

This PR adds a ticker which schedules the "synced check" at least every sync time window interval to keep the flag consistent even if no markers got confirmed.

Closes #1477

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Integration tests.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
