### PR TITLE
fix(doc): update faucet API example

### DIFF
--- a/docs/tutorials/request_funds.md
+++ b/docs/tutorials/request_funds.md
@@ -27,12 +27,12 @@ messageID, err := goshimAPI.SendFaucetRequest("JaMauTaTSVBNc13edCCvBK9fZxZ1KKW5f
 // invoke go get github.com/iotaledger/goshimmer/client/wallet for wallet usage
 // get the given address from a wallet instance and
 connector := wallet.GenericConnector(wallet.NewWebConnector("http://localhost:8080"))
-addr := wallet.New(connector).Seed().Address(0)
+addr := wallet.New(connector).ReceiveAddress()
 // use String() to get base58 representation
 // the proof of work difficulty,
 // the optional aManaPledgeID (Base58 encoded),
 // the optional cManaPledgeID (Base58 encoded)
-messageID, err := goshimAPI.SendFaucetRequest(addr.String(), 22, "2GtxMQD94KvDH1SJPJV7icxofkyV1njuUZKtsqKmtux5", "2GtxMQD94KvDH1SJPJV7icxofkyV1njuUZKtsqKmtux5")
+messageID, err := goshimAPI.SendFaucetRequest(addr.Base58(), 22, "2GtxMQD94KvDH1SJPJV7icxofkyV1njuUZKtsqKmtux5", "2GtxMQD94KvDH1SJPJV7icxofkyV1njuUZKtsqKmtux5")
 ```
 
 ### Via the wallet


### PR DESCRIPTION
# Description of change

The `SendFaucetRequest` example was outdated; it used `address.String`, which returns a human-readable string containing the Base58 representation, but the string itself is not parseable by `SendFaucetRequest`.

Getting the newly created wallet's address can be simplified by using `ReceiveAddress()` instead of `Seed().Address()`.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Documentation Fix

## How the change has been tested

I tested the snippet of the new example on the latest goshimmer lib in the `develop` branch.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.
