### PR TITLE
Release v0.7.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 *.dat.bkp
 
 # Snapshots are stored in bin format
-# *.bin
+*.bin
 
 # cli-wallet config
 tools/cli-wallet/config.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+# v0.7.3 - 2021-07-01
+* Add latest snapshot download from S3
+* Add weak tips on local dashboard
+* Improve integration test framework
+* Add FCoB metrics to remote logger
+* Remove tips broadcaster
+* Improve APIs
+* Fix Sync status
+* Fix gossip and requester issues
+* Fix Inclusion state inconsistencies
+* Fix Prometheus issues when autopeering is not enabled
+* Increase maxVerticesWithoutFutureMarker to 3000000
+* Update snapshot file with DevNet UTXO at 2021-06-30 21:16 UTC
+* Update JS dependencies
+* Update hive.go
+* **Breaking**: bumps network and database versions
+
 # v0.7.2 - 2021-06-17
 * Add local double spend filter in webAPI
 * Add SetBranchFinalized to FCoB

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ We always recommend running your node via [Docker](https://goshimmer.docs.iota.o
 
 Please follow this guide: https://github.com/facebook/rocksdb/blob/master/INSTALL.md to build above libs.
 
-Finally, when compiling GoShimmer, just run the build script:
+When compiling GoShimmer, just run the build script:
 
 ```bash
 ./scripts/build.sh
@@ -73,6 +73,12 @@ Finally, when compiling GoShimmer, just run the build script:
 If you also want to link the libraries statically (only on Linux) run this instead:
 ```bash
 ./scripts/build_goshimmer_rocksdb_builtin.sh
+```
+
+Finally, download the latest snapshot and make sure to place it in the root folder of GoShimmer:
+
+```bash
+wget -O snapshot.bin https://dbfiles-goshimmer.s3.eu-central-1.amazonaws.com/snapshots/nectar/snapshot-latest.bin
 ```
 
 ## Supporting the project

--- a/plugins/autopeering/discovery/parameters.go
+++ b/plugins/autopeering/discovery/parameters.go
@@ -5,7 +5,7 @@ import "github.com/iotaledger/hive.go/configuration"
 // Parameters contains the configuration parameters used by the message layer.
 var Parameters = struct {
 	// NetworkVersion defines the config flag of the network version.
-	NetworkVersion int `default:"35" usage:"autopeering network version"`
+	NetworkVersion int `default:"36" usage:"autopeering network version"`
 
 	// EntryNodes defines the config flag of the entry nodes.
 	EntryNodes []string `default:"2PV5487xMw5rasGBXXWeqSi4hLz7r19YBt8Y1TGAsQbj@ressims.iota.cafe:15626,5EDH4uY78EA6wrBkHHAVBWBMDt7EcksRq6pjzipoW15B@entryshimmer.tanglebay.com:14646" usage:"list of trusted entry nodes for auto peering"`

--- a/plugins/banner/plugin.go
+++ b/plugins/banner/plugin.go
@@ -17,7 +17,7 @@ var (
 	once   sync.Once
 
 	// AppVersion version number
-	AppVersion = "v0.7.2"
+	AppVersion = "v0.7.3"
 	// SimplifiedAppVersion is the version number without commit hash
 	SimplifiedAppVersion = simplifiedVersion(AppVersion)
 )

--- a/plugins/database/versioning.go
+++ b/plugins/database/versioning.go
@@ -11,7 +11,7 @@ import (
 const (
 	// DBVersion defines the version of the database schema this version of GoShimmer supports.
 	// Every time there's a breaking change regarding the stored data, this version flag should be adjusted.
-	DBVersion = 37
+	DBVersion = 38
 )
 
 var (


### PR DESCRIPTION
# v0.7.3 - 2021-07-01
* Add latest snapshot download from S3
* Add weak tips on local dashboard
* Improve integration test framework
* Add FCoB metrics to remote logger
* Remove tips broadcaster
* Improve APIs
* Fix Sync status
* Fix gossip and requester issues
* Fix Inclusion state inconsistencies
* Fix Prometheus issues when autopeering is not enabled
* Increase maxVerticesWithoutFutureMarker to 3000000
* Update snapshot file with DevNet UTXO at 2021-06-30 21:16 UTC
* Update JS dependencies
* Update hive.go
* **Breaking**: bumps network and database versions