### PR TITLE
Dockerfile & GoReleaser download latest snapshot from S3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,8 @@ jobs:
           go-version: 1.16.3
       - name: Copy config.default.json to config.json
         run: cp config.default.json config.json
+      - name: Download latest snapshot file
+        run: wget -O snapshot.bin https://dbfiles-goshimmer.s3.eu-central-1.amazonaws.com/snapshots/nectar/snapshot-latest.bin
       - name: Run GoReleaser
         run: goreleaser --rm-dist
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,8 @@ RUN --mount=target=. \
     -o /go/bin/goshimmer; \
     ./check_static.sh
 
+RUN wget -O /tmp/snapshot.bin https://dbfiles-goshimmer.s3.eu-central-1.amazonaws.com/snapshots/nectar/snapshot-latest.bin
+
 ############################
 # Image
 ############################
@@ -44,7 +46,7 @@ EXPOSE 14666/tcp
 EXPOSE 14626/udp
 
 # Copy configuration
-COPY snapshot.bin /snapshot.bin
+COPY --from=build /tmp/snapshot.bin /snapshot.bin
 COPY config.default.json /config.json
 
 # Copy the Pre-built binary file from the previous stage


### PR DESCRIPTION
# Description of change

Snapshot files became to big to efficiently store them as part of the repo.
Let's use an S3 bucket for it:

Always [https://dbfiles-goshimmer.s3.eu-central-1.amazonaws.com/snapshots/nectar/snapshot-latest.bin](https://dbfiles-goshimmer.s3.eu-central-1.amazonaws.com/snapshots/nectar/snapshot-latest.bin)

## Type of change

- Enhancement (a non-breaking change which adds functionality)