### PR TITLE
Eligibility Manager 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,6 @@ go 1.16
 
 replace github.com/linxGnu/grocksdb => github.com/gohornet/grocksdb v1.6.34-0.20210518222204-d6ea5eedcfb9
 
-replace github.com/iotaledger/hive.go => /home/galr/IdeaProjects/hive.go
-
 require (
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
 	github.com/beevik/ntp v0.3.0
@@ -19,7 +17,7 @@ require (
 	github.com/go-resty/resty/v2 v2.6.0
 	github.com/golang/protobuf v1.4.3
 	github.com/gorilla/websocket v1.4.2
-	github.com/iotaledger/hive.go v0.0.0-20210623095912-c1c6f098a6db
+	github.com/iotaledger/hive.go v0.0.0-20210708115003-f1a9732260a8
 	github.com/labstack/echo v3.3.10+incompatible
 	github.com/labstack/gommon v0.3.0
 	github.com/linxGnu/grocksdb v1.6.35 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.16
 
 replace github.com/linxGnu/grocksdb => github.com/gohornet/grocksdb v1.6.34-0.20210518222204-d6ea5eedcfb9
 
+replace github.com/iotaledger/hive.go => /home/galr/IdeaProjects/hive.go
+
 require (
 	github.com/DataDog/zstd v1.4.8 // indirect
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
@@ -12,7 +14,6 @@ require (
 	github.com/cockroachdb/errors v1.8.4
 	github.com/drand/drand v1.1.1
 	github.com/drand/kyber v1.1.2
-	github.com/emirpasic/gods v1.12.0
 	github.com/gin-gonic/gin v1.6.3
 	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/go-resty/resty/v2 v2.6.0

--- a/go.mod
+++ b/go.mod
@@ -7,13 +7,13 @@ replace github.com/linxGnu/grocksdb => github.com/gohornet/grocksdb v1.6.34-0.20
 replace github.com/iotaledger/hive.go => /home/galr/IdeaProjects/hive.go
 
 require (
-	github.com/DataDog/zstd v1.4.8 // indirect
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
 	github.com/beevik/ntp v0.3.0
 	github.com/capossele/asset-registry v0.0.0-20210521112927-c9d6e74574e8
 	github.com/cockroachdb/errors v1.8.4
 	github.com/drand/drand v1.1.1
 	github.com/drand/kyber v1.1.2
+	github.com/emirpasic/gods v1.12.0
 	github.com/gin-gonic/gin v1.6.3
 	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/go-resty/resty/v2 v2.6.0
@@ -38,7 +38,6 @@ require (
 	go.uber.org/atomic v1.7.0
 	go.uber.org/zap v1.16.0
 	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83
-	golang.org/x/exp v0.0.0-20210220032938-85be41e4509f // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	google.golang.org/genproto v0.0.0-20201203001206-6486ece9c497 // indirect
 	google.golang.org/grpc v1.34.0

--- a/go.sum
+++ b/go.sum
@@ -11,7 +11,6 @@ cloud.google.com/go/firestore v1.1.0/go.mod h1:ulACoGHTpvq5r8rxGJ4ddJZBZqakUQqCl
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
 cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiyrjsg+URw=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-dmitri.shuralyov.com/gpu/mtl v0.0.0-20201218220906-28db891af037/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/AndreasBriese/bbloom v0.0.0-20180913140656-343706a395b7/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
 github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
@@ -21,13 +20,10 @@ github.com/CloudyKit/fastprinter v0.0.0-20170127035650-74b38d55f37a/go.mod h1:EF
 github.com/CloudyKit/jet v2.1.3-0.20180809161101-62edd43e4f88+incompatible/go.mod h1:HPYO+50pSWkPoj9Q/eq0aRGByCL6ScRlUmiEX5Zgm+w=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/DataDog/zstd v1.4.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
-github.com/DataDog/zstd v1.4.8 h1:Rpmta4xZ/MgZnriKNd24iZMhGpP5dvUcs/uqfBapKZY=
-github.com/DataDog/zstd v1.4.8/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/Joker/hpp v1.0.0/go.mod h1:8x5n+M1Hp5hC0g8okX3sR3vFQwynaX/UgSOM9MeBKzY=
 github.com/Joker/jade v1.0.1-0.20190614124447-d475f43051e7/go.mod h1:6E6s8o2AE4KhCrqr6GRJjdC/gNfTdxkIXvuGZZda2VM=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/Kubuxu/go-os-helper v0.0.1/go.mod h1:N8B+I7vPCT80IcP58r50u4+gEEcsZETFUpAzWW2ep1Y=
-github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/Shopify/goreferrer v0.0.0-20181106222321-ec9c9a553398/go.mod h1:a1uqRtAwp2Xwc6WNPJEufxJ7fx3npB4UV/JOLmbu5I0=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
@@ -108,7 +104,6 @@ github.com/cockroachdb/errors v1.8.4 h1:41oZ1A4Eju6LviqkGpu5R2M39gHHVAFvOYsQjot1
 github.com/cockroachdb/errors v1.8.4/go.mod h1:GScl7wnuvY335l6h0jbkHIKJ+8uEmUmJRVWKnenUbfI=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f h1:o/kfcElHqOiXqcou5a3rIlMc7oJbMQkeLk0VQJ7zgqY=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/cockroachdb/pebble v0.0.0-20210313162627-639dfcee1d23 h1:UvUEq6cU4jdzsPZ/w87PYF206koN26nx1rusWjDPCp8=
 github.com/cockroachdb/pebble v0.0.0-20210313162627-639dfcee1d23/go.mod h1:1XpB4cLQcF189RAcWi4gUc110zJgtOfT7SVNGY8sOe0=
 github.com/cockroachdb/redact v1.0.8 h1:8QG/764wK+vmEYoOlfobpe12EQcS81ukx/a4hdVMxNw=
 github.com/cockroachdb/redact v1.0.8/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
@@ -141,17 +136,13 @@ github.com/davidlazar/go-crypto v0.0.0-20190912175916-7055855a373f/go.mod h1:rQY
 github.com/dgraph-io/badger v1.5.5-0.20190226225317-8115aed38f8f/go.mod h1:VZxzAIRPHRVNRKRo6AXrX9BJegn6il06VMTZVJYCIjQ=
 github.com/dgraph-io/badger v1.6.0-rc1/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
 github.com/dgraph-io/badger v1.6.0/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
-github.com/dgraph-io/badger v1.6.1 h1:w9pSFNSdq/JPM1N12Fz/F/bzo993Is1W+Q7HjPzi7yg=
 github.com/dgraph-io/badger v1.6.1/go.mod h1:FRmFw3uxvcpa8zG3Rxs0th+hCLIuaQg8HlNV5bjgnuU=
-github.com/dgraph-io/badger/v2 v2.0.3 h1:inzdf6VF/NZ+tJ8RwwYMjJMvsOALTHYdozn0qSl6XJI=
 github.com/dgraph-io/badger/v2 v2.0.3/go.mod h1:3KY8+bsP8wI0OEnQJAKpd4wIJW/Mm32yw2j/9FUVnIM=
 github.com/dgraph-io/ristretto v0.0.2-0.20200115201040-8f368f2f2ab3/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
-github.com/dgraph-io/ristretto v0.0.2 h1:a5WaUrDa0qm0YrAAS1tUykT5El3kt62KNZZeMxQn3po=
 github.com/dgraph-io/ristretto v0.0.2/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-farm v0.0.0-20190104051053-3adb47b1fb0f/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
-github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/drand/bls12-381 v0.3.2 h1:RImU8Wckmx8XQx1tp1q04OV73J9Tj6mmpQLYDP7V1XE=
@@ -165,7 +156,6 @@ github.com/drand/kyber v1.1.2/go.mod h1:x6KOpK7avKj0GJ4emhXFP5n7M7W7ChAPmnQh/OL6
 github.com/drand/kyber-bls12381 v0.1.0 h1:/P4C65VnyEwxzR5ZYYVMNzY1If+aYBrdUU5ukwh7LQw=
 github.com/drand/kyber-bls12381 v0.1.0/go.mod h1:N1emiHpm+jj7kMlxEbu3MUyOiooTgNySln564cgD9mk=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
@@ -407,8 +397,6 @@ github.com/hydrogen18/memlistener v0.0.0-20141126152155-54553eb933fb/go.mod h1:q
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/iotaledger/hive.go v0.0.0-20210623095912-c1c6f098a6db h1:qXA5CyDaVBF5c/DncHYcEFHOo8jdyFZ4a24VdGn+rRA=
-github.com/iotaledger/hive.go v0.0.0-20210623095912-c1c6f098a6db/go.mod h1:NyBg/Ny7FFAdDs59zdwTVoysU2ZbJVQnRwyLIDFKJYA=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.2/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.3/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
@@ -913,7 +901,6 @@ github.com/soundcloud/go-runit v0.0.0-20150630195641-06ad41a06c4a/go.mod h1:LeFC
 github.com/spacemonkeygo/openssl v0.0.0-20181017203307-c2dcc5cca94a/go.mod h1:7AyxJNCJ7SBZ1MfVQCWD6Uqo2oubI2Eq2y2eqf+A5r0=
 github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572/go.mod h1:w0SWMsp6j9O/dk4/ZpIhL+3CkG8ofA2vuv7k+ltqUMc=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
-github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.3.0 h1:Ysnmjh1Di8EaWaBv40CYR4IdaIsBc5996Gh1oZzCBKk=
@@ -1090,12 +1077,9 @@ golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWP
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
-golang.org/x/exp v0.0.0-20190731235908-ec7cb31e5a56/go.mod h1:JhuoJpWY28nO4Vef9tZUw9qufEGTyX1+7lmHxV5q5G4=
 golang.org/x/exp v0.0.0-20190829153037-c13cbed26979/go.mod h1:86+5VVa7VpoJ4kLfm080zCjGlMRFzhUhsZKEZO7MGek=
 golang.org/x/exp v0.0.0-20191030013958-a1ab85dbe136/go.mod h1:JXzH8nQsPlswgeRAPE3MuO9GYsAcnJvJ4vnMwN/5qkY=
 golang.org/x/exp v0.0.0-20200513190911-00229845015e/go.mod h1:4M0jN8W1tt0AVLNr8HDosyJCDCDuyL9N9+3m7wDWgKw=
-golang.org/x/exp v0.0.0-20210220032938-85be41e4509f h1:GrkO5AtFUU9U/1f5ctbIBXtBGeSJbWwIYfIsTcFMaX4=
-golang.org/x/exp v0.0.0-20210220032938-85be41e4509f/go.mod h1:I6l2HNBLBZEcrOoCpyKLdY2lHoRZ8lI4x60KMCQDft4=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -1110,12 +1094,10 @@ golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5 h1:2M3HP5CCK1Si9FQhwnzYhXdG
 golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
-golang.org/x/mobile v0.0.0-20201217150744-e6ae53a27f4f/go.mod h1:skQtrUTUwhdJvXM/2KKJzY8pDgNr9I/FOMqDVRPBUS4=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
-golang.org/x/mod v0.1.1-0.20191209134235-331c550502dd/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.1-0.20200828183125-ce943fd02449 h1:xUIPaMhvROX9dhPvRCenIJtU78+lbEenGbgqB5hfHCQ=
@@ -1277,7 +1259,6 @@ golang.org/x/tools v0.0.0-20191112195655-aa38f8e97acc/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191216052735-49a3e744a425/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200103221440-774c71fcf114/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
-golang.org/x/tools v0.0.0-20200117012304-6edc0a871e69/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200207183749-b753a1ba74fa/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200216192241-b320d3a0f5a2/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=

--- a/go.sum
+++ b/go.sum
@@ -397,6 +397,8 @@ github.com/hydrogen18/memlistener v0.0.0-20141126152155-54553eb933fb/go.mod h1:q
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
+github.com/iotaledger/hive.go v0.0.0-20210708115003-f1a9732260a8 h1:+hyYZ4T/cvH6H1fsBwsRnD37Q9ejGKomSaGZ6vSHZbs=
+github.com/iotaledger/hive.go v0.0.0-20210708115003-f1a9732260a8/go.mod h1:NyBg/Ny7FFAdDs59zdwTVoysU2ZbJVQnRwyLIDFKJYA=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.2/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.3/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=

--- a/packages/consensus/fcob/consensusmechanism.go
+++ b/packages/consensus/fcob/consensusmechanism.go
@@ -125,8 +125,6 @@ func (f *ConsensusMechanism) EvaluateTimestamp(messageID tangle.MessageID) {
 		LoK:       Two,
 	})
 
-	f.setEligibility(messageID)
-
 	f.setTimestampOpinionDone(messageID)
 
 	if f.messageDone(messageID) {

--- a/packages/consensus/fcob/consensusmechanism_test.go
+++ b/packages/consensus/fcob/consensusmechanism_test.go
@@ -219,7 +219,6 @@ func TestOpinionFormer_Scenario2(t *testing.T) {
 	testTangle.ConsensusManager.Events.MessageOpinionFormed.Attach(events.NewClosure(func(messageID tangle.MessageID) {
 		t.Logf("MessageOpinionFormed for %s", messageID)
 
-		assert.True(t, testTangle.ConsensusManager.MessageEligible(messageID))
 		assert.Equal(t, payloadLiked[messageID], testTangle.ConsensusManager.PayloadLiked(messageID))
 		t.Log("Payload Liked:", testTangle.ConsensusManager.PayloadLiked(messageID))
 		wg.Done()
@@ -316,7 +315,6 @@ func TestOpinionFormer(t *testing.T) {
 	testTangle.ConsensusManager.Events.MessageOpinionFormed.Attach(events.NewClosure(func(messageID tangle.MessageID) {
 		t.Log("MessageOpinionFormed for ", messageID)
 
-		assert.True(t, testTangle.ConsensusManager.MessageEligible(messageID))
 		assert.Equal(t, payloadLiked[messageID], testTangle.ConsensusManager.PayloadLiked(messageID))
 		t.Log("Payload Liked:", testTangle.ConsensusManager.PayloadLiked(messageID))
 		wg.Done()

--- a/packages/ledgerstate/input.go
+++ b/packages/ledgerstate/input.go
@@ -237,6 +237,16 @@ func (i Inputs) Strings() (result []string) {
 	return
 }
 
+func (i Inputs) Filter(condition func(Input) bool) (filteredInputs Inputs) {
+	filteredInputs = make(Inputs, 0)
+	for _, input := range i {
+		if condition(input) {
+			filteredInputs = append(filteredInputs, input)
+		}
+	}
+	return
+}
+
 // endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 // region UTXOInput ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/packages/ledgerstate/input.go
+++ b/packages/ledgerstate/input.go
@@ -237,16 +237,6 @@ func (i Inputs) Strings() (result []string) {
 	return
 }
 
-func (i Inputs) Filter(condition func(Input) bool) (filteredInputs Inputs) {
-	filteredInputs = make(Inputs, 0)
-	for _, input := range i {
-		if condition(input) {
-			filteredInputs = append(filteredInputs, input)
-		}
-	}
-	return
-}
-
 // endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 // region UTXOInput ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/packages/ledgerstate/transaction.go
+++ b/packages/ledgerstate/transaction.go
@@ -96,6 +96,21 @@ func TransactionIDFromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (transac
 	return
 }
 
+// TransactionIDsFromMarshalUtil unmarshals TransactionIDs using a MarshalUtil (for easier unmarshaling).
+func TransactionIDsFromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (transactionIDs TransactionIDs, err error) {
+	transactionIDs = make(TransactionIDs)
+	for !marshalUtil.DoneReading() {
+		var transactionID TransactionID
+		transactionID, err = TransactionIDFromMarshalUtil(marshalUtil)
+		if err != nil {
+			err = errors.Errorf("failed to parse TransactionIDs: %w", err)
+			return nil, err
+		}
+		transactionIDs[transactionID] = types.Void
+	}
+	return
+}
+
 // TransactionIDFromRandomness returns a random TransactionID which can for example be used in unit tests.
 func TransactionIDFromRandomness() (transactionID TransactionID, err error) {
 	_, err = rand.Read(transactionID[:])

--- a/packages/ledgerstate/transaction.go
+++ b/packages/ledgerstate/transaction.go
@@ -3,6 +3,7 @@ package ledgerstate
 import (
 	"crypto/rand"
 	"fmt"
+	"github.com/iotaledger/hive.go/datastructure/orderedmap"
 	"strconv"
 	"strings"
 	"sync"
@@ -97,8 +98,8 @@ func TransactionIDFromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (transac
 }
 
 // TransactionIDsFromMarshalUtil unmarshals TransactionIDs using a MarshalUtil (for easier unmarshaling).
-func TransactionIDsFromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (transactionIDs TransactionIDs, err error) {
-	transactionIDs = make(TransactionIDs)
+func TransactionIDsFromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (transactionIDs *orderedmap.OrderedMap, err error) {
+	transactionIDs = orderedmap.New()
 	for {
 		doneReading, err := marshalUtil.DoneReading()
 		if err != nil {
@@ -114,7 +115,7 @@ func TransactionIDsFromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (transa
 			err = errors.Errorf("failed to parse TransactionIDs: %w", err)
 			return nil, err
 		}
-		transactionIDs[transactionID] = types.Void
+		transactionIDs.Set(transactionID, types.Void)
 	}
 	return
 }

--- a/packages/ledgerstate/transaction.go
+++ b/packages/ledgerstate/transaction.go
@@ -99,7 +99,15 @@ func TransactionIDFromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (transac
 // TransactionIDsFromMarshalUtil unmarshals TransactionIDs using a MarshalUtil (for easier unmarshaling).
 func TransactionIDsFromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (transactionIDs TransactionIDs, err error) {
 	transactionIDs = make(TransactionIDs)
-	for !marshalUtil.DoneReading() {
+	for {
+		doneReading, err := marshalUtil.DoneReading()
+		if err != nil {
+			return nil, err
+		}
+		if doneReading {
+			break
+		}
+
 		var transactionID TransactionID
 		transactionID, err = TransactionIDFromMarshalUtil(marshalUtil)
 		if err != nil {

--- a/packages/ledgerstate/utxo_dag.go
+++ b/packages/ledgerstate/utxo_dag.go
@@ -518,7 +518,7 @@ func (u *UTXODAG) solidifyTransaction(transaction *Transaction, transactionMetad
 	}
 
 	if validErr := u.transactionObjectivelyValid(transaction, consumedOutputs); validErr != nil {
-		u.Events.TransactionInvalid.Trigger(transaction, validErr)
+		u.Events().TransactionInvalid.Trigger(transaction, validErr)
 
 		return
 	}
@@ -526,7 +526,7 @@ func (u *UTXODAG) solidifyTransaction(transaction *Transaction, transactionMetad
 	if _, err = u.bookTransaction(transaction, transactionMetadata, consumedOutputs); err != nil {
 		err = errors.Errorf("failed to book Transaction with %s: %w", transaction.ID(), err)
 
-		u.Events.Error.Trigger(err)
+		u.Events().Error.Trigger(err)
 
 		return
 	}
@@ -535,7 +535,7 @@ func (u *UTXODAG) solidifyTransaction(transaction *Transaction, transactionMetad
 		u.ManageStoreAddressOutputMapping(output)
 	}
 
-	u.Events.TransactionSolid.Trigger(transaction.ID())
+	u.Events().TransactionSolid.Trigger(transaction.ID())
 
 	for transactionID := range u.consumingTransactionIDs(transaction, Unsolid) {
 		propagationWalker.Push(transactionID)

--- a/packages/ledgerstate/utxo_dag.go
+++ b/packages/ledgerstate/utxo_dag.go
@@ -78,6 +78,7 @@ type utxoDagMock struct {
 	utxoDag IUTXODAG
 }
 
+// NewUtxoDagMock creates a mock for UTXODAG
 func NewUtxoDagMock(t *testing.T, utxoDag IUTXODAG) *utxoDagMock {
 	u := &utxoDagMock{
 		test: t,

--- a/packages/ledgerstate/utxo_dag.go
+++ b/packages/ledgerstate/utxo_dag.go
@@ -5,9 +5,6 @@ import (
 	"fmt"
 	"strconv"
 	"sync"
-	"testing"
-
-	"github.com/stretchr/testify/mock"
 
 	"github.com/cockroachdb/errors"
 	"github.com/iotaledger/hive.go/byteutils"
@@ -70,97 +67,6 @@ type IUTXODAG interface {
 	ManageStoreAddressOutputMapping(output Output)
 	// StoreAddressOutputMapping stores the address-output mapping.
 	StoreAddressOutputMapping(address Address, outputID OutputID)
-}
-
-type utxoDagMock struct {
-	mock.Mock
-	test    *testing.T
-	utxoDag IUTXODAG
-}
-
-// NewUtxoDagMock creates a mock for UTXODAG
-func NewUtxoDagMock(t *testing.T, utxoDag IUTXODAG) *utxoDagMock {
-	u := &utxoDagMock{
-		test: t,
-	}
-	u.Test(t)
-	u.utxoDag = utxoDag
-	return u
-}
-
-func (u *utxoDagMock) Events() *UTXODAGEvents {
-	return u.utxoDag.Events()
-}
-
-func (u *utxoDagMock) InclusionState(transactionID TransactionID) (inclusionState InclusionState, err error) {
-	args := u.Called(transactionID)
-	inclusionState = args.Get(0).(InclusionState)
-	return
-}
-
-func (u *utxoDagMock) Shutdown() {
-	u.utxoDag.Shutdown()
-	return
-}
-
-func (u *utxoDagMock) StoreTransaction(transaction *Transaction) (stored bool, solidityType SolidityType, err error) {
-	return u.utxoDag.StoreTransaction(transaction)
-}
-
-func (u *utxoDagMock) CheckTransaction(transaction *Transaction) (err error) {
-	return u.utxoDag.CheckTransaction(transaction)
-}
-
-func (u *utxoDagMock) CachedTransaction(transactionID TransactionID) (cachedTransaction *CachedTransaction) {
-	return u.utxoDag.CachedTransaction(transactionID)
-}
-
-func (u *utxoDagMock) Transaction(transactionID TransactionID) (transaction *Transaction) {
-	return u.utxoDag.Transaction(transactionID)
-}
-
-func (u *utxoDagMock) Transactions() (transactions map[TransactionID]*Transaction) {
-	return u.utxoDag.Transactions()
-}
-
-func (u *utxoDagMock) CachedTransactionMetadata(transactionID TransactionID, computeIfAbsentCallback ...func(transactionID TransactionID) *TransactionMetadata) (cachedTransactionMetadata *CachedTransactionMetadata) {
-	return u.utxoDag.CachedTransactionMetadata(transactionID, computeIfAbsentCallback...)
-}
-
-func (u *utxoDagMock) CachedOutput(outputID OutputID) (cachedOutput *CachedOutput) {
-	return u.utxoDag.CachedOutput(outputID)
-}
-
-func (u *utxoDagMock) CachedOutputMetadata(outputID OutputID) (cachedOutput *CachedOutputMetadata) {
-	return u.utxoDag.CachedOutputMetadata(outputID)
-}
-
-func (u *utxoDagMock) CachedConsumers(outputID OutputID, optionalSolidityType ...SolidityType) (cachedConsumers CachedConsumers) {
-	return u.utxoDag.CachedConsumers(outputID, optionalSolidityType...)
-}
-
-func (u *utxoDagMock) LoadSnapshot(snapshot *Snapshot) {
-	u.utxoDag.LoadSnapshot(snapshot)
-}
-
-func (u *utxoDagMock) CachedAddressOutputMapping(address Address) (cachedAddressOutputMappings CachedAddressOutputMappings) {
-	return u.utxoDag.CachedAddressOutputMapping(address)
-}
-
-func (u *utxoDagMock) SetTransactionConfirmed(transactionID TransactionID) (err error) {
-	return u.utxoDag.SetTransactionConfirmed(transactionID)
-}
-
-func (u *utxoDagMock) ConsumedOutputs(transaction *Transaction) (cachedInputs CachedOutputs) {
-	return u.utxoDag.ConsumedOutputs(transaction)
-}
-
-func (u *utxoDagMock) ManageStoreAddressOutputMapping(output Output) {
-	u.utxoDag.ManageStoreAddressOutputMapping(output)
-}
-
-func (u *utxoDagMock) StoreAddressOutputMapping(address Address, outputID OutputID) {
-	u.utxoDag.StoreAddressOutputMapping(address, outputID)
 }
 
 // UTXODAG represents the DAG that is formed by Transactions consuming Inputs and creating Outputs. It forms the core of

--- a/packages/ledgerstate/utxo_dag.go
+++ b/packages/ledgerstate/utxo_dag.go
@@ -150,6 +150,18 @@ func (u *utxoDagMock) ConsumedOutputs(transaction *Transaction) (cachedInputs Ca
 	return u.utxoDag.ConsumedOutputs(transaction)
 }
 
+func (u *utxoDagMock) BookTransaction(transaction *Transaction) (targetBranch BranchID, err error) {
+	return u.utxoDag.BookTransaction(transaction)
+}
+
+func (u *utxoDagMock) ManageStoreAddressOutputMapping(output Output) {
+	u.utxoDag.ManageStoreAddressOutputMapping(output)
+}
+
+func (u *utxoDagMock) StoreAddressOutputMapping(address Address, outputID OutputID) {
+	u.utxoDag.StoreAddressOutputMapping(address, outputID)
+}
+
 // UTXODAG represents the DAG that is formed by Transactions consuming Inputs and creating Outputs. It forms the core of
 // the ledger state and keeps track of the balances and the different perceptions of potential conflicts.
 type UTXODAG struct {

--- a/packages/ledgerstate/utxo_dag.go
+++ b/packages/ledgerstate/utxo_dag.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"strconv"
 	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
 
 	"github.com/cockroachdb/errors"
 	"github.com/iotaledger/hive.go/byteutils"
@@ -67,6 +70,84 @@ type IUTXODAG interface {
 	ManageStoreAddressOutputMapping(output Output)
 	// StoreAddressOutputMapping stores the address-output mapping.
 	StoreAddressOutputMapping(address Address, outputID OutputID)
+}
+
+type utxoDagMock struct {
+	mock.Mock
+	test    *testing.T
+	utxoDag IUTXODAG
+}
+
+func NewUtxoDagMock(t *testing.T, utxoDag IUTXODAG) *utxoDagMock {
+	u := &utxoDagMock{
+		test: t,
+	}
+	u.Test(t)
+	u.utxoDag = utxoDag
+	return u
+}
+
+func (u *utxoDagMock) Events() *UTXODAGEvents {
+	return u.Events()
+}
+
+func (u *utxoDagMock) InclusionState(transactionID TransactionID) (inclusionState InclusionState, err error) {
+	args := u.Called(transactionID)
+	inclusionState = args.Get(0).(InclusionState)
+	return
+}
+
+func (u *utxoDagMock) Shutdown() {
+	u.utxoDag.Shutdown()
+	return
+}
+
+func (u *utxoDagMock) CheckTransaction(transaction *Transaction) (err error) {
+	return u.utxoDag.CheckTransaction(transaction)
+}
+
+func (u *utxoDagMock) CachedTransaction(transactionID TransactionID) (cachedTransaction *CachedTransaction) {
+	return u.utxoDag.CachedTransaction(transactionID)
+}
+
+func (u *utxoDagMock) Transaction(transactionID TransactionID) (transaction *Transaction) {
+	return u.utxoDag.Transaction(transactionID)
+}
+
+func (u *utxoDagMock) Transactions() (transactions map[TransactionID]*Transaction) {
+	return u.utxoDag.Transactions()
+}
+
+func (u *utxoDagMock) CachedTransactionMetadata(transactionID TransactionID) (cachedTransactionMetadata *CachedTransactionMetadata) {
+	return u.utxoDag.CachedTransactionMetadata(transactionID)
+}
+
+func (u *utxoDagMock) CachedOutput(outputID OutputID) (cachedOutput *CachedOutput) {
+	return u.utxoDag.CachedOutput(outputID)
+}
+
+func (u *utxoDagMock) CachedOutputMetadata(outputID OutputID) (cachedOutput *CachedOutputMetadata) {
+	return u.utxoDag.CachedOutputMetadata(outputID)
+}
+
+func (u *utxoDagMock) CachedConsumers(outputID OutputID) (cachedConsumers CachedConsumers) {
+	return u.utxoDag.CachedConsumers(outputID)
+}
+
+func (u *utxoDagMock) LoadSnapshot(snapshot *Snapshot) {
+	u.utxoDag.LoadSnapshot(snapshot)
+}
+
+func (u *utxoDagMock) CachedAddressOutputMapping(address Address) (cachedAddressOutputMappings CachedAddressOutputMappings) {
+	return u.utxoDag.CachedAddressOutputMapping(address)
+}
+
+func (u *utxoDagMock) SetTransactionConfirmed(transactionID TransactionID) (err error) {
+	return u.utxoDag.SetTransactionConfirmed(transactionID)
+}
+
+func (u *utxoDagMock) ConsumedOutputs(transaction *Transaction) (cachedInputs CachedOutputs) {
+	return u.utxoDag.ConsumedOutputs(transaction)
 }
 
 // UTXODAG represents the DAG that is formed by Transactions consuming Inputs and creating Outputs. It forms the core of

--- a/packages/ledgerstate/utxo_dag.go
+++ b/packages/ledgerstate/utxo_dag.go
@@ -25,10 +25,54 @@ import (
 
 // region UTXODAG //////////////////////////////////////////////////////////////////////////////////////////////////////
 
+// IUTXODAG is the interface for UTXODAG which is the core of the ledger state
+// that is formed by Transactions consuming Inputs and creating Outputs.  It represents all the methods
+// that helps to keep track of the balances and the different perceptions of potential conflicts.
+type IUTXODAG interface {
+	// Events returns all events of the UTXODAG
+	Events() *UTXODAGEvents
+	// Shutdown shuts down the UTXODAG and persists its state.
+	Shutdown()
+	// CheckTransaction contains fast checks that have to be performed before booking a Transaction.
+	CheckTransaction(transaction *Transaction) (err error)
+	// BookTransaction books a Transaction into the ledger state.
+	BookTransaction(transaction *Transaction) (targetBranch BranchID, err error)
+	// InclusionState returns the InclusionState of the Transaction with the given TransactionID which can either be
+	// Pending, Confirmed or Rejected.
+	InclusionState(transactionID TransactionID) (inclusionState InclusionState, err error)
+	// CachedTransaction retrieves the Transaction with the given TransactionID from the object storage.
+	CachedTransaction(transactionID TransactionID) (cachedTransaction *CachedTransaction)
+	// Transaction returns a specific transaction, consumed.
+	Transaction(transactionID TransactionID) (transaction *Transaction)
+	// Transactions returns all the transactions, consumed.
+	Transactions() (transactions map[TransactionID]*Transaction)
+	// CachedTransactionMetadata retrieves the TransactionMetadata with the given TransactionID from the object storage.
+	CachedTransactionMetadata(transactionID TransactionID) (cachedTransactionMetadata *CachedTransactionMetadata)
+	// CachedOutput retrieves the Output with the given OutputID from the object storage.
+	CachedOutput(outputID OutputID) (cachedOutput *CachedOutput)
+	// CachedOutputMetadata retrieves the OutputMetadata with the given OutputID from the object storage.
+	CachedOutputMetadata(outputID OutputID) (cachedOutput *CachedOutputMetadata)
+	// CachedConsumers retrieves the Consumers of the given OutputID from the object storage.
+	CachedConsumers(outputID OutputID) (cachedConsumers CachedConsumers)
+	// LoadSnapshot creates a set of outputs in the UTXO-DAG, that are forming the genesis for future transactions.
+	LoadSnapshot(snapshot *Snapshot)
+	// CachedAddressOutputMapping retrieves the outputs for the given address.
+	CachedAddressOutputMapping(address Address) (cachedAddressOutputMappings CachedAddressOutputMappings)
+	// SetTransactionConfirmed marks a Transaction (and all Transactions in its past cone) as confirmed. It also marks the
+	// conflicting Transactions to be rejected.
+	SetTransactionConfirmed(transactionID TransactionID) (err error)
+	// ConsumedOutputs returns the consumed (cached)Outputs of the given Transaction.
+	ConsumedOutputs(transaction *Transaction) (cachedInputs CachedOutputs)
+	// ManageStoreAddressOutputMapping mangages how to store the address-output mapping dependent on which type of output it is.
+	ManageStoreAddressOutputMapping(output Output)
+	// StoreAddressOutputMapping stores the address-output mapping.
+	StoreAddressOutputMapping(address Address, outputID OutputID)
+}
+
 // UTXODAG represents the DAG that is formed by Transactions consuming Inputs and creating Outputs. It forms the core of
 // the ledger state and keeps track of the balances and the different perceptions of potential conflicts.
 type UTXODAG struct {
-	Events *UTXODAGEvents
+	events *UTXODAGEvents
 
 	transactionStorage          *objectstorage.ObjectStorage
 	transactionMetadataStorage  *objectstorage.ObjectStorage
@@ -47,7 +91,7 @@ func NewUTXODAG(store kvstore.KVStore, cacheProvider *database.CacheTimeProvider
 	options := buildObjectStorageOptions(cacheProvider)
 	osFactory := objectstorage.NewFactory(store, database.PrefixLedgerState)
 	utxoDAG = &UTXODAG{
-		Events: &UTXODAGEvents{
+		events: &UTXODAGEvents{
 			TransactionBranchIDUpdated: events.NewEvent(transactionIDEventHandler),
 			TransactionConfirmed:       events.NewEvent(transactionIDEventHandler),
 			TransactionSolid:           events.NewEvent(transactionIDEventHandler),
@@ -61,6 +105,11 @@ func NewUTXODAG(store kvstore.KVStore, cacheProvider *database.CacheTimeProvider
 		branchDAG:                   branchDAG,
 	}
 	return
+}
+
+// Events returns all events of the UTXODAG
+func (u *UTXODAG) Events() *UTXODAGEvents {
+	return u.events
 }
 
 // Shutdown shuts down the UTXODAG and persists its state.
@@ -308,7 +357,7 @@ func (u *UTXODAG) SetTransactionConfirmed(transactionID TransactionID) (err erro
 			continue
 		}
 
-		u.Events.TransactionConfirmed.Trigger(currentTransactionID)
+		u.Events().TransactionConfirmed.Trigger(currentTransactionID)
 	}
 
 	return err
@@ -616,7 +665,7 @@ func (u *UTXODAG) forkConsumer(transactionID TransactionID, conflictingInputs Ou
 		cachedConsumingConflictBranch.Release()
 
 		txMetadata.SetBranchID(conflictBranchID)
-		u.Events.TransactionBranchIDUpdated.Trigger(transactionID)
+		u.Events().TransactionBranchIDUpdated.Trigger(transactionID)
 
 		outputIds := u.createdOutputIDsOfTransaction(transactionID)
 		for _, outputID := range outputIds {
@@ -664,7 +713,7 @@ func (u *UTXODAG) propagateBranchUpdates(transactionID TransactionID) (updatedOu
 func (u *UTXODAG) updateBranchOfTransaction(transactionID TransactionID, branchID BranchID) (updatedOutputs []OutputID) {
 	if !u.CachedTransactionMetadata(transactionID).Consume(func(transactionMetadata *TransactionMetadata) {
 		if transactionMetadata.SetBranchID(branchID) {
-			u.Events.TransactionBranchIDUpdated.Trigger(transactionID)
+			u.Events().TransactionBranchIDUpdated.Trigger(transactionID)
 
 			updatedOutputs = u.createdOutputIDsOfTransaction(transactionID)
 			for _, outputID := range updatedOutputs {

--- a/packages/ledgerstate/utxo_dag_mock.go
+++ b/packages/ledgerstate/utxo_dag_mock.go
@@ -1,0 +1,97 @@
+package ledgerstate
+
+import (
+	"github.com/stretchr/testify/mock"
+	"testing"
+)
+
+type utxoDagMock struct {
+	mock.Mock
+	test    *testing.T
+	utxoDag IUTXODAG
+}
+
+// NewUtxoDagMock creates a mock for UTXODAG
+func NewUtxoDagMock(t *testing.T, utxoDag IUTXODAG) *utxoDagMock {
+	u := &utxoDagMock{
+		test: t,
+	}
+	u.Test(t)
+	u.utxoDag = utxoDag
+	return u
+}
+
+func (u *utxoDagMock) Events() *UTXODAGEvents {
+	return u.utxoDag.Events()
+}
+
+func (u *utxoDagMock) InclusionState(transactionID TransactionID) (inclusionState InclusionState, err error) {
+	args := u.Called(transactionID)
+	inclusionState = args.Get(0).(InclusionState)
+	return
+}
+
+func (u *utxoDagMock) Shutdown() {
+	u.utxoDag.Shutdown()
+	return
+}
+
+func (u *utxoDagMock) StoreTransaction(transaction *Transaction) (stored bool, solidityType SolidityType, err error) {
+	return u.utxoDag.StoreTransaction(transaction)
+}
+
+func (u *utxoDagMock) CheckTransaction(transaction *Transaction) (err error) {
+	return u.utxoDag.CheckTransaction(transaction)
+}
+
+func (u *utxoDagMock) CachedTransaction(transactionID TransactionID) (cachedTransaction *CachedTransaction) {
+	return u.utxoDag.CachedTransaction(transactionID)
+}
+
+func (u *utxoDagMock) Transaction(transactionID TransactionID) (transaction *Transaction) {
+	return u.utxoDag.Transaction(transactionID)
+}
+
+func (u *utxoDagMock) Transactions() (transactions map[TransactionID]*Transaction) {
+	return u.utxoDag.Transactions()
+}
+
+func (u *utxoDagMock) CachedTransactionMetadata(transactionID TransactionID, computeIfAbsentCallback ...func(transactionID TransactionID) *TransactionMetadata) (cachedTransactionMetadata *CachedTransactionMetadata) {
+	return u.utxoDag.CachedTransactionMetadata(transactionID, computeIfAbsentCallback...)
+}
+
+func (u *utxoDagMock) CachedOutput(outputID OutputID) (cachedOutput *CachedOutput) {
+	return u.utxoDag.CachedOutput(outputID)
+}
+
+func (u *utxoDagMock) CachedOutputMetadata(outputID OutputID) (cachedOutput *CachedOutputMetadata) {
+	return u.utxoDag.CachedOutputMetadata(outputID)
+}
+
+func (u *utxoDagMock) CachedConsumers(outputID OutputID, optionalSolidityType ...SolidityType) (cachedConsumers CachedConsumers) {
+	return u.utxoDag.CachedConsumers(outputID, optionalSolidityType...)
+}
+
+func (u *utxoDagMock) LoadSnapshot(snapshot *Snapshot) {
+	u.utxoDag.LoadSnapshot(snapshot)
+}
+
+func (u *utxoDagMock) CachedAddressOutputMapping(address Address) (cachedAddressOutputMappings CachedAddressOutputMappings) {
+	return u.utxoDag.CachedAddressOutputMapping(address)
+}
+
+func (u *utxoDagMock) SetTransactionConfirmed(transactionID TransactionID) (err error) {
+	return u.utxoDag.SetTransactionConfirmed(transactionID)
+}
+
+func (u *utxoDagMock) ConsumedOutputs(transaction *Transaction) (cachedInputs CachedOutputs) {
+	return u.utxoDag.ConsumedOutputs(transaction)
+}
+
+func (u *utxoDagMock) ManageStoreAddressOutputMapping(output Output) {
+	u.utxoDag.ManageStoreAddressOutputMapping(output)
+}
+
+func (u *utxoDagMock) StoreAddressOutputMapping(address Address, outputID OutputID) {
+	u.utxoDag.StoreAddressOutputMapping(address, outputID)
+}

--- a/packages/ledgerstate/utxo_dag_mock.go
+++ b/packages/ledgerstate/utxo_dag_mock.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+// UtxoDagMock is the mock for UTXODAG that is used for unit tests.
 type UtxoDagMock struct {
 	mock.Mock
 	test    *testing.T
@@ -22,76 +23,99 @@ func NewUtxoDagMock(t *testing.T, utxoDag IUTXODAG) *UtxoDagMock {
 	return u
 }
 
+// Events returns all events of the underlying UTXODAG
 func (u *UtxoDagMock) Events() *UTXODAGEvents {
 	return u.utxoDag.Events()
 }
 
+// InclusionState returns the mocked InclusionState of the Transaction with the given TransactionID.
 func (u *UtxoDagMock) InclusionState(transactionID TransactionID) (inclusionState InclusionState, err error) {
 	args := u.Called(transactionID)
 	inclusionState = args.Get(0).(InclusionState)
 	return
 }
 
+// Shutdown shuts down the underlying UTXODAG and persists its state.
 func (u *UtxoDagMock) Shutdown() {
 	u.utxoDag.Shutdown()
 }
 
+// StoreTransaction uses the underling UTXODAG method to store the transaction.
 func (u *UtxoDagMock) StoreTransaction(transaction *Transaction) (stored bool, solidityType SolidityType, err error) {
 	return u.utxoDag.StoreTransaction(transaction)
 }
 
+// CheckTransaction uses the underling UTXODAG method to contain fast checks that have to be performed before booking a Transaction.
 func (u *UtxoDagMock) CheckTransaction(transaction *Transaction) (err error) {
 	return u.utxoDag.CheckTransaction(transaction)
 }
 
+// CachedTransaction uses the underling UTXODAG method to retrieves the Transaction with the given TransactionID from the object storage.
 func (u *UtxoDagMock) CachedTransaction(transactionID TransactionID) (cachedTransaction *CachedTransaction) {
 	return u.utxoDag.CachedTransaction(transactionID)
 }
 
+// Transaction uses the underling UTXODAG method to return a specific transaction, consumed.
 func (u *UtxoDagMock) Transaction(transactionID TransactionID) (transaction *Transaction) {
 	return u.utxoDag.Transaction(transactionID)
 }
 
+// Transactions uses the underling UTXODAG method to return all the transactions, consumed.
 func (u *UtxoDagMock) Transactions() (transactions map[TransactionID]*Transaction) {
 	return u.utxoDag.Transactions()
 }
 
+// CachedTransactionMetadata uses the underling UTXODAG method to retrieve the TransactionMetadata
+// with the given TransactionID from the object storage.
 func (u *UtxoDagMock) CachedTransactionMetadata(transactionID TransactionID, computeIfAbsentCallback ...func(transactionID TransactionID) *TransactionMetadata) (cachedTransactionMetadata *CachedTransactionMetadata) {
 	return u.utxoDag.CachedTransactionMetadata(transactionID, computeIfAbsentCallback...)
 }
 
+// CachedOutput uses the underling UTXODAG method to retrieve the Output with the given OutputID from the object storage.
 func (u *UtxoDagMock) CachedOutput(outputID OutputID) (cachedOutput *CachedOutput) {
 	return u.utxoDag.CachedOutput(outputID)
 }
 
+// CachedOutputMetadata uses the underling UTXODAG method to retrieve the OutputMetadata with the given OutputID from the object storage.
 func (u *UtxoDagMock) CachedOutputMetadata(outputID OutputID) (cachedOutput *CachedOutputMetadata) {
 	return u.utxoDag.CachedOutputMetadata(outputID)
 }
 
+// CachedConsumers uses the underling UTXODAG method to retrieve the Consumers of the given OutputID from the object storage.
 func (u *UtxoDagMock) CachedConsumers(outputID OutputID, optionalSolidityType ...SolidityType) (cachedConsumers CachedConsumers) {
 	return u.utxoDag.CachedConsumers(outputID, optionalSolidityType...)
 }
 
+// LoadSnapshot uses the underling UTXODAG method to create a set of outputs in the UTXO-DAG, that are forming the genesis
+// for future transactions.
 func (u *UtxoDagMock) LoadSnapshot(snapshot *Snapshot) {
 	u.utxoDag.LoadSnapshot(snapshot)
 }
 
+// CachedAddressOutputMapping uses the underling UTXODAG method to retrieve the outputs for the given address.
 func (u *UtxoDagMock) CachedAddressOutputMapping(address Address) (cachedAddressOutputMappings CachedAddressOutputMappings) {
 	return u.utxoDag.CachedAddressOutputMapping(address)
 }
 
+// SetTransactionConfirmed uses the underling UTXODAG method to mark a Transaction (and all Transactions in its past cone)
+// as confirmed. It also marks the
+// conflicting Transactions to be rejected.
 func (u *UtxoDagMock) SetTransactionConfirmed(transactionID TransactionID) (err error) {
 	return u.utxoDag.SetTransactionConfirmed(transactionID)
 }
 
+// ConsumedOutputs uses the underling UTXODAG method to return the consumed (cached)Outputs of the given Transaction.
 func (u *UtxoDagMock) ConsumedOutputs(transaction *Transaction) (cachedInputs CachedOutputs) {
 	return u.utxoDag.ConsumedOutputs(transaction)
 }
 
+// ManageStoreAddressOutputMapping uses the underling UTXODAG method to mangage how to store the address-output mapping
+// dependent on which type of output it is.
 func (u *UtxoDagMock) ManageStoreAddressOutputMapping(output Output) {
 	u.utxoDag.ManageStoreAddressOutputMapping(output)
 }
 
+// StoreAddressOutputMapping uses the underling UTXODAG method to store the address-output mapping.
 func (u *UtxoDagMock) StoreAddressOutputMapping(address Address, outputID OutputID) {
 	u.utxoDag.StoreAddressOutputMapping(address, outputID)
 }

--- a/packages/ledgerstate/utxo_dag_mock.go
+++ b/packages/ledgerstate/utxo_dag_mock.go
@@ -1,19 +1,20 @@
 package ledgerstate
 
 import (
-	"github.com/stretchr/testify/mock"
 	"testing"
+
+	"github.com/stretchr/testify/mock"
 )
 
-type utxoDagMock struct {
+type UtxoDagMock struct {
 	mock.Mock
 	test    *testing.T
 	utxoDag IUTXODAG
 }
 
 // NewUtxoDagMock creates a mock for UTXODAG
-func NewUtxoDagMock(t *testing.T, utxoDag IUTXODAG) *utxoDagMock {
-	u := &utxoDagMock{
+func NewUtxoDagMock(t *testing.T, utxoDag IUTXODAG) *UtxoDagMock {
+	u := &UtxoDagMock{
 		test: t,
 	}
 	u.Test(t)
@@ -21,77 +22,76 @@ func NewUtxoDagMock(t *testing.T, utxoDag IUTXODAG) *utxoDagMock {
 	return u
 }
 
-func (u *utxoDagMock) Events() *UTXODAGEvents {
+func (u *UtxoDagMock) Events() *UTXODAGEvents {
 	return u.utxoDag.Events()
 }
 
-func (u *utxoDagMock) InclusionState(transactionID TransactionID) (inclusionState InclusionState, err error) {
+func (u *UtxoDagMock) InclusionState(transactionID TransactionID) (inclusionState InclusionState, err error) {
 	args := u.Called(transactionID)
 	inclusionState = args.Get(0).(InclusionState)
 	return
 }
 
-func (u *utxoDagMock) Shutdown() {
+func (u *UtxoDagMock) Shutdown() {
 	u.utxoDag.Shutdown()
-	return
 }
 
-func (u *utxoDagMock) StoreTransaction(transaction *Transaction) (stored bool, solidityType SolidityType, err error) {
+func (u *UtxoDagMock) StoreTransaction(transaction *Transaction) (stored bool, solidityType SolidityType, err error) {
 	return u.utxoDag.StoreTransaction(transaction)
 }
 
-func (u *utxoDagMock) CheckTransaction(transaction *Transaction) (err error) {
+func (u *UtxoDagMock) CheckTransaction(transaction *Transaction) (err error) {
 	return u.utxoDag.CheckTransaction(transaction)
 }
 
-func (u *utxoDagMock) CachedTransaction(transactionID TransactionID) (cachedTransaction *CachedTransaction) {
+func (u *UtxoDagMock) CachedTransaction(transactionID TransactionID) (cachedTransaction *CachedTransaction) {
 	return u.utxoDag.CachedTransaction(transactionID)
 }
 
-func (u *utxoDagMock) Transaction(transactionID TransactionID) (transaction *Transaction) {
+func (u *UtxoDagMock) Transaction(transactionID TransactionID) (transaction *Transaction) {
 	return u.utxoDag.Transaction(transactionID)
 }
 
-func (u *utxoDagMock) Transactions() (transactions map[TransactionID]*Transaction) {
+func (u *UtxoDagMock) Transactions() (transactions map[TransactionID]*Transaction) {
 	return u.utxoDag.Transactions()
 }
 
-func (u *utxoDagMock) CachedTransactionMetadata(transactionID TransactionID, computeIfAbsentCallback ...func(transactionID TransactionID) *TransactionMetadata) (cachedTransactionMetadata *CachedTransactionMetadata) {
+func (u *UtxoDagMock) CachedTransactionMetadata(transactionID TransactionID, computeIfAbsentCallback ...func(transactionID TransactionID) *TransactionMetadata) (cachedTransactionMetadata *CachedTransactionMetadata) {
 	return u.utxoDag.CachedTransactionMetadata(transactionID, computeIfAbsentCallback...)
 }
 
-func (u *utxoDagMock) CachedOutput(outputID OutputID) (cachedOutput *CachedOutput) {
+func (u *UtxoDagMock) CachedOutput(outputID OutputID) (cachedOutput *CachedOutput) {
 	return u.utxoDag.CachedOutput(outputID)
 }
 
-func (u *utxoDagMock) CachedOutputMetadata(outputID OutputID) (cachedOutput *CachedOutputMetadata) {
+func (u *UtxoDagMock) CachedOutputMetadata(outputID OutputID) (cachedOutput *CachedOutputMetadata) {
 	return u.utxoDag.CachedOutputMetadata(outputID)
 }
 
-func (u *utxoDagMock) CachedConsumers(outputID OutputID, optionalSolidityType ...SolidityType) (cachedConsumers CachedConsumers) {
+func (u *UtxoDagMock) CachedConsumers(outputID OutputID, optionalSolidityType ...SolidityType) (cachedConsumers CachedConsumers) {
 	return u.utxoDag.CachedConsumers(outputID, optionalSolidityType...)
 }
 
-func (u *utxoDagMock) LoadSnapshot(snapshot *Snapshot) {
+func (u *UtxoDagMock) LoadSnapshot(snapshot *Snapshot) {
 	u.utxoDag.LoadSnapshot(snapshot)
 }
 
-func (u *utxoDagMock) CachedAddressOutputMapping(address Address) (cachedAddressOutputMappings CachedAddressOutputMappings) {
+func (u *UtxoDagMock) CachedAddressOutputMapping(address Address) (cachedAddressOutputMappings CachedAddressOutputMappings) {
 	return u.utxoDag.CachedAddressOutputMapping(address)
 }
 
-func (u *utxoDagMock) SetTransactionConfirmed(transactionID TransactionID) (err error) {
+func (u *UtxoDagMock) SetTransactionConfirmed(transactionID TransactionID) (err error) {
 	return u.utxoDag.SetTransactionConfirmed(transactionID)
 }
 
-func (u *utxoDagMock) ConsumedOutputs(transaction *Transaction) (cachedInputs CachedOutputs) {
+func (u *UtxoDagMock) ConsumedOutputs(transaction *Transaction) (cachedInputs CachedOutputs) {
 	return u.utxoDag.ConsumedOutputs(transaction)
 }
 
-func (u *utxoDagMock) ManageStoreAddressOutputMapping(output Output) {
+func (u *UtxoDagMock) ManageStoreAddressOutputMapping(output Output) {
 	u.utxoDag.ManageStoreAddressOutputMapping(output)
 }
 
-func (u *utxoDagMock) StoreAddressOutputMapping(address Address, outputID OutputID) {
+func (u *UtxoDagMock) StoreAddressOutputMapping(address Address, outputID OutputID) {
 	u.utxoDag.StoreAddressOutputMapping(address, outputID)
 }

--- a/packages/tangle/booker.go
+++ b/packages/tangle/booker.go
@@ -57,7 +57,7 @@ func (b *Booker) Setup() {
 		}
 	}))
 
-	b.tangle.LedgerState.UTXODAG.Events.TransactionBranchIDUpdated.Attach(events.NewClosure(func(transactionID ledgerstate.TransactionID) {
+	b.tangle.LedgerState.UTXODAG.Events().TransactionBranchIDUpdated.Attach(events.NewClosure(func(transactionID ledgerstate.TransactionID) {
 		if err := b.BookConflictingTransaction(transactionID); err != nil {
 			b.Events.Error.Trigger(errors.Errorf("failed to propagate ConflictBranch of %s to tangle: %w", transactionID, err))
 		}

--- a/packages/tangle/eligibilitymanager.go
+++ b/packages/tangle/eligibilitymanager.go
@@ -85,7 +85,7 @@ func (e *EligibilityManager) storeMissingDependencies(dependentTxID, dependencyT
 	e.storageMutex.Lock()
 	defer e.storageMutex.Unlock()
 
-	var isStored bool
+	isStored := false
 	e.tangle.Storage.UnconfirmedTransactionDependencies(*dependencyTxID, func() *UnconfirmedTxDependency {
 		return NewUnconfirmedTxDependency(*dependencyTxID)
 	}).Consume(func(unconfirmedTxDependency *UnconfirmedTxDependency) {

--- a/packages/tangle/eligibilitymanager.go
+++ b/packages/tangle/eligibilitymanager.go
@@ -86,9 +86,9 @@ func (e *EligibilityManager) storeMissingDependencies(dependentTxID *ledgerstate
 	defer e.storageMutex.Unlock()
 
 	storage := e.tangle.Storage
-	if cachedDependencies := storage.UnconfirmedTransactionDependencies(dependencyTxID); cachedDependencies != nil {
+	if cachedDependencies := storage.UnconfirmedTransactionDependencies(*dependencyTxID); cachedDependencies != nil {
 		cachedDependencies.Consume(func(unconfirmedTxDependency *UnconfirmedTxDependency) {
-			unconfirmedTxDependency.AddDependency(dependentTxID)
+			unconfirmedTxDependency.AddDependency(*dependentTxID)
 		})
 		return nil
 	}
@@ -131,7 +131,7 @@ func (e *EligibilityManager) Setup() {
 func (e *EligibilityManager) updateEligibilityAfterDependencyConfirmation(dependencyTxID *ledgerstate.TransactionID) error {
 	dependentTxs := make([]*ledgerstate.Transaction, 0)
 	// get all txID dependent on this transactionID
-	if cachedDependencies := e.tangle.Storage.UnconfirmedTransactionDependencies(dependencyTxID); cachedDependencies != nil {
+	if cachedDependencies := e.tangle.Storage.UnconfirmedTransactionDependencies(*dependencyTxID); cachedDependencies != nil {
 		// tx that need to be checked for the eligibility after one of dependency has been confirmed
 		cachedDependencies.Consume(func(unconfirmedTxDependency *UnconfirmedTxDependency) {
 			// get tx from storage
@@ -141,7 +141,7 @@ func (e *EligibilityManager) updateEligibilityAfterDependencyConfirmation(depend
 				})
 			}
 		})
-		e.tangle.Storage.deleteUnconfirmedTxDependencies(dependencyTxID)
+		e.tangle.Storage.deleteUnconfirmedTxDependencies(*dependencyTxID)
 	}
 
 	for _, dependentTx := range dependentTxs {

--- a/packages/tangle/eligibilitymanager.go
+++ b/packages/tangle/eligibilitymanager.go
@@ -80,7 +80,7 @@ func (e *EligibilityManager) checkEligibility(messageID MessageID) error {
 }
 
 // storeMissingDependencies adds missing dependencies to the object storage
-// or append if already exist append dependent txID to the existing one
+// or if already exist it appends dependent txID to the existing object storage.
 func (e *EligibilityManager) storeMissingDependencies(dependentTxID *ledgerstate.TransactionID, dependencyTxID *ledgerstate.TransactionID) error {
 	e.storageMutex.Lock()
 	defer e.storageMutex.Unlock()
@@ -116,9 +116,9 @@ func (e *EligibilityManager) Setup() {
 	}))
 }
 
-// updateEligibilityAfterDependencyConfirmation triggered on transaction confirmation event
-// remove unconfirmed dependency from object storage and checks if any of dependent transactions
-// can be set to eligible
+// updateEligibilityAfterDependencyConfirmation is triggered on transaction confirmation event.
+// It removes confirmed dependency along with dependent transactions from object storage and checks if any of dependent
+// transactions can be set to eligible.
 func (e *EligibilityManager) updateEligibilityAfterDependencyConfirmation(dependencyTxID *ledgerstate.TransactionID) error {
 	dependentTxs := make([]*ledgerstate.Transaction, 0)
 	// get all txID dependent on this transactionID
@@ -147,7 +147,7 @@ func (e *EligibilityManager) updateEligibilityAfterDependencyConfirmation(depend
 	return nil
 }
 
-// obtainPendingDependencies return all transaction ids that are still pending confirmation that tx depends upon
+// obtainPendingDependencies returns all transactionIDs that are still pending confirmation that tx depends upon
 func (e *EligibilityManager) obtainPendingDependencies(tx *ledgerstate.Transaction) (ledgerstate.TransactionIDs, error) {
 	pendingDependencies := make(ledgerstate.TransactionIDs)
 	for _, input := range tx.Essence().Inputs() {
@@ -164,7 +164,7 @@ func (e *EligibilityManager) obtainPendingDependencies(tx *ledgerstate.Transacti
 	return pendingDependencies, nil
 }
 
-// makeAttachmentsEligible set eligibility to true for all transaction's attachments if all dependencies has been confirmed
+// makeAttachmentsEligible sets eligibility to true for all transaction's attachments if all dependencies has been confirmed
 func (e *EligibilityManager) makeAttachmentsEligible(dependentTx *ledgerstate.Transaction) {
 	// set eligible all tx dependent attachments
 	messageIDs := e.tangle.Storage.AttachmentMessageIDs(dependentTx.ID())

--- a/packages/tangle/eligibilitymanager.go
+++ b/packages/tangle/eligibilitymanager.go
@@ -131,11 +131,13 @@ func (e *EligibilityManager) updateEligibilityAfterDependencyConfirmation(depend
 		// tx that need to be checked for the eligibility after one of dependency has been confirmed
 		cachedDependencies.Consume(func(unconfirmedTxDependency *UnconfirmedTxDependency) {
 			// get tx from storage
-			for txID := range unconfirmedTxDependency.txDependentIDs {
+			unconfirmedTxDependency.txDependentIDs.ForEach(func(key, value interface{}) bool {
+				txID := key.(ledgerstate.TransactionID)
 				e.tangle.LedgerState.Transaction(txID).Consume(func(tx *ledgerstate.Transaction) {
 					dependentTxs = append(dependentTxs, tx)
 				})
-			}
+				return true
+			})
 		})
 		e.tangle.Storage.deleteUnconfirmedTxDependencies(*dependencyTxID)
 	}

--- a/packages/tangle/eligibilitymanager.go
+++ b/packages/tangle/eligibilitymanager.go
@@ -85,11 +85,16 @@ func (e *EligibilityManager) storeMissingDependencies(dependentTxID, dependencyT
 	e.storageMutex.Lock()
 	defer e.storageMutex.Unlock()
 
+	var isStored bool
 	e.tangle.Storage.UnconfirmedTransactionDependencies(*dependencyTxID, func() *UnconfirmedTxDependency {
 		return NewUnconfirmedTxDependency(*dependencyTxID)
 	}).Consume(func(unconfirmedTxDependency *UnconfirmedTxDependency) {
 		unconfirmedTxDependency.AddDependency(*dependentTxID)
+		isStored = true
 	})
+	if !isStored {
+		return errors.Errorf("failed to store a new transaction dependency")
+	}
 
 	return nil
 }

--- a/packages/tangle/eligibilitymanager.go
+++ b/packages/tangle/eligibilitymanager.go
@@ -1,0 +1,219 @@
+package tangle
+
+import (
+	"sync"
+
+	"github.com/cockroachdb/errors"
+	"github.com/iotaledger/hive.go/byteutils"
+	"github.com/iotaledger/hive.go/events"
+	"github.com/iotaledger/hive.go/marshalutil"
+	"github.com/iotaledger/hive.go/objectstorage"
+
+	"github.com/iotaledger/goshimmer/packages/ledgerstate"
+)
+
+// EligibilityEvents contain all events that can be triggered by the manager
+type EligibilityEvents struct {
+	// MessageEligible is triggered when message eligible flag is set to true
+	MessageEligible *events.Event
+	Error           *events.Event
+}
+
+// EligibilityManager manages when tips become eligible and handle the persistence of the status
+type EligibilityManager struct {
+	Events *EligibilityEvents
+
+	tangle       *Tangle
+	storageMutex sync.Mutex
+}
+
+// NewEligibilityManager creates a new eligibility manager ready to trigger events
+func NewEligibilityManager(tangle *Tangle) (eligibilityManager *EligibilityManager) {
+	eligibilityManager = &EligibilityManager{
+		Events: &EligibilityEvents{
+			MessageEligible: events.NewEvent(MessageIDCaller),
+			Error:           events.NewEvent(events.ErrorCaller),
+		},
+
+		tangle: tangle,
+	}
+	return
+}
+
+// checkEligibility checks if message cn be set to eligible. If yes, it set eligibility flag and triggers message eligible event.
+// If not it stores transactions dependencies to the object storage
+func (e *EligibilityManager) checkEligibility(messageID MessageID) error {
+	cachedMsg := e.tangle.Storage.Message(messageID)
+	defer cachedMsg.Release()
+
+	message := cachedMsg.Unwrap()
+	payloadType := message.Payload().Type()
+	// data messages are eligible right after solidification
+	if payloadType != ledgerstate.TransactionType {
+		e.makeEligible(messageID)
+		return nil
+	}
+
+	tx := message.Payload().(*ledgerstate.Transaction)
+	pendingDependencies, err := e.obtainPendingDependencies(tx)
+	if err != nil {
+		return errors.Errorf("failed to get pending transaction's dependencies: %w", err)
+	}
+	// no pending dependencies left
+	if len(pendingDependencies) == 0 {
+		e.makeEligible(messageID)
+		return nil
+		// All dependencies are approved by the message
+	} else if NewUtils(e.tangle).AllTransactionsDirectlyApprovedByMessages(pendingDependencies, messageID) {
+		e.makeEligible(messageID)
+		return nil
+	}
+
+	for dependencyTxID := range pendingDependencies {
+		txID := tx.ID()
+		err = e.storeMissingDependencies(&txID, &dependencyTxID)
+		if err != nil {
+			return errors.Errorf("failed to add missing dependencies: %w", err)
+		}
+	}
+	return nil
+}
+
+// storeMissingDependencies adds missing dependencies to the object storage
+// or append if already exist append dependent txID to the existing one
+func (e *EligibilityManager) storeMissingDependencies(dependentTxID *ledgerstate.TransactionID, dependencyTxID *ledgerstate.TransactionID) error {
+	e.storageMutex.Lock()
+	defer e.storageMutex.Unlock()
+
+	storage := e.tangle.Storage
+	if cachedDependencies := storage.UnconfirmedTransactionDependencies(dependencyTxID); cachedDependencies != nil {
+		cachedDependencies.Consume(func(unconfirmedTxDependency *UnconfirmedTxDependency) {
+			unconfirmedTxDependency.AddDependency(dependentTxID)
+		})
+		return nil
+	}
+	txDependency := NewUnconfirmedTxDependency(dependencyTxID)
+	txDependency.AddDependency(dependentTxID)
+	cachedDependency := storage.StoreUnconfirmedTransactionDependencies(txDependency)
+	if cachedDependency == nil {
+		return errors.Errorf("failed to store dependency, txID: %s", dependentTxID)
+	}
+	cachedDependency.Release()
+
+	return nil
+}
+
+func (e *EligibilityManager) makeEligible(messageID MessageID) {
+	e.tangle.Storage.MessageMetadata(messageID).Consume(func(messageMetadata *MessageMetadata) {
+		messageMetadata.SetEligible(true)
+	})
+	e.Events.MessageEligible.Trigger(messageID)
+}
+
+// Setup sets up the behavior of the component by making it attach to the relevant events of other components.
+func (e *EligibilityManager) Setup() {
+	e.tangle.Solidifier.Events.MessageSolid.Attach(events.NewClosure(func(messageID MessageID) {
+		if err := e.checkEligibility(messageID); err != nil {
+			e.Events.Error.Trigger(errors.Errorf("failed to check eligibility of message %s. %w", messageID.Base58(), err))
+		}
+	}))
+
+	e.tangle.LedgerState.UTXODAG.Events().TransactionConfirmed.Attach(events.NewClosure(func(transactionID *ledgerstate.TransactionID) {
+		if err := e.updateEligibilityAfterDependencyConfirmation(transactionID); err != nil {
+			e.Events.Error.Trigger(errors.Errorf("failed to update eligibility after tx %s was confirmed. %w", transactionID.Base58(), err))
+		}
+	}))
+}
+
+// updateEligibilityAfterDependencyConfirmation triggered on transaction confirmation event
+// remove unconfirmed dependency from object storage and checks if any of dependent transactions
+// can be set to eligible
+func (e *EligibilityManager) updateEligibilityAfterDependencyConfirmation(dependencyTxID *ledgerstate.TransactionID) error {
+	dependentTxs := make([]*ledgerstate.Transaction, 0)
+	// get all txID dependent on this transactionID
+	if cachedDependencies := e.tangle.Storage.UnconfirmedTransactionDependencies(dependencyTxID); cachedDependencies != nil {
+		// tx that need to be checked for the eligibility after one of dependency has been confirmed
+		cachedDependencies.Consume(func(unconfirmedTxDependency *UnconfirmedTxDependency) {
+			// get tx from storage
+			for txID := range unconfirmedTxDependency.dependentTxIDs {
+				e.tangle.LedgerState.Transaction(txID).Consume(func(tx *ledgerstate.Transaction) {
+					dependentTxs = append(dependentTxs, tx)
+				})
+			}
+		})
+		e.tangle.Storage.deleteUnconfirmedTxDependencies(dependencyTxID)
+	}
+
+	for _, dependentTx := range dependentTxs {
+		pendingDependencies, err := e.obtainPendingDependencies(dependentTx)
+		if err != nil {
+			return errors.Errorf("failed to get pending transaction's dependencies: %w", err)
+		}
+		if len(pendingDependencies) == 0 {
+			e.makeAttachmentsEligible(dependentTx)
+		}
+	}
+	return nil
+}
+
+// obtainPendingDependencies return all transaction ids that are still pending confirmation that tx depends upon
+func (e *EligibilityManager) obtainPendingDependencies(tx *ledgerstate.Transaction) (ledgerstate.TransactionIDs, error) {
+	pendingDependencies := make(ledgerstate.TransactionIDs)
+	for _, input := range tx.Essence().Inputs() {
+		outputID := input.(*ledgerstate.UTXOInput).ReferencedOutputID()
+		txID := outputID.TransactionID()
+		state, err := e.tangle.LedgerState.UTXODAG.InclusionState(txID)
+		if err != nil {
+			return nil, errors.Errorf("failed to get inclusion state: %w", err)
+		}
+		if state != ledgerstate.Confirmed {
+			pendingDependencies[txID] = struct{}{}
+		}
+	}
+	return pendingDependencies, nil
+}
+
+// makeAttachmentsEligible set eligibility to true for all transaction's attachments if all dependencies has been confirmed
+func (e *EligibilityManager) makeAttachmentsEligible(dependentTx *ledgerstate.Transaction) {
+	// set eligible all tx dependent attachments
+	messageIDs := e.tangle.Storage.AttachmentMessageIDs(dependentTx.ID())
+	for _, messageID := range messageIDs {
+		e.makeEligible(messageID)
+	}
+}
+
+// UnconfirmedTxDependenciesFromObjectStorage restores an UnconfirmedTxDependency object that was stored in the ObjectStorage.
+func UnconfirmedTxDependenciesFromObjectStorage(key, data []byte) (result objectstorage.StorableObject, err error) {
+	if result, _, err = UnconfirmedTxDependencyFromBytes(byteutils.ConcatBytes(key, data)); err != nil {
+		err = errors.Errorf("failed to parse UnconfirmedTxDependencyFromByte from bytes: %w", err)
+		return
+	}
+
+	return
+}
+
+// UnconfirmedTxDependencyFromBytes unmarshals an UnconfirmedTxDependency from bytes.
+func UnconfirmedTxDependencyFromBytes(bytes []byte) (unconfirmedTxDependency *UnconfirmedTxDependency,
+	consumedBytes int, err error) {
+	marshalUtil := marshalutil.New(bytes)
+
+	txID, err := ledgerstate.TransactionIDFromMarshalUtil(marshalUtil)
+	if err != nil {
+		err = errors.Errorf("failed to parse TransactionID from MarshalUtil: %w", err)
+		return
+	}
+	txDependencies, err := ledgerstate.TransactionIDsFromMarshalUtil(marshalUtil)
+	if err != nil {
+		err = errors.Errorf("failed to parse TransactionIDs from MarshalUtil: %w", err)
+		return
+	}
+
+	unconfirmedTxDependency = &UnconfirmedTxDependency{
+		dependencyTxID: txID,
+		dependentTxIDs: txDependencies,
+	}
+
+	consumedBytes = marshalUtil.ReadOffset()
+
+	return
+}

--- a/packages/tangle/eligibilitymanager.go
+++ b/packages/tangle/eligibilitymanager.go
@@ -81,7 +81,7 @@ func (e *EligibilityManager) checkEligibility(messageID MessageID) error {
 
 // storeMissingDependencies adds missing dependencies to the object storage
 // or if already exist it appends dependent txID to the existing object storage.
-func (e *EligibilityManager) storeMissingDependencies(dependentTxID *ledgerstate.TransactionID, dependencyTxID *ledgerstate.TransactionID) error {
+func (e *EligibilityManager) storeMissingDependencies(dependentTxID, dependencyTxID *ledgerstate.TransactionID) error {
 	e.storageMutex.Lock()
 	defer e.storageMutex.Unlock()
 

--- a/packages/tangle/eligibilitymanager.go
+++ b/packages/tangle/eligibilitymanager.go
@@ -109,8 +109,8 @@ func (e *EligibilityManager) Setup() {
 		}
 	}))
 
-	e.tangle.LedgerState.UTXODAG.Events().TransactionConfirmed.Attach(events.NewClosure(func(transactionID *ledgerstate.TransactionID) {
-		if err := e.updateEligibilityAfterDependencyConfirmation(transactionID); err != nil {
+	e.tangle.LedgerState.UTXODAG.Events().TransactionConfirmed.Attach(events.NewClosure(func(transactionID ledgerstate.TransactionID) {
+		if err := e.updateEligibilityAfterDependencyConfirmation(&transactionID); err != nil {
 			e.Events.Error.Trigger(errors.Errorf("failed to update eligibility after tx %s was confirmed. %w", transactionID.Base58(), err))
 		}
 	}))

--- a/packages/tangle/eligibilitymanager.go
+++ b/packages/tangle/eligibilitymanager.go
@@ -92,8 +92,8 @@ func (e *EligibilityManager) storeMissingDependencies(dependentTxID *ledgerstate
 		})
 		return nil
 	}
-	txDependency := NewUnconfirmedTxDependency(dependencyTxID)
-	txDependency.AddDependency(dependentTxID)
+	txDependency := NewUnconfirmedTxDependency(*dependencyTxID)
+	txDependency.AddDependency(*dependentTxID)
 	cachedDependency := storage.StoreUnconfirmedTransactionDependencies(txDependency)
 	if cachedDependency == nil {
 		return errors.Errorf("failed to store dependency, txID: %s", dependentTxID)

--- a/packages/tangle/eligibilitymanager_test.go
+++ b/packages/tangle/eligibilitymanager_test.go
@@ -316,8 +316,6 @@ func scenarioMessagesApproveDependency(t *testing.T, tangle *Tangle, wallets map
 	attachment, stored := tangle.Storage.StoreAttachment(transactions["1"].ID(), messages["1"].ID())
 	assert.True(t, stored)
 	attachment.Release()
-
-	return
 }
 
 // creates transaction that is dependent on two other transactions and is not connected by direct approval of their messages

--- a/packages/tangle/eligibilitymanager_test.go
+++ b/packages/tangle/eligibilitymanager_test.go
@@ -1,0 +1,422 @@
+package tangle
+
+import (
+	"testing"
+	"time"
+
+	"github.com/iotaledger/hive.go/events"
+
+	"github.com/stretchr/testify/mock"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/iotaledger/goshimmer/packages/ledgerstate"
+
+	"github.com/iotaledger/hive.go/identity"
+)
+
+func TestDependenciesConfirmed(t *testing.T) {
+	eligibleEventTriggered := false
+	tangle := newTestTangle()
+	defer tangle.Shutdown()
+	wallets, walletsByAddress, messages, transactions, inputs, outputs, outputsByID := setupEligibilityTests(t, tangle)
+	scenarioMessagesApproveEmptyID(t, tangle, wallets, walletsByAddress, messages, transactions, inputs, outputs, outputsByID)
+
+	tangle.EligibilityManager.Events.MessageEligible.Attach(events.NewClosure(func(messageID MessageID) {
+		assert.Equal(t, messages["1"].ID(), messageID)
+		eligibleEventTriggered = true
+	}))
+
+	mockUTXO := ledgerstate.NewUtxoDagMock(t, tangle.LedgerState.UTXODAG)
+	tangle.LedgerState.UTXODAG = mockUTXO
+	mockUTXO.On("InclusionState", transactions["0"].ID()).Return(ledgerstate.Pending)
+
+	isEligibleFlag := runCheckEligibilityAndGetEligibility(t, tangle, messages["1"].ID())
+	assert.False(t, isEligibleFlag, "Message 1 shouldn't be eligible")
+
+	// reset mock, since calls can't be overridden
+	mockUTXO.ExpectedCalls = make([]*mock.Call, 0)
+
+	mockUTXO.On("InclusionState", transactions["0"].ID()).Return(ledgerstate.Confirmed)
+	isEligibleFlag = runCheckEligibilityAndGetEligibility(t, tangle, messages["1"].ID())
+	assert.True(t, isEligibleFlag, "Message 1 isn't eligible")
+
+	assert.True(t, eligibleEventTriggered, "Eligibility event wasn't triggered")
+}
+
+func TestDataMessageAlwaysEligible(t *testing.T) {
+	tangle := newTestTangle()
+	defer tangle.Shutdown()
+
+	message := newTestDataMessage("data")
+	tangle.Storage.StoreMessage(message)
+
+	err := tangle.EligibilityManager.checkEligibility(message.ID())
+	assert.NoError(t, err)
+
+	var eligibilityResult bool
+	tangle.Storage.MessageMetadata(message.ID()).Consume(func(messageMetadata *MessageMetadata) {
+		eligibilityResult = messageMetadata.IsEligible()
+	})
+	assert.True(t, eligibilityResult, "Data messages should awlays be eligible")
+}
+
+func TestDependencyDirectApproval(t *testing.T) {
+	tangle := newTestTangle()
+	defer tangle.Shutdown()
+
+	wallets, walletsByAddress, messages, transactions, inputs, outputs, outputsByID := setupEligibilityTests(t, tangle)
+
+	scenarioMessagesApproveDependency(t, tangle, wallets, walletsByAddress, messages, transactions, inputs, outputs, outputsByID)
+
+	mockUTXO := ledgerstate.NewUtxoDagMock(t, tangle.LedgerState.UTXODAG)
+	tangle.LedgerState.UTXODAG = mockUTXO
+	mockUTXO.On("InclusionState", transactions["0"].ID()).Return(ledgerstate.Pending)
+
+	isEligibleFlag := runCheckEligibilityAndGetEligibility(t, tangle, messages["1"].ID())
+	assert.True(t, isEligibleFlag, "Message 1 isn't eligible")
+}
+
+func TestUpdateEligibilityAfterDependencyConfirmation(t *testing.T) {
+	tangle := newTestTangle()
+	defer tangle.Shutdown()
+	wallets, walletsByAddress, messages, transactions, inputs, outputs, outputsByID := setupEligibilityTests(t, tangle)
+	txID := transactions["0"].ID()
+	eligibleEventTriggered := false
+
+	scenarioMessagesApproveEmptyID(t, tangle, wallets, walletsByAddress, messages, transactions, inputs, outputs, outputsByID)
+
+	tangle.EligibilityManager.Events.MessageEligible.Attach(events.NewClosure(func(messageID MessageID) {
+		assert.Equal(t, messages["1"].ID(), messageID)
+		eligibleEventTriggered = true
+	}))
+
+	mockUTXO := ledgerstate.NewUtxoDagMock(t, tangle.LedgerState.UTXODAG)
+	tangle.LedgerState.UTXODAG = mockUTXO
+	mockUTXO.On("InclusionState", txID).Return(ledgerstate.Pending)
+
+	messageID := messages["1"].ID()
+	isEligibleFlag := runCheckEligibilityAndGetEligibility(t, tangle, messageID)
+	assert.False(t, isEligibleFlag, "Message 1 shouldn't be eligible")
+
+	// reset mock, since calls can't be overridden
+	mockUTXO.ExpectedCalls = make([]*mock.Call, 0)
+	mockUTXO.On("InclusionState", txID).Return(ledgerstate.Confirmed)
+
+	err := tangle.EligibilityManager.updateEligibilityAfterDependencyConfirmation(&txID)
+	assert.NoError(t, err)
+
+	tangle.Storage.MessageMetadata(messageID).Consume(func(messageMetadata *MessageMetadata) {
+		isEligibleFlag = messageMetadata.IsEligible()
+	})
+	assert.True(t, isEligibleFlag, "Message 1 isn't eligible")
+
+	assert.True(t, eligibleEventTriggered, "eligibility event wasn't triggered")
+}
+
+func TestDoNotUpdateEligibilityAfterPartialDependencyConfirmation(t *testing.T) {
+	tangle := newTestTangle()
+	defer tangle.Shutdown()
+	wallets, walletsByAddress, messages, transactions, inputs, outputs, outputsByID := setupEligibilityTests(t, tangle)
+
+	scenarioMoreThanOneDependency(t, tangle, wallets, walletsByAddress, messages, transactions, inputs, outputs, outputsByID)
+
+	mockUTXO := ledgerstate.NewUtxoDagMock(t, tangle.LedgerState.UTXODAG)
+	tangle.LedgerState.UTXODAG = mockUTXO
+	tx1ID := transactions["1"].ID()
+	tx2ID := transactions["2"].ID()
+	mockUTXO.On("InclusionState", tx1ID).Return(ledgerstate.Pending)
+	mockUTXO.On("InclusionState", tx2ID).Return(ledgerstate.Pending)
+
+	messageID := messages["3"].ID()
+	isEligibleFlag := runCheckEligibilityAndGetEligibility(t, tangle, messageID)
+	assert.False(t, isEligibleFlag)
+
+	// reset mock, since calls can't be overridden
+	mockUTXO.ExpectedCalls = make([]*mock.Call, 0)
+	mockUTXO.On("InclusionState", tx1ID).Return(ledgerstate.Confirmed)
+	mockUTXO.On("InclusionState", tx2ID).Return(ledgerstate.Pending)
+
+	err := tangle.EligibilityManager.updateEligibilityAfterDependencyConfirmation(&tx1ID)
+	assert.NoError(t, err)
+	tangle.Storage.MessageMetadata(messageID).Consume(func(messageMetadata *MessageMetadata) {
+		isEligibleFlag = messageMetadata.IsEligible()
+	})
+	assert.False(t, isEligibleFlag)
+
+	// reset mock, since calls can't be overridden
+	mockUTXO.ExpectedCalls = make([]*mock.Call, 0)
+	mockUTXO.On("InclusionState", tx1ID).Return(ledgerstate.Confirmed)
+	mockUTXO.On("InclusionState", tx2ID).Return(ledgerstate.Confirmed)
+
+	err = tangle.EligibilityManager.updateEligibilityAfterDependencyConfirmation(&tx2ID)
+	assert.NoError(t, err)
+	tangle.Storage.MessageMetadata(messageID).Consume(func(messageMetadata *MessageMetadata) {
+		isEligibleFlag = messageMetadata.IsEligible()
+	})
+	assert.True(t, isEligibleFlag)
+}
+
+func TestConfirmationMakeEligibleOneOfDependentTransaction(t *testing.T) {
+	tangle := newTestTangle()
+	defer tangle.Shutdown()
+	wallets, walletsByAddress, messages, transactions, inputs, outputs, outputsByID := setupEligibilityTests(t, tangle)
+	scenarioMoreThanOneDependentTransaction(t, tangle, wallets, walletsByAddress, messages, transactions, inputs, outputs, outputsByID)
+
+	mockUTXO := ledgerstate.NewUtxoDagMock(t, tangle.LedgerState.UTXODAG)
+	tangle.LedgerState.UTXODAG = mockUTXO
+	mockUTXO.On("InclusionState", transactions["3"].ID()).Return(ledgerstate.Pending)
+	mockUTXO.On("InclusionState", transactions["0"].ID()).Return(ledgerstate.Pending)
+
+	isEligibleFlag := runCheckEligibilityAndGetEligibility(t, tangle, messages["1"].ID())
+	assert.False(t, isEligibleFlag)
+
+	isEligibleFlag = runCheckEligibilityAndGetEligibility(t, tangle, messages["2"].ID())
+	assert.False(t, isEligibleFlag)
+
+	// reset mock, since calls can't be overridden
+	mockUTXO.ExpectedCalls = make([]*mock.Call, 0)
+	mockUTXO.On("InclusionState", transactions["3"].ID()).Return(ledgerstate.Pending)
+	mockUTXO.On("InclusionState", transactions["0"].ID()).Return(ledgerstate.Confirmed)
+
+	confirmedTransactionID := transactions["0"].ID()
+
+	err := tangle.EligibilityManager.updateEligibilityAfterDependencyConfirmation(&confirmedTransactionID)
+	assert.NoError(t, err)
+
+	tangle.Storage.MessageMetadata(messages["1"].ID()).Consume(func(messageMetadata *MessageMetadata) {
+		isEligibleFlag = messageMetadata.IsEligible()
+	})
+	assert.False(t, isEligibleFlag)
+	tangle.Storage.MessageMetadata(messages["2"].ID()).Consume(func(messageMetadata *MessageMetadata) {
+		isEligibleFlag = messageMetadata.IsEligible()
+	})
+	assert.True(t, isEligibleFlag, "Message 1 isn't eligible")
+
+	// reset mock, since calls can't be overridden
+	mockUTXO.ExpectedCalls = make([]*mock.Call, 0)
+	mockUTXO.On("InclusionState", transactions["3"].ID()).Return(ledgerstate.Confirmed)
+	mockUTXO.On("InclusionState", transactions["0"].ID()).Return(ledgerstate.Confirmed)
+
+	confirmedTransactionID = transactions["3"].ID()
+
+	err = tangle.EligibilityManager.updateEligibilityAfterDependencyConfirmation(&confirmedTransactionID)
+	assert.NoError(t, err)
+
+	tangle.Storage.MessageMetadata(messages["1"].ID()).Consume(func(messageMetadata *MessageMetadata) {
+		isEligibleFlag = messageMetadata.IsEligible()
+	})
+	assert.True(t, isEligibleFlag)
+	tangle.Storage.MessageMetadata(messages["2"].ID()).Consume(func(messageMetadata *MessageMetadata) {
+		isEligibleFlag = messageMetadata.IsEligible()
+	})
+	assert.True(t, isEligibleFlag)
+}
+
+func setupEligibilityTests(t *testing.T, tangle *Tangle) (map[string]wallet, map[ledgerstate.Address]wallet, map[string]*Message, map[string]*ledgerstate.Transaction, map[string]*ledgerstate.UTXOInput, map[string]*ledgerstate.SigLockedSingleOutput, map[ledgerstate.OutputID]ledgerstate.Output) {
+	tangle.EligibilityManager.Setup()
+
+	wallets := make(map[string]wallet)
+	walletsByAddress := make(map[ledgerstate.Address]wallet)
+	w := createWallets(10)
+	wallets["GENESIS"] = w[0]
+	wallets["A"] = w[1]
+	wallets["B"] = w[2]
+	wallets["C"] = w[3]
+	wallets["D"] = w[4]
+	wallets["E"] = w[5]
+	wallets["F"] = w[6]
+	wallets["H"] = w[7]
+	wallets["I"] = w[8]
+	wallets["J"] = w[9]
+	for _, wlt := range wallets {
+		walletsByAddress[wlt.address] = wlt
+	}
+	genesisBalance := ledgerstate.NewColoredBalances(
+		map[ledgerstate.Color]uint64{
+			ledgerstate.ColorIOTA: 3,
+		})
+	genesisEssence := ledgerstate.NewTransactionEssence(
+		0,
+		time.Unix(DefaultGenesisTime, 0),
+		identity.ID{},
+		identity.ID{},
+		ledgerstate.NewInputs(ledgerstate.NewUTXOInput(ledgerstate.NewOutputID(ledgerstate.GenesisTransactionID, 0))),
+		ledgerstate.NewOutputs(ledgerstate.NewSigLockedColoredOutput(genesisBalance, wallets["GENESIS"].address)),
+	)
+
+	genesisTransaction := ledgerstate.NewTransaction(genesisEssence, ledgerstate.UnlockBlocks{ledgerstate.NewReferenceUnlockBlock(0)})
+	stored, _, _ := tangle.LedgerState.UTXODAG.StoreTransaction(genesisTransaction)
+	assert.True(t, stored, "genesis transaction stored")
+
+	messages := make(map[string]*Message)
+	transactions := make(map[string]*ledgerstate.Transaction)
+	inputs := make(map[string]*ledgerstate.UTXOInput)
+	outputs := make(map[string]*ledgerstate.SigLockedSingleOutput)
+	outputsByID := make(map[ledgerstate.OutputID]ledgerstate.Output)
+
+	// Base message
+	inputs["GENESIS"] = ledgerstate.NewUTXOInput(ledgerstate.NewOutputID(genesisTransaction.ID(), 0))
+	outputs["0A"] = ledgerstate.NewSigLockedSingleOutput(1, wallets["A"].address)
+	outputs["0B"] = ledgerstate.NewSigLockedSingleOutput(1, wallets["B"].address)
+	outputs["0C"] = ledgerstate.NewSigLockedSingleOutput(1, wallets["C"].address)
+	transactions["0"] = makeTransaction(ledgerstate.NewInputs(inputs["GENESIS"]), ledgerstate.NewOutputs(outputs["0A"], outputs["0B"], outputs["0C"]), outputsByID, walletsByAddress, wallets["GENESIS"])
+	messages["0"] = newTestParentsPayloadMessage(transactions["0"], []MessageID{EmptyMessageID}, []MessageID{})
+	stored, _, _ = tangle.LedgerState.UTXODAG.StoreTransaction(transactions["0"])
+	assert.True(t, stored)
+	tangle.Storage.StoreMessage(messages["0"])
+	attachment, stored := tangle.Storage.StoreAttachment(transactions["0"].ID(), messages["0"].ID())
+	assert.True(t, stored)
+	attachment.Release()
+
+	return wallets, walletsByAddress, messages, transactions, inputs, outputs, outputsByID
+}
+
+func runCheckEligibilityAndGetEligibility(t *testing.T, tangle *Tangle, messageID MessageID) bool {
+	err := tangle.EligibilityManager.checkEligibility(messageID)
+	assert.NoError(t, err)
+	var isEligibleFlag bool
+	tangle.Storage.MessageMetadata(messageID).Consume(func(messageMetadata *MessageMetadata) {
+		isEligibleFlag = messageMetadata.IsEligible()
+	})
+	return isEligibleFlag
+}
+
+// create transaction 1 (msg 1) that takes input from tx 0 (msg 0) and does not approve msg 0 directly
+func scenarioMessagesApproveEmptyID(t *testing.T, tangle *Tangle, wallets map[string]wallet, walletsByAddress map[ledgerstate.Address]wallet, messages map[string]*Message, transactions map[string]*ledgerstate.Transaction, inputs map[string]*ledgerstate.UTXOInput, outputs map[string]*ledgerstate.SigLockedSingleOutput, outputsByID map[ledgerstate.OutputID]ledgerstate.Output) {
+	inputs["1A"] = ledgerstate.NewUTXOInput(ledgerstate.NewOutputID(transactions["0"].ID(), selectIndex(transactions["0"], wallets["A"])))
+	outputsByID[inputs["1A"].ReferencedOutputID()] = ledgerstate.NewOutputs(outputs["0A"])[0]
+
+	outputs["1D"] = ledgerstate.NewSigLockedSingleOutput(1, wallets["D"].address)
+	transactions["1"] = makeTransaction(ledgerstate.NewInputs(inputs["1A"]), ledgerstate.NewOutputs(outputs["1D"]), outputsByID, walletsByAddress)
+	messages["1"] = newTestParentsPayloadMessage(transactions["1"], []MessageID{EmptyMessageID}, []MessageID{})
+
+	tangle.Storage.StoreMessage(messages["1"])
+	stored, _, _ := tangle.LedgerState.UTXODAG.StoreTransaction(transactions["1"])
+	assert.True(t, stored)
+
+	attachment, stored := tangle.Storage.StoreAttachment(transactions["1"].ID(), messages["1"].ID())
+	assert.True(t, stored)
+	attachment.Release()
+}
+
+// creates tx and msg 1 that directly approves msg 0 and uses tx0 outputs as its inputs
+func scenarioMessagesApproveDependency(t *testing.T, tangle *Tangle, wallets map[string]wallet, walletsByAddress map[ledgerstate.Address]wallet, messages map[string]*Message, transactions map[string]*ledgerstate.Transaction, inputs map[string]*ledgerstate.UTXOInput, outputs map[string]*ledgerstate.SigLockedSingleOutput, outputsByID map[ledgerstate.OutputID]ledgerstate.Output) {
+	inputs["1A"] = ledgerstate.NewUTXOInput(ledgerstate.NewOutputID(transactions["0"].ID(), selectIndex(transactions["0"], wallets["A"])))
+	outputsByID[inputs["1A"].ReferencedOutputID()] = ledgerstate.NewOutputs(outputs["0A"])[0]
+	outputs["1D"] = ledgerstate.NewSigLockedSingleOutput(1, wallets["D"].address)
+
+	transactions["1"] = makeTransaction(ledgerstate.NewInputs(inputs["1A"]), ledgerstate.NewOutputs(outputs["1D"]), outputsByID, walletsByAddress)
+	messages["1"] = newTestParentsPayloadMessage(transactions["1"], []MessageID{messages["0"].ID()}, []MessageID{})
+
+	tangle.Storage.StoreMessage(messages["1"])
+	stored, _, _ := tangle.LedgerState.UTXODAG.StoreTransaction(transactions["1"])
+	assert.True(t, stored)
+
+	attachment, stored := tangle.Storage.StoreAttachment(transactions["1"].ID(), messages["1"].ID())
+	assert.True(t, stored)
+	attachment.Release()
+
+	return
+}
+
+// creates transaction that is dependent on two other transactions and is not connected by direct approval of their messages
+func scenarioMoreThanOneDependency(t *testing.T, tangle *Tangle, wallets map[string]wallet, walletsByAddress map[ledgerstate.Address]wallet, messages map[string]*Message, transactions map[string]*ledgerstate.Transaction, inputs map[string]*ledgerstate.UTXOInput, outputs map[string]*ledgerstate.SigLockedSingleOutput, outputsByID map[ledgerstate.OutputID]ledgerstate.Output) {
+	// transaction 1
+	inputs["1A"] = ledgerstate.NewUTXOInput(ledgerstate.NewOutputID(transactions["0"].ID(), selectIndex(transactions["0"], wallets["A"])))
+	outputsByID[inputs["1A"].ReferencedOutputID()] = ledgerstate.NewOutputs(outputs["0A"])[0]
+	outputs["1D"] = ledgerstate.NewSigLockedSingleOutput(1, wallets["D"].address)
+
+	transactions["1"] = makeTransaction(ledgerstate.NewInputs(inputs["1A"]), ledgerstate.NewOutputs(outputs["1D"]), outputsByID, walletsByAddress)
+	messages["1"] = newTestParentsPayloadMessage(transactions["1"], []MessageID{EmptyMessageID}, []MessageID{})
+
+	// transaction 2
+	inputs["2B"] = ledgerstate.NewUTXOInput(ledgerstate.NewOutputID(transactions["0"].ID(), selectIndex(transactions["0"], wallets["B"])))
+	outputsByID[inputs["2B"].ReferencedOutputID()] = ledgerstate.NewOutputs(outputs["0B"])[0]
+	outputs["2E"] = ledgerstate.NewSigLockedSingleOutput(1, wallets["E"].address)
+
+	transactions["2"] = makeTransaction(ledgerstate.NewInputs(inputs["2B"]), ledgerstate.NewOutputs(outputs["2E"]), outputsByID, walletsByAddress)
+	messages["2"] = newTestParentsPayloadMessage(transactions["2"], []MessageID{EmptyMessageID}, []MessageID{})
+
+	// transaction 3 dependent on transactions 1 and 2
+	inputs["3D"] = ledgerstate.NewUTXOInput(ledgerstate.NewOutputID(transactions["1"].ID(), selectIndex(transactions["1"], wallets["D"])))
+	outputsByID[inputs["3D"].ReferencedOutputID()] = ledgerstate.NewOutputs(outputs["1D"])[0]
+	inputs["3E"] = ledgerstate.NewUTXOInput(ledgerstate.NewOutputID(transactions["2"].ID(), selectIndex(transactions["2"], wallets["E"])))
+	outputsByID[inputs["3E"].ReferencedOutputID()] = ledgerstate.NewOutputs(outputs["2E"])[0]
+	outputs["3F"] = ledgerstate.NewSigLockedSingleOutput(1, wallets["F"].address)
+
+	transactions["3"] = makeTransaction(ledgerstate.NewInputs(inputs["3D"], inputs["3E"]), ledgerstate.NewOutputs(outputs["3F"]), outputsByID, walletsByAddress)
+	messages["3"] = newTestParentsPayloadMessage(transactions["3"], []MessageID{EmptyMessageID}, []MessageID{})
+
+	// store all transactions and messages
+	tangle.Storage.StoreMessage(messages["1"])
+	stored, _, _ := tangle.LedgerState.UTXODAG.StoreTransaction(transactions["1"])
+	assert.True(t, stored)
+	attachment, stored := tangle.Storage.StoreAttachment(transactions["1"].ID(), messages["1"].ID())
+	attachment.Release()
+	assert.True(t, stored)
+	tangle.Storage.StoreMessage(messages["3"])
+	stored, _, _ = tangle.LedgerState.UTXODAG.StoreTransaction(transactions["3"])
+	assert.True(t, stored)
+	attachment, stored = tangle.Storage.StoreAttachment(transactions["3"].ID(), messages["3"].ID())
+	attachment.Release()
+	assert.True(t, stored)
+	tangle.Storage.StoreMessage(messages["2"])
+	stored, _, _ = tangle.LedgerState.UTXODAG.StoreTransaction(transactions["2"])
+	assert.True(t, stored)
+	attachment, stored = tangle.Storage.StoreAttachment(transactions["2"].ID(), messages["2"].ID())
+	attachment.Release()
+	assert.True(t, stored)
+}
+
+// two transactions 1 and 2 are dependent on the same transaction 0 and are not connected by direct approval between messages
+// transaction is also dependent on other transaction 3 that will get confirmed before 0
+func scenarioMoreThanOneDependentTransaction(t *testing.T, tangle *Tangle, wallets map[string]wallet, walletsByAddress map[ledgerstate.Address]wallet, messages map[string]*Message, transactions map[string]*ledgerstate.Transaction, inputs map[string]*ledgerstate.UTXOInput, outputs map[string]*ledgerstate.SigLockedSingleOutput, outputsByID map[ledgerstate.OutputID]ledgerstate.Output) {
+	// transaction 3
+	inputs["3B"] = ledgerstate.NewUTXOInput(ledgerstate.NewOutputID(transactions["0"].ID(), selectIndex(transactions["0"], wallets["B"])))
+	outputsByID[inputs["3B"].ReferencedOutputID()] = ledgerstate.NewOutputs(outputs["0B"])[0]
+	outputs["3E"] = ledgerstate.NewSigLockedSingleOutput(2, wallets["E"].address)
+
+	transactions["3"] = makeTransaction(ledgerstate.NewInputs(inputs["3B"]), ledgerstate.NewOutputs(outputs["3E"]), outputsByID, walletsByAddress)
+	messages["3"] = newTestParentsPayloadMessage(transactions["3"], []MessageID{EmptyMessageID}, []MessageID{})
+
+	// transaction 1
+	inputs["1A"] = ledgerstate.NewUTXOInput(ledgerstate.NewOutputID(transactions["0"].ID(), selectIndex(transactions["0"], wallets["A"])))
+	outputsByID[inputs["1A"].ReferencedOutputID()] = ledgerstate.NewOutputs(outputs["0A"])[0]
+	inputs["1E"] = ledgerstate.NewUTXOInput(ledgerstate.NewOutputID(transactions["3"].ID(), selectIndex(transactions["3"], wallets["E"])))
+	outputsByID[inputs["1E"].ReferencedOutputID()] = ledgerstate.NewOutputs(outputs["3E"])[0]
+	outputs["1D"] = ledgerstate.NewSigLockedSingleOutput(2, wallets["D"].address)
+
+	transactions["1"] = makeTransaction(ledgerstate.NewInputs(inputs["1A"], inputs["1E"]), ledgerstate.NewOutputs(outputs["1D"]), outputsByID, walletsByAddress)
+	messages["1"] = newTestParentsPayloadMessage(transactions["1"], []MessageID{EmptyMessageID}, []MessageID{})
+
+	// transaction 2
+	inputs["2C"] = ledgerstate.NewUTXOInput(ledgerstate.NewOutputID(transactions["0"].ID(), selectIndex(transactions["0"], wallets["C"])))
+	outputsByID[inputs["2C"].ReferencedOutputID()] = ledgerstate.NewOutputs(outputs["0C"])[0]
+	outputs["2F"] = ledgerstate.NewSigLockedSingleOutput(1, wallets["F"].address)
+
+	transactions["2"] = makeTransaction(ledgerstate.NewInputs(inputs["2C"]), ledgerstate.NewOutputs(outputs["2F"]), outputsByID, walletsByAddress)
+	messages["2"] = newTestParentsPayloadMessage(transactions["2"], []MessageID{EmptyMessageID}, []MessageID{})
+
+	// store all transactions and messages
+	tangle.Storage.StoreMessage(messages["1"])
+	stored, _, _ := tangle.LedgerState.UTXODAG.StoreTransaction(transactions["1"])
+	assert.True(t, stored)
+	attachment, stored := tangle.Storage.StoreAttachment(transactions["1"].ID(), messages["1"].ID())
+	attachment.Release()
+	assert.True(t, stored)
+
+	tangle.Storage.StoreMessage(messages["2"])
+	stored, _, _ = tangle.LedgerState.UTXODAG.StoreTransaction(transactions["2"])
+	assert.True(t, stored)
+	attachment, stored = tangle.Storage.StoreAttachment(transactions["2"].ID(), messages["2"].ID())
+	attachment.Release()
+	assert.True(t, stored)
+
+	tangle.Storage.StoreMessage(messages["3"])
+	stored, _, _ = tangle.LedgerState.UTXODAG.StoreTransaction(transactions["3"])
+	assert.True(t, stored)
+	attachment, stored = tangle.Storage.StoreAttachment(transactions["3"].ID(), messages["3"].ID())
+	attachment.Release()
+	assert.True(t, stored)
+}

--- a/packages/tangle/eligibilitymanager_test.go
+++ b/packages/tangle/eligibilitymanager_test.go
@@ -19,26 +19,26 @@ func TestDependenciesConfirmed(t *testing.T) {
 	eligibleEventTriggered := false
 	tangle := newTestTangle()
 	defer tangle.Shutdown()
-	wallets, walletsByAddress, messages, transactions, inputs, outputs, outputsByID := setupEligibilityTests(t, tangle)
-	scenarioMessagesApproveEmptyID(t, tangle, wallets, walletsByAddress, messages, transactions, inputs, outputs, outputsByID)
+	wallets, walletsByAddress, assets := setupEligibilityTests(t, tangle)
+	scenarioMessagesApproveEmptyID(t, tangle, wallets, walletsByAddress, assets)
 
 	tangle.EligibilityManager.Events.MessageEligible.Attach(events.NewClosure(func(messageID MessageID) {
-		assert.Equal(t, messages["1"].ID(), messageID)
+		assert.Equal(t, assets.messages["1"].ID(), messageID)
 		eligibleEventTriggered = true
 	}))
 
 	mockUTXO := ledgerstate.NewUtxoDagMock(t, tangle.LedgerState.UTXODAG)
 	tangle.LedgerState.UTXODAG = mockUTXO
-	mockUTXO.On("InclusionState", transactions["0"].ID()).Return(ledgerstate.Pending)
+	mockUTXO.On("InclusionState", assets.transactions["0"].ID()).Return(ledgerstate.Pending)
 
-	isEligibleFlag := runCheckEligibilityAndGetEligibility(t, tangle, messages["1"].ID())
+	isEligibleFlag := runCheckEligibilityAndGetEligibility(t, tangle, assets.messages["1"].ID())
 	assert.False(t, isEligibleFlag, "Message 1 shouldn't be eligible")
 
 	// reset mock, since calls can't be overridden
 	mockUTXO.ExpectedCalls = make([]*mock.Call, 0)
 
-	mockUTXO.On("InclusionState", transactions["0"].ID()).Return(ledgerstate.Confirmed)
-	isEligibleFlag = runCheckEligibilityAndGetEligibility(t, tangle, messages["1"].ID())
+	mockUTXO.On("InclusionState", assets.transactions["0"].ID()).Return(ledgerstate.Confirmed)
+	isEligibleFlag = runCheckEligibilityAndGetEligibility(t, tangle, assets.messages["1"].ID())
 	assert.True(t, isEligibleFlag, "Message 1 isn't eligible")
 
 	assert.True(t, eligibleEventTriggered, "Eligibility event wasn't triggered")
@@ -65,29 +65,29 @@ func TestDependencyDirectApproval(t *testing.T) {
 	tangle := newTestTangle()
 	defer tangle.Shutdown()
 
-	wallets, walletsByAddress, messages, transactions, inputs, outputs, outputsByID := setupEligibilityTests(t, tangle)
+	wallets, walletsByAddress, assets := setupEligibilityTests(t, tangle)
 
-	scenarioMessagesApproveDependency(t, tangle, wallets, walletsByAddress, messages, transactions, inputs, outputs, outputsByID)
+	scenarioMessagesApproveDependency(t, tangle, wallets, walletsByAddress, assets)
 
 	mockUTXO := ledgerstate.NewUtxoDagMock(t, tangle.LedgerState.UTXODAG)
 	tangle.LedgerState.UTXODAG = mockUTXO
-	mockUTXO.On("InclusionState", transactions["0"].ID()).Return(ledgerstate.Pending)
+	mockUTXO.On("InclusionState", assets.transactions["0"].ID()).Return(ledgerstate.Pending)
 
-	isEligibleFlag := runCheckEligibilityAndGetEligibility(t, tangle, messages["1"].ID())
+	isEligibleFlag := runCheckEligibilityAndGetEligibility(t, tangle, assets.messages["1"].ID())
 	assert.True(t, isEligibleFlag, "Message 1 isn't eligible")
 }
 
 func TestUpdateEligibilityAfterDependencyConfirmation(t *testing.T) {
 	tangle := newTestTangle()
 	defer tangle.Shutdown()
-	wallets, walletsByAddress, messages, transactions, inputs, outputs, outputsByID := setupEligibilityTests(t, tangle)
-	txID := transactions["0"].ID()
+	wallets, walletsByAddress, assets := setupEligibilityTests(t, tangle)
+	txID := assets.transactions["0"].ID()
 	eligibleEventTriggered := false
 
-	scenarioMessagesApproveEmptyID(t, tangle, wallets, walletsByAddress, messages, transactions, inputs, outputs, outputsByID)
+	scenarioMessagesApproveEmptyID(t, tangle, wallets, walletsByAddress, assets)
 
 	tangle.EligibilityManager.Events.MessageEligible.Attach(events.NewClosure(func(messageID MessageID) {
-		assert.Equal(t, messages["1"].ID(), messageID)
+		assert.Equal(t, assets.messages["1"].ID(), messageID)
 		eligibleEventTriggered = true
 	}))
 
@@ -95,7 +95,7 @@ func TestUpdateEligibilityAfterDependencyConfirmation(t *testing.T) {
 	tangle.LedgerState.UTXODAG = mockUTXO
 	mockUTXO.On("InclusionState", txID).Return(ledgerstate.Pending)
 
-	messageID := messages["1"].ID()
+	messageID := assets.messages["1"].ID()
 	isEligibleFlag := runCheckEligibilityAndGetEligibility(t, tangle, messageID)
 	assert.False(t, isEligibleFlag, "Message 1 shouldn't be eligible")
 
@@ -117,18 +117,18 @@ func TestUpdateEligibilityAfterDependencyConfirmation(t *testing.T) {
 func TestDoNotUpdateEligibilityAfterPartialDependencyConfirmation(t *testing.T) {
 	tangle := newTestTangle()
 	defer tangle.Shutdown()
-	wallets, walletsByAddress, messages, transactions, inputs, outputs, outputsByID := setupEligibilityTests(t, tangle)
+	wallets, walletsByAddress, assets := setupEligibilityTests(t, tangle)
 
-	scenarioMoreThanOneDependency(t, tangle, wallets, walletsByAddress, messages, transactions, inputs, outputs, outputsByID)
+	scenarioMoreThanOneDependency(t, tangle, wallets, walletsByAddress, assets)
 
 	mockUTXO := ledgerstate.NewUtxoDagMock(t, tangle.LedgerState.UTXODAG)
 	tangle.LedgerState.UTXODAG = mockUTXO
-	tx1ID := transactions["1"].ID()
-	tx2ID := transactions["2"].ID()
+	tx1ID := assets.transactions["1"].ID()
+	tx2ID := assets.transactions["2"].ID()
 	mockUTXO.On("InclusionState", tx1ID).Return(ledgerstate.Pending)
 	mockUTXO.On("InclusionState", tx2ID).Return(ledgerstate.Pending)
 
-	messageID := messages["3"].ID()
+	messageID := assets.messages["3"].ID()
 	isEligibleFlag := runCheckEligibilityAndGetEligibility(t, tangle, messageID)
 	assert.False(t, isEligibleFlag)
 
@@ -160,60 +160,78 @@ func TestDoNotUpdateEligibilityAfterPartialDependencyConfirmation(t *testing.T) 
 func TestConfirmationMakeEligibleOneOfDependentTransaction(t *testing.T) {
 	tangle := newTestTangle()
 	defer tangle.Shutdown()
-	wallets, walletsByAddress, messages, transactions, inputs, outputs, outputsByID := setupEligibilityTests(t, tangle)
-	scenarioMoreThanOneDependentTransaction(t, tangle, wallets, walletsByAddress, messages, transactions, inputs, outputs, outputsByID)
+	wallets, walletsByAddress, assets := setupEligibilityTests(t, tangle)
+	scenarioMoreThanOneDependentTransaction(t, tangle, wallets, walletsByAddress, assets)
 
 	mockUTXO := ledgerstate.NewUtxoDagMock(t, tangle.LedgerState.UTXODAG)
 	tangle.LedgerState.UTXODAG = mockUTXO
-	mockUTXO.On("InclusionState", transactions["3"].ID()).Return(ledgerstate.Pending)
-	mockUTXO.On("InclusionState", transactions["0"].ID()).Return(ledgerstate.Pending)
+	mockUTXO.On("InclusionState", assets.transactions["3"].ID()).Return(ledgerstate.Pending)
+	mockUTXO.On("InclusionState", assets.transactions["0"].ID()).Return(ledgerstate.Pending)
 
-	isEligibleFlag := runCheckEligibilityAndGetEligibility(t, tangle, messages["1"].ID())
+	isEligibleFlag := runCheckEligibilityAndGetEligibility(t, tangle, assets.messages["1"].ID())
 	assert.False(t, isEligibleFlag)
 
-	isEligibleFlag = runCheckEligibilityAndGetEligibility(t, tangle, messages["2"].ID())
+	isEligibleFlag = runCheckEligibilityAndGetEligibility(t, tangle, assets.messages["2"].ID())
 	assert.False(t, isEligibleFlag)
 
 	// reset mock, since calls can't be overridden
 	mockUTXO.ExpectedCalls = make([]*mock.Call, 0)
-	mockUTXO.On("InclusionState", transactions["3"].ID()).Return(ledgerstate.Pending)
-	mockUTXO.On("InclusionState", transactions["0"].ID()).Return(ledgerstate.Confirmed)
+	mockUTXO.On("InclusionState", assets.transactions["3"].ID()).Return(ledgerstate.Pending)
+	mockUTXO.On("InclusionState", assets.transactions["0"].ID()).Return(ledgerstate.Confirmed)
 
-	confirmedTransactionID := transactions["0"].ID()
+	confirmedTransactionID := assets.transactions["0"].ID()
 
 	err := tangle.EligibilityManager.updateEligibilityAfterDependencyConfirmation(&confirmedTransactionID)
 	assert.NoError(t, err)
 
-	tangle.Storage.MessageMetadata(messages["1"].ID()).Consume(func(messageMetadata *MessageMetadata) {
+	tangle.Storage.MessageMetadata(assets.messages["1"].ID()).Consume(func(messageMetadata *MessageMetadata) {
 		isEligibleFlag = messageMetadata.IsEligible()
 	})
 	assert.False(t, isEligibleFlag)
-	tangle.Storage.MessageMetadata(messages["2"].ID()).Consume(func(messageMetadata *MessageMetadata) {
+	tangle.Storage.MessageMetadata(assets.messages["2"].ID()).Consume(func(messageMetadata *MessageMetadata) {
 		isEligibleFlag = messageMetadata.IsEligible()
 	})
 	assert.True(t, isEligibleFlag, "Message 1 isn't eligible")
 
 	// reset mock, since calls can't be overridden
 	mockUTXO.ExpectedCalls = make([]*mock.Call, 0)
-	mockUTXO.On("InclusionState", transactions["3"].ID()).Return(ledgerstate.Confirmed)
-	mockUTXO.On("InclusionState", transactions["0"].ID()).Return(ledgerstate.Confirmed)
+	mockUTXO.On("InclusionState", assets.transactions["3"].ID()).Return(ledgerstate.Confirmed)
+	mockUTXO.On("InclusionState", assets.transactions["0"].ID()).Return(ledgerstate.Confirmed)
 
-	confirmedTransactionID = transactions["3"].ID()
+	confirmedTransactionID = assets.transactions["3"].ID()
 
 	err = tangle.EligibilityManager.updateEligibilityAfterDependencyConfirmation(&confirmedTransactionID)
 	assert.NoError(t, err)
 
-	tangle.Storage.MessageMetadata(messages["1"].ID()).Consume(func(messageMetadata *MessageMetadata) {
+	tangle.Storage.MessageMetadata(assets.messages["1"].ID()).Consume(func(messageMetadata *MessageMetadata) {
 		isEligibleFlag = messageMetadata.IsEligible()
 	})
 	assert.True(t, isEligibleFlag)
-	tangle.Storage.MessageMetadata(messages["2"].ID()).Consume(func(messageMetadata *MessageMetadata) {
+	tangle.Storage.MessageMetadata(assets.messages["2"].ID()).Consume(func(messageMetadata *MessageMetadata) {
 		isEligibleFlag = messageMetadata.IsEligible()
 	})
 	assert.True(t, isEligibleFlag)
 }
 
-func setupEligibilityTests(t *testing.T, tangle *Tangle) (map[string]wallet, map[ledgerstate.Address]wallet, map[string]*Message, map[string]*ledgerstate.Transaction, map[string]*ledgerstate.UTXOInput, map[string]*ledgerstate.SigLockedSingleOutput, map[ledgerstate.OutputID]ledgerstate.Output) {
+type testAssets struct {
+	messages     map[string]*Message
+	transactions map[string]*ledgerstate.Transaction
+	inputs       map[string]*ledgerstate.UTXOInput
+	outputs      map[string]*ledgerstate.SigLockedSingleOutput
+	outputsByID  map[ledgerstate.OutputID]ledgerstate.Output
+}
+
+func newTestAssets() testAssets {
+	return testAssets{
+		messages:     make(map[string]*Message),
+		transactions: make(map[string]*ledgerstate.Transaction),
+		inputs:       make(map[string]*ledgerstate.UTXOInput),
+		outputs:      make(map[string]*ledgerstate.SigLockedSingleOutput),
+		outputsByID:  make(map[ledgerstate.OutputID]ledgerstate.Output),
+	}
+}
+
+func setupEligibilityTests(t *testing.T, tangle *Tangle) (map[string]wallet, map[ledgerstate.Address]wallet, *testAssets) {
 	tangle.EligibilityManager.Setup()
 
 	wallets := make(map[string]wallet)
@@ -249,27 +267,23 @@ func setupEligibilityTests(t *testing.T, tangle *Tangle) (map[string]wallet, map
 	stored, _, _ := tangle.LedgerState.UTXODAG.StoreTransaction(genesisTransaction)
 	assert.True(t, stored, "genesis transaction stored")
 
-	messages := make(map[string]*Message)
-	transactions := make(map[string]*ledgerstate.Transaction)
-	inputs := make(map[string]*ledgerstate.UTXOInput)
-	outputs := make(map[string]*ledgerstate.SigLockedSingleOutput)
-	outputsByID := make(map[ledgerstate.OutputID]ledgerstate.Output)
+	assets := newTestAssets()
 
 	// Base message
-	inputs["GENESIS"] = ledgerstate.NewUTXOInput(ledgerstate.NewOutputID(genesisTransaction.ID(), 0))
-	outputs["0A"] = ledgerstate.NewSigLockedSingleOutput(1, wallets["A"].address)
-	outputs["0B"] = ledgerstate.NewSigLockedSingleOutput(1, wallets["B"].address)
-	outputs["0C"] = ledgerstate.NewSigLockedSingleOutput(1, wallets["C"].address)
-	transactions["0"] = makeTransaction(ledgerstate.NewInputs(inputs["GENESIS"]), ledgerstate.NewOutputs(outputs["0A"], outputs["0B"], outputs["0C"]), outputsByID, walletsByAddress, wallets["GENESIS"])
-	messages["0"] = newTestParentsPayloadMessage(transactions["0"], []MessageID{EmptyMessageID}, []MessageID{})
-	stored, _, _ = tangle.LedgerState.UTXODAG.StoreTransaction(transactions["0"])
+	assets.inputs["GENESIS"] = ledgerstate.NewUTXOInput(ledgerstate.NewOutputID(genesisTransaction.ID(), 0))
+	assets.outputs["0A"] = ledgerstate.NewSigLockedSingleOutput(1, wallets["A"].address)
+	assets.outputs["0B"] = ledgerstate.NewSigLockedSingleOutput(1, wallets["B"].address)
+	assets.outputs["0C"] = ledgerstate.NewSigLockedSingleOutput(1, wallets["C"].address)
+	assets.transactions["0"] = makeTransaction(ledgerstate.NewInputs(assets.inputs["GENESIS"]), ledgerstate.NewOutputs(assets.outputs["0A"], assets.outputs["0B"], assets.outputs["0C"]), assets.outputsByID, walletsByAddress, wallets["GENESIS"])
+	assets.messages["0"] = newTestParentsPayloadMessage(assets.transactions["0"], []MessageID{EmptyMessageID}, []MessageID{})
+	stored, _, _ = tangle.LedgerState.UTXODAG.StoreTransaction(assets.transactions["0"])
 	assert.True(t, stored)
-	tangle.Storage.StoreMessage(messages["0"])
-	attachment, stored := tangle.Storage.StoreAttachment(transactions["0"].ID(), messages["0"].ID())
+	tangle.Storage.StoreMessage(assets.messages["0"])
+	attachment, stored := tangle.Storage.StoreAttachment(assets.transactions["0"].ID(), assets.messages["0"].ID())
 	assert.True(t, stored)
 	attachment.Release()
 
-	return wallets, walletsByAddress, messages, transactions, inputs, outputs, outputsByID
+	return wallets, walletsByAddress, &assets
 }
 
 func runCheckEligibilityAndGetEligibility(t *testing.T, tangle *Tangle, messageID MessageID) bool {
@@ -283,138 +297,138 @@ func runCheckEligibilityAndGetEligibility(t *testing.T, tangle *Tangle, messageI
 }
 
 // create transaction 1 (msg 1) that takes input from tx 0 (msg 0) and does not approve msg 0 directly
-func scenarioMessagesApproveEmptyID(t *testing.T, tangle *Tangle, wallets map[string]wallet, walletsByAddress map[ledgerstate.Address]wallet, messages map[string]*Message, transactions map[string]*ledgerstate.Transaction, inputs map[string]*ledgerstate.UTXOInput, outputs map[string]*ledgerstate.SigLockedSingleOutput, outputsByID map[ledgerstate.OutputID]ledgerstate.Output) {
-	inputs["1A"] = ledgerstate.NewUTXOInput(ledgerstate.NewOutputID(transactions["0"].ID(), selectIndex(transactions["0"], wallets["A"])))
-	outputsByID[inputs["1A"].ReferencedOutputID()] = ledgerstate.NewOutputs(outputs["0A"])[0]
+func scenarioMessagesApproveEmptyID(t *testing.T, tangle *Tangle, wallets map[string]wallet, walletsByAddress map[ledgerstate.Address]wallet, assets *testAssets) {
+	assets.inputs["1A"] = ledgerstate.NewUTXOInput(ledgerstate.NewOutputID(assets.transactions["0"].ID(), selectIndex(assets.transactions["0"], wallets["A"])))
+	assets.outputsByID[assets.inputs["1A"].ReferencedOutputID()] = ledgerstate.NewOutputs(assets.outputs["0A"])[0]
 
-	outputs["1D"] = ledgerstate.NewSigLockedSingleOutput(1, wallets["D"].address)
-	transactions["1"] = makeTransaction(ledgerstate.NewInputs(inputs["1A"]), ledgerstate.NewOutputs(outputs["1D"]), outputsByID, walletsByAddress)
-	messages["1"] = newTestParentsPayloadMessage(transactions["1"], []MessageID{EmptyMessageID}, []MessageID{})
+	assets.outputs["1D"] = ledgerstate.NewSigLockedSingleOutput(1, wallets["D"].address)
+	assets.transactions["1"] = makeTransaction(ledgerstate.NewInputs(assets.inputs["1A"]), ledgerstate.NewOutputs(assets.outputs["1D"]), assets.outputsByID, walletsByAddress)
+	assets.messages["1"] = newTestParentsPayloadMessage(assets.transactions["1"], []MessageID{EmptyMessageID}, []MessageID{})
 
-	tangle.Storage.StoreMessage(messages["1"])
-	stored, _, _ := tangle.LedgerState.UTXODAG.StoreTransaction(transactions["1"])
+	tangle.Storage.StoreMessage(assets.messages["1"])
+	stored, _, _ := tangle.LedgerState.UTXODAG.StoreTransaction(assets.transactions["1"])
 	assert.True(t, stored)
 
-	attachment, stored := tangle.Storage.StoreAttachment(transactions["1"].ID(), messages["1"].ID())
+	attachment, stored := tangle.Storage.StoreAttachment(assets.transactions["1"].ID(), assets.messages["1"].ID())
 	assert.True(t, stored)
 	attachment.Release()
 }
 
 // creates tx and msg 1 that directly approves msg 0 and uses tx0 outputs as its inputs
-func scenarioMessagesApproveDependency(t *testing.T, tangle *Tangle, wallets map[string]wallet, walletsByAddress map[ledgerstate.Address]wallet, messages map[string]*Message, transactions map[string]*ledgerstate.Transaction, inputs map[string]*ledgerstate.UTXOInput, outputs map[string]*ledgerstate.SigLockedSingleOutput, outputsByID map[ledgerstate.OutputID]ledgerstate.Output) {
-	inputs["1A"] = ledgerstate.NewUTXOInput(ledgerstate.NewOutputID(transactions["0"].ID(), selectIndex(transactions["0"], wallets["A"])))
-	outputsByID[inputs["1A"].ReferencedOutputID()] = ledgerstate.NewOutputs(outputs["0A"])[0]
-	outputs["1D"] = ledgerstate.NewSigLockedSingleOutput(1, wallets["D"].address)
+func scenarioMessagesApproveDependency(t *testing.T, tangle *Tangle, wallets map[string]wallet, walletsByAddress map[ledgerstate.Address]wallet, assets *testAssets) {
+	assets.inputs["1A"] = ledgerstate.NewUTXOInput(ledgerstate.NewOutputID(assets.transactions["0"].ID(), selectIndex(assets.transactions["0"], wallets["A"])))
+	assets.outputsByID[assets.inputs["1A"].ReferencedOutputID()] = ledgerstate.NewOutputs(assets.outputs["0A"])[0]
+	assets.outputs["1D"] = ledgerstate.NewSigLockedSingleOutput(1, wallets["D"].address)
 
-	transactions["1"] = makeTransaction(ledgerstate.NewInputs(inputs["1A"]), ledgerstate.NewOutputs(outputs["1D"]), outputsByID, walletsByAddress)
-	messages["1"] = newTestParentsPayloadMessage(transactions["1"], []MessageID{messages["0"].ID()}, []MessageID{})
+	assets.transactions["1"] = makeTransaction(ledgerstate.NewInputs(assets.inputs["1A"]), ledgerstate.NewOutputs(assets.outputs["1D"]), assets.outputsByID, walletsByAddress)
+	assets.messages["1"] = newTestParentsPayloadMessage(assets.transactions["1"], []MessageID{assets.messages["0"].ID()}, []MessageID{})
 
-	tangle.Storage.StoreMessage(messages["1"])
-	stored, _, _ := tangle.LedgerState.UTXODAG.StoreTransaction(transactions["1"])
+	tangle.Storage.StoreMessage(assets.messages["1"])
+	stored, _, _ := tangle.LedgerState.UTXODAG.StoreTransaction(assets.transactions["1"])
 	assert.True(t, stored)
 
-	attachment, stored := tangle.Storage.StoreAttachment(transactions["1"].ID(), messages["1"].ID())
+	attachment, stored := tangle.Storage.StoreAttachment(assets.transactions["1"].ID(), assets.messages["1"].ID())
 	assert.True(t, stored)
 	attachment.Release()
 }
 
-// creates transaction that is dependent on two other transactions and is not connected by direct approval of their messages
-func scenarioMoreThanOneDependency(t *testing.T, tangle *Tangle, wallets map[string]wallet, walletsByAddress map[ledgerstate.Address]wallet, messages map[string]*Message, transactions map[string]*ledgerstate.Transaction, inputs map[string]*ledgerstate.UTXOInput, outputs map[string]*ledgerstate.SigLockedSingleOutput, outputsByID map[ledgerstate.OutputID]ledgerstate.Output) {
+// creates transaction that is dependent on two other transactions and is not connected by direct approval of their assets.messages
+func scenarioMoreThanOneDependency(t *testing.T, tangle *Tangle, wallets map[string]wallet, walletsByAddress map[ledgerstate.Address]wallet, assets *testAssets) {
 	// transaction 1
-	inputs["1A"] = ledgerstate.NewUTXOInput(ledgerstate.NewOutputID(transactions["0"].ID(), selectIndex(transactions["0"], wallets["A"])))
-	outputsByID[inputs["1A"].ReferencedOutputID()] = ledgerstate.NewOutputs(outputs["0A"])[0]
-	outputs["1D"] = ledgerstate.NewSigLockedSingleOutput(1, wallets["D"].address)
+	assets.inputs["1A"] = ledgerstate.NewUTXOInput(ledgerstate.NewOutputID(assets.transactions["0"].ID(), selectIndex(assets.transactions["0"], wallets["A"])))
+	assets.outputsByID[assets.inputs["1A"].ReferencedOutputID()] = ledgerstate.NewOutputs(assets.outputs["0A"])[0]
+	assets.outputs["1D"] = ledgerstate.NewSigLockedSingleOutput(1, wallets["D"].address)
 
-	transactions["1"] = makeTransaction(ledgerstate.NewInputs(inputs["1A"]), ledgerstate.NewOutputs(outputs["1D"]), outputsByID, walletsByAddress)
-	messages["1"] = newTestParentsPayloadMessage(transactions["1"], []MessageID{EmptyMessageID}, []MessageID{})
+	assets.transactions["1"] = makeTransaction(ledgerstate.NewInputs(assets.inputs["1A"]), ledgerstate.NewOutputs(assets.outputs["1D"]), assets.outputsByID, walletsByAddress)
+	assets.messages["1"] = newTestParentsPayloadMessage(assets.transactions["1"], []MessageID{EmptyMessageID}, []MessageID{})
 
 	// transaction 2
-	inputs["2B"] = ledgerstate.NewUTXOInput(ledgerstate.NewOutputID(transactions["0"].ID(), selectIndex(transactions["0"], wallets["B"])))
-	outputsByID[inputs["2B"].ReferencedOutputID()] = ledgerstate.NewOutputs(outputs["0B"])[0]
-	outputs["2E"] = ledgerstate.NewSigLockedSingleOutput(1, wallets["E"].address)
+	assets.inputs["2B"] = ledgerstate.NewUTXOInput(ledgerstate.NewOutputID(assets.transactions["0"].ID(), selectIndex(assets.transactions["0"], wallets["B"])))
+	assets.outputsByID[assets.inputs["2B"].ReferencedOutputID()] = ledgerstate.NewOutputs(assets.outputs["0B"])[0]
+	assets.outputs["2E"] = ledgerstate.NewSigLockedSingleOutput(1, wallets["E"].address)
 
-	transactions["2"] = makeTransaction(ledgerstate.NewInputs(inputs["2B"]), ledgerstate.NewOutputs(outputs["2E"]), outputsByID, walletsByAddress)
-	messages["2"] = newTestParentsPayloadMessage(transactions["2"], []MessageID{EmptyMessageID}, []MessageID{})
+	assets.transactions["2"] = makeTransaction(ledgerstate.NewInputs(assets.inputs["2B"]), ledgerstate.NewOutputs(assets.outputs["2E"]), assets.outputsByID, walletsByAddress)
+	assets.messages["2"] = newTestParentsPayloadMessage(assets.transactions["2"], []MessageID{EmptyMessageID}, []MessageID{})
 
 	// transaction 3 dependent on transactions 1 and 2
-	inputs["3D"] = ledgerstate.NewUTXOInput(ledgerstate.NewOutputID(transactions["1"].ID(), selectIndex(transactions["1"], wallets["D"])))
-	outputsByID[inputs["3D"].ReferencedOutputID()] = ledgerstate.NewOutputs(outputs["1D"])[0]
-	inputs["3E"] = ledgerstate.NewUTXOInput(ledgerstate.NewOutputID(transactions["2"].ID(), selectIndex(transactions["2"], wallets["E"])))
-	outputsByID[inputs["3E"].ReferencedOutputID()] = ledgerstate.NewOutputs(outputs["2E"])[0]
-	outputs["3F"] = ledgerstate.NewSigLockedSingleOutput(1, wallets["F"].address)
+	assets.inputs["3D"] = ledgerstate.NewUTXOInput(ledgerstate.NewOutputID(assets.transactions["1"].ID(), selectIndex(assets.transactions["1"], wallets["D"])))
+	assets.outputsByID[assets.inputs["3D"].ReferencedOutputID()] = ledgerstate.NewOutputs(assets.outputs["1D"])[0]
+	assets.inputs["3E"] = ledgerstate.NewUTXOInput(ledgerstate.NewOutputID(assets.transactions["2"].ID(), selectIndex(assets.transactions["2"], wallets["E"])))
+	assets.outputsByID[assets.inputs["3E"].ReferencedOutputID()] = ledgerstate.NewOutputs(assets.outputs["2E"])[0]
+	assets.outputs["3F"] = ledgerstate.NewSigLockedSingleOutput(1, wallets["F"].address)
 
-	transactions["3"] = makeTransaction(ledgerstate.NewInputs(inputs["3D"], inputs["3E"]), ledgerstate.NewOutputs(outputs["3F"]), outputsByID, walletsByAddress)
-	messages["3"] = newTestParentsPayloadMessage(transactions["3"], []MessageID{EmptyMessageID}, []MessageID{})
+	assets.transactions["3"] = makeTransaction(ledgerstate.NewInputs(assets.inputs["3D"], assets.inputs["3E"]), ledgerstate.NewOutputs(assets.outputs["3F"]), assets.outputsByID, walletsByAddress)
+	assets.messages["3"] = newTestParentsPayloadMessage(assets.transactions["3"], []MessageID{EmptyMessageID}, []MessageID{})
 
-	// store all transactions and messages
-	tangle.Storage.StoreMessage(messages["1"])
-	stored, _, _ := tangle.LedgerState.UTXODAG.StoreTransaction(transactions["1"])
+	// store all transactions and assets.messages
+	tangle.Storage.StoreMessage(assets.messages["1"])
+	stored, _, _ := tangle.LedgerState.UTXODAG.StoreTransaction(assets.transactions["1"])
 	assert.True(t, stored)
-	attachment, stored := tangle.Storage.StoreAttachment(transactions["1"].ID(), messages["1"].ID())
+	attachment, stored := tangle.Storage.StoreAttachment(assets.transactions["1"].ID(), assets.messages["1"].ID())
 	attachment.Release()
 	assert.True(t, stored)
-	tangle.Storage.StoreMessage(messages["3"])
-	stored, _, _ = tangle.LedgerState.UTXODAG.StoreTransaction(transactions["3"])
+	tangle.Storage.StoreMessage(assets.messages["3"])
+	stored, _, _ = tangle.LedgerState.UTXODAG.StoreTransaction(assets.transactions["3"])
 	assert.True(t, stored)
-	attachment, stored = tangle.Storage.StoreAttachment(transactions["3"].ID(), messages["3"].ID())
+	attachment, stored = tangle.Storage.StoreAttachment(assets.transactions["3"].ID(), assets.messages["3"].ID())
 	attachment.Release()
 	assert.True(t, stored)
-	tangle.Storage.StoreMessage(messages["2"])
-	stored, _, _ = tangle.LedgerState.UTXODAG.StoreTransaction(transactions["2"])
+	tangle.Storage.StoreMessage(assets.messages["2"])
+	stored, _, _ = tangle.LedgerState.UTXODAG.StoreTransaction(assets.transactions["2"])
 	assert.True(t, stored)
-	attachment, stored = tangle.Storage.StoreAttachment(transactions["2"].ID(), messages["2"].ID())
+	attachment, stored = tangle.Storage.StoreAttachment(assets.transactions["2"].ID(), assets.messages["2"].ID())
 	attachment.Release()
 	assert.True(t, stored)
 }
 
 // two transactions 1 and 2 are dependent on the same transaction 0 and are not connected by direct approval between messages
 // transaction is also dependent on other transaction 3 that will get confirmed before 0
-func scenarioMoreThanOneDependentTransaction(t *testing.T, tangle *Tangle, wallets map[string]wallet, walletsByAddress map[ledgerstate.Address]wallet, messages map[string]*Message, transactions map[string]*ledgerstate.Transaction, inputs map[string]*ledgerstate.UTXOInput, outputs map[string]*ledgerstate.SigLockedSingleOutput, outputsByID map[ledgerstate.OutputID]ledgerstate.Output) {
+func scenarioMoreThanOneDependentTransaction(t *testing.T, tangle *Tangle, wallets map[string]wallet, walletsByAddress map[ledgerstate.Address]wallet, assets *testAssets) {
 	// transaction 3
-	inputs["3B"] = ledgerstate.NewUTXOInput(ledgerstate.NewOutputID(transactions["0"].ID(), selectIndex(transactions["0"], wallets["B"])))
-	outputsByID[inputs["3B"].ReferencedOutputID()] = ledgerstate.NewOutputs(outputs["0B"])[0]
-	outputs["3E"] = ledgerstate.NewSigLockedSingleOutput(2, wallets["E"].address)
+	assets.inputs["3B"] = ledgerstate.NewUTXOInput(ledgerstate.NewOutputID(assets.transactions["0"].ID(), selectIndex(assets.transactions["0"], wallets["B"])))
+	assets.outputsByID[assets.inputs["3B"].ReferencedOutputID()] = ledgerstate.NewOutputs(assets.outputs["0B"])[0]
+	assets.outputs["3E"] = ledgerstate.NewSigLockedSingleOutput(2, wallets["E"].address)
 
-	transactions["3"] = makeTransaction(ledgerstate.NewInputs(inputs["3B"]), ledgerstate.NewOutputs(outputs["3E"]), outputsByID, walletsByAddress)
-	messages["3"] = newTestParentsPayloadMessage(transactions["3"], []MessageID{EmptyMessageID}, []MessageID{})
+	assets.transactions["3"] = makeTransaction(ledgerstate.NewInputs(assets.inputs["3B"]), ledgerstate.NewOutputs(assets.outputs["3E"]), assets.outputsByID, walletsByAddress)
+	assets.messages["3"] = newTestParentsPayloadMessage(assets.transactions["3"], []MessageID{EmptyMessageID}, []MessageID{})
 
 	// transaction 1
-	inputs["1A"] = ledgerstate.NewUTXOInput(ledgerstate.NewOutputID(transactions["0"].ID(), selectIndex(transactions["0"], wallets["A"])))
-	outputsByID[inputs["1A"].ReferencedOutputID()] = ledgerstate.NewOutputs(outputs["0A"])[0]
-	inputs["1E"] = ledgerstate.NewUTXOInput(ledgerstate.NewOutputID(transactions["3"].ID(), selectIndex(transactions["3"], wallets["E"])))
-	outputsByID[inputs["1E"].ReferencedOutputID()] = ledgerstate.NewOutputs(outputs["3E"])[0]
-	outputs["1D"] = ledgerstate.NewSigLockedSingleOutput(2, wallets["D"].address)
+	assets.inputs["1A"] = ledgerstate.NewUTXOInput(ledgerstate.NewOutputID(assets.transactions["0"].ID(), selectIndex(assets.transactions["0"], wallets["A"])))
+	assets.outputsByID[assets.inputs["1A"].ReferencedOutputID()] = ledgerstate.NewOutputs(assets.outputs["0A"])[0]
+	assets.inputs["1E"] = ledgerstate.NewUTXOInput(ledgerstate.NewOutputID(assets.transactions["3"].ID(), selectIndex(assets.transactions["3"], wallets["E"])))
+	assets.outputsByID[assets.inputs["1E"].ReferencedOutputID()] = ledgerstate.NewOutputs(assets.outputs["3E"])[0]
+	assets.outputs["1D"] = ledgerstate.NewSigLockedSingleOutput(2, wallets["D"].address)
 
-	transactions["1"] = makeTransaction(ledgerstate.NewInputs(inputs["1A"], inputs["1E"]), ledgerstate.NewOutputs(outputs["1D"]), outputsByID, walletsByAddress)
-	messages["1"] = newTestParentsPayloadMessage(transactions["1"], []MessageID{EmptyMessageID}, []MessageID{})
+	assets.transactions["1"] = makeTransaction(ledgerstate.NewInputs(assets.inputs["1A"], assets.inputs["1E"]), ledgerstate.NewOutputs(assets.outputs["1D"]), assets.outputsByID, walletsByAddress)
+	assets.messages["1"] = newTestParentsPayloadMessage(assets.transactions["1"], []MessageID{EmptyMessageID}, []MessageID{})
 
 	// transaction 2
-	inputs["2C"] = ledgerstate.NewUTXOInput(ledgerstate.NewOutputID(transactions["0"].ID(), selectIndex(transactions["0"], wallets["C"])))
-	outputsByID[inputs["2C"].ReferencedOutputID()] = ledgerstate.NewOutputs(outputs["0C"])[0]
-	outputs["2F"] = ledgerstate.NewSigLockedSingleOutput(1, wallets["F"].address)
+	assets.inputs["2C"] = ledgerstate.NewUTXOInput(ledgerstate.NewOutputID(assets.transactions["0"].ID(), selectIndex(assets.transactions["0"], wallets["C"])))
+	assets.outputsByID[assets.inputs["2C"].ReferencedOutputID()] = ledgerstate.NewOutputs(assets.outputs["0C"])[0]
+	assets.outputs["2F"] = ledgerstate.NewSigLockedSingleOutput(1, wallets["F"].address)
 
-	transactions["2"] = makeTransaction(ledgerstate.NewInputs(inputs["2C"]), ledgerstate.NewOutputs(outputs["2F"]), outputsByID, walletsByAddress)
-	messages["2"] = newTestParentsPayloadMessage(transactions["2"], []MessageID{EmptyMessageID}, []MessageID{})
+	assets.transactions["2"] = makeTransaction(ledgerstate.NewInputs(assets.inputs["2C"]), ledgerstate.NewOutputs(assets.outputs["2F"]), assets.outputsByID, walletsByAddress)
+	assets.messages["2"] = newTestParentsPayloadMessage(assets.transactions["2"], []MessageID{EmptyMessageID}, []MessageID{})
 
 	// store all transactions and messages
-	tangle.Storage.StoreMessage(messages["1"])
-	stored, _, _ := tangle.LedgerState.UTXODAG.StoreTransaction(transactions["1"])
+	tangle.Storage.StoreMessage(assets.messages["1"])
+	stored, _, _ := tangle.LedgerState.UTXODAG.StoreTransaction(assets.transactions["1"])
 	assert.True(t, stored)
-	attachment, stored := tangle.Storage.StoreAttachment(transactions["1"].ID(), messages["1"].ID())
+	attachment, stored := tangle.Storage.StoreAttachment(assets.transactions["1"].ID(), assets.messages["1"].ID())
 	attachment.Release()
 	assert.True(t, stored)
 
-	tangle.Storage.StoreMessage(messages["2"])
-	stored, _, _ = tangle.LedgerState.UTXODAG.StoreTransaction(transactions["2"])
+	tangle.Storage.StoreMessage(assets.messages["2"])
+	stored, _, _ = tangle.LedgerState.UTXODAG.StoreTransaction(assets.transactions["2"])
 	assert.True(t, stored)
-	attachment, stored = tangle.Storage.StoreAttachment(transactions["2"].ID(), messages["2"].ID())
+	attachment, stored = tangle.Storage.StoreAttachment(assets.transactions["2"].ID(), assets.messages["2"].ID())
 	attachment.Release()
 	assert.True(t, stored)
 
-	tangle.Storage.StoreMessage(messages["3"])
-	stored, _, _ = tangle.LedgerState.UTXODAG.StoreTransaction(transactions["3"])
+	tangle.Storage.StoreMessage(assets.messages["3"])
+	stored, _, _ = tangle.LedgerState.UTXODAG.StoreTransaction(assets.transactions["3"])
 	assert.True(t, stored)
-	attachment, stored = tangle.Storage.StoreAttachment(transactions["3"].ID(), messages["3"].ID())
+	attachment, stored = tangle.Storage.StoreAttachment(assets.transactions["3"].ID(), assets.messages["3"].ID())
 	attachment.Release()
 	assert.True(t, stored)
 }

--- a/packages/tangle/eligibilitymanager_test.go
+++ b/packages/tangle/eligibilitymanager_test.go
@@ -58,7 +58,7 @@ func TestDataMessageAlwaysEligible(t *testing.T) {
 	tangle.Storage.MessageMetadata(message.ID()).Consume(func(messageMetadata *MessageMetadata) {
 		eligibilityResult = messageMetadata.IsEligible()
 	})
-	assert.True(t, eligibilityResult, "Data messages should awlays be eligible")
+	assert.True(t, eligibilityResult, "Data messages should always be eligible")
 }
 
 func TestDependencyDirectApproval(t *testing.T) {

--- a/packages/tangle/ledgerstate.go
+++ b/packages/tangle/ledgerstate.go
@@ -17,7 +17,7 @@ import (
 type LedgerState struct {
 	tangle    *Tangle
 	BranchDAG *ledgerstate.BranchDAG
-	UTXODAG   *ledgerstate.UTXODAG
+	UTXODAG   ledgerstate.IUTXODAG
 
 	totalSupply uint64
 }

--- a/packages/tangle/storage.go
+++ b/packages/tangle/storage.go
@@ -241,7 +241,7 @@ func (s *Storage) UnconfirmedTransactionDependencies(transactionID ledgerstate.T
 			return computeIfAbsentCallback[0]()
 		})}
 	}
-	return &CachedUnconfirmedTxDependency{CachedObject: s.unconfirmedTxDependenciesStorage.Load(transactionID[:])}
+	return &CachedUnconfirmedTxDependency{CachedObject: s.unconfirmedTxDependenciesStorage.Load(transactionID.Bytes())}
 }
 
 // StoreAttachment stores a new attachment if not already stored.
@@ -1218,15 +1218,6 @@ func (u *UnconfirmedTxDependency) ObjectStorageValue() []byte {
 // accessor methods with a type-casted one.
 type CachedUnconfirmedTxDependency struct {
 	objectstorage.CachedObject
-}
-
-// ID returns the dependency transactionID of the UnconfirmedTxDependency.
-func (c *CachedUnconfirmedTxDependency) ID() (id ledgerstate.TransactionID) {
-	id, _, err := ledgerstate.TransactionIDFromBytes(c.Key())
-	if err != nil {
-		panic(err)
-	}
-	return
 }
 
 // Retain marks the CachedObject to still be in use by the program.

--- a/packages/tangle/storage.go
+++ b/packages/tangle/storage.go
@@ -1166,7 +1166,7 @@ type UnconfirmedTxDependency struct {
 func NewUnconfirmedTxDependency(txID ledgerstate.TransactionID) *UnconfirmedTxDependency {
 	return &UnconfirmedTxDependency{
 		transactionID:  txID,
-		txDependentIDs: make(ledgerstate.TransactionIDs, 0),
+		txDependentIDs: make(ledgerstate.TransactionIDs),
 	}
 }
 
@@ -1188,10 +1188,14 @@ func (u *UnconfirmedTxDependency) DeleteDependency(txID ledgerstate.TransactionI
 	u.SetModified()
 }
 
+// Update update the UnconfirmedTxDependency.
+// It should never happen and will panic if called.
 func (u *UnconfirmedTxDependency) Update(other objectstorage.StorableObject) {
 	panic("UnconfirmedTxDependency shouldn't be updated this way")
 }
 
+// ObjectStorageKey returns the key of the stored UnconfirmedTxDependency.
+// This returns the bytes of the transactionID of the dependency transaction.
 func (u *UnconfirmedTxDependency) ObjectStorageKey() []byte {
 	u.mutex.RLock()
 	defer u.mutex.RUnlock()
@@ -1199,6 +1203,7 @@ func (u *UnconfirmedTxDependency) ObjectStorageKey() []byte {
 	return u.transactionID.Bytes()
 }
 
+// ObjectStorageValue returns the value of the stored UnconfirmedTxDependency.
 func (u *UnconfirmedTxDependency) ObjectStorageValue() []byte {
 	u.mutex.RLock()
 	defer u.mutex.RUnlock()

--- a/packages/tangle/storage.go
+++ b/packages/tangle/storage.go
@@ -476,6 +476,7 @@ func (s *Storage) Shutdown() {
 	s.statementStorage.Shutdown()
 	s.branchWeightStorage.Shutdown()
 	s.markerMessageMappingStorage.Shutdown()
+	s.unconfirmedTxDependenciesStorage.Shutdown()
 
 	close(s.shutdown)
 }
@@ -495,6 +496,7 @@ func (s *Storage) Prune() error {
 		s.statementStorage,
 		s.branchWeightStorage,
 		s.markerMessageMappingStorage,
+		s.unconfirmedTxDependenciesStorage,
 	} {
 		if err := storage.Prune(); err != nil {
 			err = fmt.Errorf("failed to prune storage: %w", err)
@@ -1227,7 +1229,6 @@ type CachedUnconfirmedTxDependency struct {
 	objectstorage.CachedObject
 }
 
-//TODO what for?
 // ID returns the dependency transactionID of the UnconfirmedTxDependency.
 func (c *CachedUnconfirmedTxDependency) ID() (id ledgerstate.TransactionID) {
 	id, _, err := ledgerstate.TransactionIDFromBytes(c.Key())

--- a/packages/tangle/storage.go
+++ b/packages/tangle/storage.go
@@ -113,7 +113,7 @@ func NewStorage(tangle *Tangle) (storage *Storage) {
 		statementStorage:                  osFactory.New(PrefixStatement, StatementFromObjectStorage, cacheProvider.CacheTime(cacheTime), objectstorage.LeakDetectionEnabled(false)),
 		branchWeightStorage:               osFactory.New(PrefixBranchWeight, BranchWeightFromObjectStorage, cacheProvider.CacheTime(cacheTime), objectstorage.LeakDetectionEnabled(false)),
 		markerMessageMappingStorage:       osFactory.New(PrefixMarkerMessageMapping, MarkerMessageMappingFromObjectStorage, cacheProvider.CacheTime(cacheTime), MarkerMessageMappingPartitionKeys, objectstorage.StoreOnCreation(true)),
-		unconfirmedTxDependenciesStorage:  osFactory.New(PrefixUnconfirmedTxDependencies, UnconfirmedTxDependenciesFromObjectStorage, cacheProvider.CacheTime(cacheTime), objectstorage.LeakDetectionEnabled(false), UnconfirmedTxDependencyPartitionKeys),
+		unconfirmedTxDependenciesStorage:  osFactory.New(PrefixUnconfirmedTxDependencies, UnconfirmedTxDependenciesFromObjectStorage, cacheProvider.CacheTime(cacheTime)),
 
 		Events: &StorageEvents{
 			MessageStored:        events.NewEvent(MessageIDCaller),
@@ -459,7 +459,7 @@ func (s *Storage) deleteWeakApprover(approvedMessageID MessageID, approvingMessa
 	s.approverStorage.Delete(byteutils.ConcatBytes(approvedMessageID.Bytes(), WeakApprover.Bytes(), approvingMessage.Bytes()))
 }
 
-func (s *Storage) deleteUnconfirmedTxDependencies(transactionID *ledgerstate.TransactionID) {
+func (s *Storage) deleteUnconfirmedTxDependencies(transactionID ledgerstate.TransactionID) {
 	s.unconfirmedTxDependenciesStorage.Delete(transactionID.Bytes())
 }
 

--- a/packages/tangle/storage.go
+++ b/packages/tangle/storage.go
@@ -247,6 +247,7 @@ func (s *Storage) UnconfirmedTransactionDependencies(transactionID *ledgerstate.
 			matchedCachedDependencies = &cachedDependencies
 			return false
 		}
+		cachedDependencies.Release()
 		return true
 	})
 	return

--- a/packages/tangle/storage.go
+++ b/packages/tangle/storage.go
@@ -3,7 +3,10 @@ package tangle
 import (
 	"fmt"
 	"strconv"
+	"sync"
 	"time"
+
+	"github.com/iotaledger/hive.go/types"
 
 	"github.com/cockroachdb/errors"
 	"github.com/iotaledger/hive.go/byteutils"
@@ -57,6 +60,9 @@ const (
 	// PrefixMarkerMessageMapping defines the storage prefix for the MarkerMessageMapping.
 	PrefixMarkerMessageMapping
 
+	// PrefixUnconfirmedTxDependencies defines the storage prefix for the
+	PrefixUnconfirmedTxDependencies
+
 	// DBSequenceNumber defines the db sequence number.
 	DBSequenceNumber = "seq"
 
@@ -81,6 +87,7 @@ type Storage struct {
 	statementStorage                  *objectstorage.ObjectStorage
 	branchWeightStorage               *objectstorage.ObjectStorage
 	markerMessageMappingStorage       *objectstorage.ObjectStorage
+	unconfirmedTxDependenciesStorage  *objectstorage.ObjectStorage
 
 	Events   *StorageEvents
 	shutdown chan struct{}
@@ -106,6 +113,7 @@ func NewStorage(tangle *Tangle) (storage *Storage) {
 		statementStorage:                  osFactory.New(PrefixStatement, StatementFromObjectStorage, cacheProvider.CacheTime(cacheTime), objectstorage.LeakDetectionEnabled(false)),
 		branchWeightStorage:               osFactory.New(PrefixBranchWeight, BranchWeightFromObjectStorage, cacheProvider.CacheTime(cacheTime), objectstorage.LeakDetectionEnabled(false)),
 		markerMessageMappingStorage:       osFactory.New(PrefixMarkerMessageMapping, MarkerMessageMappingFromObjectStorage, cacheProvider.CacheTime(cacheTime), MarkerMessageMappingPartitionKeys, objectstorage.StoreOnCreation(true)),
+		unconfirmedTxDependenciesStorage:  osFactory.New(PrefixUnconfirmedTxDependencies, UnconfirmedTxDependenciesFromObjectStorage, cacheProvider.CacheTime(cacheTime), objectstorage.LeakDetectionEnabled(false), UnconfirmedTxDependencyPartitionKeys),
 
 		Events: &StorageEvents{
 			MessageStored:        events.NewEvent(MessageIDCaller),
@@ -222,6 +230,21 @@ func (s *Storage) MissingMessages() (ids []MessageID) {
 
 		return true
 	})
+	return
+}
+
+// StoreUnconfirmedTransactionDependencies stores the dependencies
+func (s *Storage) StoreUnconfirmedTransactionDependencies(dependencies *UnconfirmedTxDependency) *CachedUnconfirmedTxDependency {
+	cachedDependencies := s.unconfirmedTxDependenciesStorage.Store(dependencies)
+	return &CachedUnconfirmedTxDependency{CachedObject: cachedDependencies}
+}
+
+// UnconfirmedTransactionDependencies gets the CachedUnconfirmedTransactionDependencies from the objectStorage that matches provided transactionID
+func (s *Storage) UnconfirmedTransactionDependencies(transactionID *ledgerstate.TransactionID) (cachedDependencies *CachedUnconfirmedTxDependency) {
+	cachedObject := s.unconfirmedTxDependenciesStorage.Load(transactionID.Bytes())
+	if !typeutils.IsInterfaceNil(cachedObject) {
+		cachedDependencies = &CachedUnconfirmedTxDependency{CachedObject: cachedObject}
+	}
 	return
 }
 
@@ -429,6 +452,10 @@ func (s *Storage) deleteStrongApprover(approvedMessageID MessageID, approvingMes
 // deleteWeakApprover deletes an Approver from the object storage that was created by a weak parent.
 func (s *Storage) deleteWeakApprover(approvedMessageID MessageID, approvingMessage MessageID) {
 	s.approverStorage.Delete(byteutils.ConcatBytes(approvedMessageID.Bytes(), WeakApprover.Bytes(), approvingMessage.Bytes()))
+}
+
+func (s *Storage) deleteUnconfirmedTxDependencies(transactionID *ledgerstate.TransactionID) {
+	s.unconfirmedTxDependenciesStorage.Delete(transactionID.Bytes())
 }
 
 // Shutdown marks the tangle as stopped, so it will not accept any new messages (waits for all backgroundTasks to finish).
@@ -1070,8 +1097,6 @@ func (m *MissingMessage) ObjectStorageValue() (result []byte) {
 		Bytes()
 }
 
-// endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
-
 // region CachedMissingMessage /////////////////////////////////////////////////////////////////////////////////////////
 
 // CachedMissingMessage is a wrapper for the generic CachedObject returned by the object storage that overrides the
@@ -1121,6 +1146,114 @@ func (c *CachedMissingMessage) Consume(consumer func(missingMessage *MissingMess
 // String returns a human readable version of the CachedMissingMessage.
 func (c *CachedMissingMessage) String() string {
 	return stringify.Struct("CachedMissingMessage",
+		stringify.StructField("CachedObject", c.Unwrap()),
+	)
+}
+
+// endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// region UnconfirmedTxDependency //////////////////////////////////////////////////////////////////////////////////////
+
+var UnconfirmedTxDependencyPartitionKeys = objectstorage.PartitionKey(ledgerstate.TransactionIDLength)
+
+// UnconfirmedTxDependency maps a transaction to all of the transactions that create its inputs which are not yet confirmed
+type UnconfirmedTxDependency struct {
+	objectstorage.StorableObjectFlags
+
+	dependencyTxID ledgerstate.TransactionID
+	dependentTxIDs ledgerstate.TransactionIDs
+	mutex          sync.RWMutex
+}
+
+// NewUnconfirmedTxDependency creates an empty mapping for txID
+func NewUnconfirmedTxDependency(txID *ledgerstate.TransactionID) *UnconfirmedTxDependency {
+	return &UnconfirmedTxDependency{
+		dependencyTxID: *txID,
+		dependentTxIDs: make(ledgerstate.TransactionIDs, 0),
+	}
+}
+
+// AddDependency adds a transaction id dependency
+func (u *UnconfirmedTxDependency) AddDependency(txID *ledgerstate.TransactionID) {
+	u.mutex.Lock()
+	defer u.mutex.Unlock()
+
+	u.dependentTxIDs[*txID] = types.Void
+}
+
+// DeleteDependency deletes a transaction id dependency
+func (u *UnconfirmedTxDependency) DeleteDependency(txID ledgerstate.TransactionID) {
+	u.mutex.Lock()
+	defer u.mutex.Unlock()
+
+	if _, ok := u.dependentTxIDs[txID]; ok {
+		delete(u.dependentTxIDs, txID)
+	}
+}
+
+func (u *UnconfirmedTxDependency) Update(other objectstorage.StorableObject) {
+	panic("UnconfirmedTxDependency shouldn't be updated this way")
+}
+
+func (u *UnconfirmedTxDependency) ObjectStorageKey() []byte {
+	u.mutex.RLock()
+	defer u.mutex.RUnlock()
+
+	return u.dependencyTxID.Bytes()
+}
+
+func (u *UnconfirmedTxDependency) ObjectStorageValue() []byte {
+	u.mutex.RLock()
+	defer u.mutex.RUnlock()
+
+	marshalUtil := marshalutil.New(ledgerstate.TransactionIDLength * len(u.dependentTxIDs))
+	for dependency := range u.dependentTxIDs {
+		marshalUtil.WriteBytes(dependency.Bytes())
+	}
+	return marshalUtil.Bytes()
+}
+
+// endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// region CachedUnconfirmedTxDependency ////////////////////////////////////////////////////////////////////////////////
+
+// CachedUnconfirmedTxDependency is a wrapper for the generic CachedObject returned by the object storage that overrides the
+// accessor methods with a type-casted one.
+type CachedUnconfirmedTxDependency struct {
+	objectstorage.CachedObject
+}
+
+// Retain marks the CachedObject to still be in use by the program.
+func (c *CachedUnconfirmedTxDependency) Retain() *CachedUnconfirmedTxDependency {
+	return &CachedUnconfirmedTxDependency{c.CachedObject.Retain()}
+}
+
+// Unwrap is the type-casted equivalent of Get. It returns nil if the object does not exist.
+func (c *CachedUnconfirmedTxDependency) Unwrap() *UnconfirmedTxDependency {
+	untypedObject := c.Get()
+	if untypedObject == nil {
+		return nil
+	}
+
+	typedObject := untypedObject.(*UnconfirmedTxDependency)
+	if typedObject == nil || typedObject.IsDeleted() {
+		return nil
+	}
+
+	return typedObject
+}
+
+// Consume unwraps the CachedObject and passes a type-casted version to the consumer (if the object is not empty - it
+// exists). It automatically releases the object when the consumer finishes.
+func (c *CachedUnconfirmedTxDependency) Consume(consumer func(unconfirmedTxDependency *UnconfirmedTxDependency), forceRelease ...bool) (consumed bool) {
+	return c.CachedObject.Consume(func(object objectstorage.StorableObject) {
+		consumer(object.(*UnconfirmedTxDependency))
+	}, forceRelease...)
+}
+
+// String returns a human readable version of the CachedMissingMessage.
+func (c *CachedUnconfirmedTxDependency) String() string {
+	return stringify.Struct("CachedUnconfirmedTxDependency",
 		stringify.StructField("CachedObject", c.Unwrap()),
 	)
 }

--- a/packages/tangle/storage_test.go
+++ b/packages/tangle/storage_test.go
@@ -68,16 +68,16 @@ func TestStorage_UnconfirmedTransactionDependencies(t *testing.T) {
 	transactionIDs[dependency1TxID] = types.Void
 	transactionIDs[dependency2TxID] = types.Void
 
-	dependencies := NewUnconfirmedTxDependency(&transactionID)
-	dependencies.AddDependency(&dependency1TxID)
-	dependencies.AddDependency(&dependency2TxID)
+	dependencies := NewUnconfirmedTxDependency(transactionID)
+	dependencies.AddDependency(dependency1TxID)
+	dependencies.AddDependency(dependency2TxID)
 
-	cachedDependencies := tangle.Storage.UnconfirmedTransactionDependencies(&transactionID)
+	cachedDependencies := tangle.Storage.UnconfirmedTransactionDependencies(transactionID)
 	cachedDependencies.Release()
 	assert.NotNil(t, cachedDependencies)
 
 	tangle.Storage.StoreUnconfirmedTransactionDependencies(dependencies)
-	cachedDependencies = tangle.Storage.UnconfirmedTransactionDependencies(&transactionID)
+	cachedDependencies = tangle.Storage.UnconfirmedTransactionDependencies(transactionID)
 	cachedDependencies.Release()
 	assert.NotNil(t, cachedDependencies)
 

--- a/packages/tangle/storage_test.go
+++ b/packages/tangle/storage_test.go
@@ -82,6 +82,6 @@ func TestStorage_UnconfirmedTransactionDependencies(t *testing.T) {
 
 	tangle.Storage.UnconfirmedTransactionDependencies(transactionID).Consume(func(unconfirmedTxDependency *UnconfirmedTxDependency) {
 		assert.Equal(t, transactionID, unconfirmedTxDependency.transactionID)
-		assert.Equal(t, 3, len(unconfirmedTxDependency.txDependentIDs))
+		assert.Equal(t, 3, unconfirmedTxDependency.txDependentIDs.Size())
 	})
 }

--- a/packages/tangle/storage_test.go
+++ b/packages/tangle/storage_test.go
@@ -1,6 +1,7 @@
 package tangle
 
 import (
+	"fmt"
 	"math/rand"
 	"testing"
 
@@ -73,14 +74,18 @@ func TestStorage_UnconfirmedTransactionDependencies(t *testing.T) {
 	dependencies.AddDependency(dependency2TxID)
 
 	cachedDependencies := tangle.Storage.UnconfirmedTransactionDependencies(transactionID)
+	assert.Nil(t, cachedDependencies.Unwrap())
 	cachedDependencies.Release()
-	assert.NotNil(t, cachedDependencies)
 
-	tangle.Storage.StoreUnconfirmedTransactionDependencies(dependencies)
-	cachedDependencies = tangle.Storage.UnconfirmedTransactionDependencies(transactionID)
-	cachedDependencies.Release()
-	assert.NotNil(t, cachedDependencies)
+	tangle.Storage.StoreUnconfirmedTransactionDependencies(dependencies).Release()
+	fmt.Println(cachedDependencies.Unwrap().dependencyTxID)
+	fmt.Println(cachedDependencies.Unwrap().dependentTxIDs)
+	cachedDependencies2 := tangle.Storage.UnconfirmedTransactionDependencies(transactionID)
+	defer cachedDependencies2.Release()
+	assert.NotNil(t, cachedDependencies2.Unwrap())
 
+	fmt.Println(cachedDependencies.Unwrap().dependencyTxID)
+	fmt.Println(cachedDependencies.Unwrap().dependentTxIDs)
 	assert.Equal(t, transactionID, cachedDependencies.Unwrap().dependencyTxID)
-	assert.Equal(t, transactionIDs, cachedDependencies.Unwrap().dependentTxIDs)
+	assert.Equal(t, transactionIDs, cachedDependencies2.Unwrap().dependentTxIDs)
 }

--- a/packages/tangle/storage_test.go
+++ b/packages/tangle/storage_test.go
@@ -82,10 +82,6 @@ func TestStorage_UnconfirmedTransactionDependencies(t *testing.T) {
 
 	tangle.Storage.UnconfirmedTransactionDependencies(transactionID).Consume(func(unconfirmedTxDependency *UnconfirmedTxDependency) {
 		assert.Equal(t, transactionID, unconfirmedTxDependency.transactionID)
-		depCount := 0
-		for dependency := range unconfirmedTxDependency.txDependentIDs {
-			assert.Equal(t, dependencies[depCount], dependency)
-			depCount += 1
-		}
+		assert.Equal(t, 3, len(unconfirmedTxDependency.txDependentIDs))
 	})
 }

--- a/packages/tangle/storage_test.go
+++ b/packages/tangle/storage_test.go
@@ -1,9 +1,10 @@
 package tangle
 
 import (
-	"github.com/iotaledger/hive.go/types"
 	"math/rand"
 	"testing"
+
+	"github.com/iotaledger/hive.go/types"
 
 	"github.com/stretchr/testify/assert"
 
@@ -72,10 +73,12 @@ func TestStorage_UnconfirmedTransactionDependencies(t *testing.T) {
 	dependencies.AddDependency(&dependency2TxID)
 
 	cachedDependencies := tangle.Storage.UnconfirmedTransactionDependencies(&transactionID)
+	cachedDependencies.Release()
 	assert.NotNil(t, cachedDependencies)
 
 	tangle.Storage.StoreUnconfirmedTransactionDependencies(dependencies)
 	cachedDependencies = tangle.Storage.UnconfirmedTransactionDependencies(&transactionID)
+	cachedDependencies.Release()
 	assert.NotNil(t, cachedDependencies)
 
 	assert.Equal(t, transactionID, cachedDependencies.Unwrap().dependencyTxID)

--- a/packages/tangle/tangle_test.go
+++ b/packages/tangle/tangle_test.go
@@ -526,7 +526,7 @@ func TestTangle_Flow(t *testing.T) {
 	}))
 
 	// data messages should not trigger this event
-	tangle.LedgerState.UTXODAG.Events.TransactionConfirmed.AttachAfter(events.NewClosure(func(transactionID ledgerstate.TransactionID) {
+	tangle.LedgerState.UTXODAG.Events().TransactionConfirmed.AttachAfter(events.NewClosure(func(transactionID ledgerstate.TransactionID) {
 		n := atomic.AddInt32(&opinionFormedTransactions, 1)
 		t.Logf("opinion formed transaction %d/%d - %s", n, totalMsgCount, transactionID)
 	}))

--- a/packages/tangle/utils.go
+++ b/packages/tangle/utils.go
@@ -90,7 +90,7 @@ func (u *Utils) WalkMessageAndMetadata(callback func(message *Message, messageMe
 
 // region structural checks ////////////////////////////////////////////////////////////////////////////////////////////
 
-// AllTransactionsApprovedByMessages checks if all Transactions were attached by at least one Message that was directly
+// AllTransactionsDirectlyApprovedByMessages checks if all Transactions were attached by at least one Message that was directly
 // approved by the given Message.
 func (u *Utils) AllTransactionsDirectlyApprovedByMessages(transactionIDs ledgerstate.TransactionIDs, messageIDs ...MessageID) (approved bool) {
 	transactionIDs = transactionIDs.Clone()

--- a/packages/txstream/tangleledger/tangleledger.go
+++ b/packages/txstream/tangleledger/tangleledger.go
@@ -39,7 +39,7 @@ func New() *TangleLedger {
 			go t.txConfirmedEvent.Trigger(transaction)
 		})
 	})
-	messagelayer.Tangle().LedgerState.UTXODAG.Events.TransactionConfirmed.Attach(t.txConfirmedClosure)
+	messagelayer.Tangle().LedgerState.UTXODAG.Events().TransactionConfirmed.Attach(t.txConfirmedClosure)
 
 	t.txBookedClosure = events.NewClosure(func(id tangle.MessageID) {
 		messagelayer.Tangle().Storage.Message(id).Consume(func(msg *tangle.Message) {
@@ -55,7 +55,7 @@ func New() *TangleLedger {
 
 // Detach detaches the event handlers
 func (t *TangleLedger) Detach() {
-	messagelayer.Tangle().LedgerState.UTXODAG.Events.TransactionConfirmed.Detach(t.txConfirmedClosure)
+	messagelayer.Tangle().LedgerState.UTXODAG.Events().TransactionConfirmed.Detach(t.txConfirmedClosure)
 	messagelayer.Tangle().Booker.Events.MessageBooked.Detach(t.txBookedClosure)
 }
 

--- a/plugins/faucet/state_manager.go
+++ b/plugins/faucet/state_manager.go
@@ -376,8 +376,8 @@ func (s *StateManager) prepareMoreFundingOutputs() (err error) {
 	})
 
 	// listen on confirmation
-	messagelayer.Tangle().LedgerState.UTXODAG.Events.TransactionConfirmed.Attach(monitorTxConfirmation)
-	defer messagelayer.Tangle().LedgerState.UTXODAG.Events.TransactionConfirmed.Detach(monitorTxConfirmation)
+	messagelayer.Tangle().LedgerState.UTXODAG.Events().TransactionConfirmed.Attach(monitorTxConfirmation)
+	defer messagelayer.Tangle().LedgerState.UTXODAG.Events().TransactionConfirmed.Detach(monitorTxConfirmation)
 
 	// issue the tx
 	issuedMsg, issueErr := s.issueTX(tx)

--- a/plugins/messagelayer/mana_plugin.go
+++ b/plugins/messagelayer/mana_plugin.go
@@ -102,7 +102,7 @@ func configureManaPlugin(*node.Plugin) {
 
 func configureEvents() {
 	// until we have the proper event...
-	Tangle().LedgerState.UTXODAG.Events.TransactionConfirmed.Attach(onTransactionConfirmedClosure)
+	Tangle().LedgerState.UTXODAG.Events().TransactionConfirmed.Attach(onTransactionConfirmedClosure)
 	// mana.Events().Pledged.Attach(onPledgeEventClosure)
 	// mana.Events().Revoked.Attach(onRevokeEventClosure)
 }
@@ -224,7 +224,7 @@ func runManaPlugin(_ *node.Plugin) {
 				manaLogger.Infof("Stopping %s ...", PluginName)
 				// mana.Events().Pledged.Detach(onPledgeEventClosure)
 				// mana.Events().Pledged.Detach(onRevokeEventClosure)
-				Tangle().LedgerState.UTXODAG.Events.TransactionConfirmed.Detach(onTransactionConfirmedClosure)
+				Tangle().LedgerState.UTXODAG.Events().TransactionConfirmed.Detach(onTransactionConfirmedClosure)
 				storeManaVectors()
 				shutdownStorages()
 				return

--- a/plugins/remotelogmetrics/plugin.go
+++ b/plugins/remotelogmetrics/plugin.go
@@ -86,7 +86,7 @@ func configureDRNGMetrics() {
 
 func configureTransactionMetrics() {
 	messagelayer.Tangle().ConsensusManager.Events.MessageOpinionFormed.Attach(events.NewClosure(onTransactionOpinionFormed))
-	messagelayer.Tangle().LedgerState.UTXODAG.Events.TransactionConfirmed.Attach(events.NewClosure(onTransactionConfirmed))
+	messagelayer.Tangle().LedgerState.UTXODAG.Events().TransactionConfirmed.Attach(events.NewClosure(onTransactionConfirmed))
 }
 
 func configureStatementMetrics() {

--- a/plugins/webapi/ledgerstate/plugin.go
+++ b/plugins/webapi/ledgerstate/plugin.go
@@ -74,7 +74,7 @@ func configure(*node.Plugin) {
 	onTransactionConfirmedClosure = events.NewClosure(func(transactionID ledgerstate.TransactionID) {
 		doubleSpendFilter.Remove(transactionID)
 	})
-	messagelayer.Tangle().LedgerState.UTXODAG.Events.TransactionConfirmed.Attach(onTransactionConfirmedClosure)
+	messagelayer.Tangle().LedgerState.UTXODAG.Events().TransactionConfirmed.Attach(onTransactionConfirmedClosure)
 	log = logger.NewLogger(PluginName)
 }
 
@@ -116,7 +116,7 @@ func worker(shutdownSignal <-chan struct{}) {
 		}
 	}()
 	log.Infof("Stopping %s ...", PluginName)
-	messagelayer.Tangle().LedgerState.UTXODAG.Events.TransactionConfirmed.Detach(onTransactionConfirmedClosure)
+	messagelayer.Tangle().LedgerState.UTXODAG.Events().TransactionConfirmed.Detach(onTransactionConfirmedClosure)
 }
 
 // endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/tools/integration-tests/tester/go.mod
+++ b/tools/integration-tests/tester/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/drand/drand v1.1.1
 	github.com/iotaledger/goshimmer v0.1.3
-	github.com/iotaledger/hive.go v0.0.0-20210623095912-c1c6f098a6db
+	github.com/iotaledger/hive.go v0.0.0-20210708115003-f1a9732260a8
 	github.com/mr-tron/base58 v1.2.0
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/stretchr/testify v1.7.0

--- a/tools/integration-tests/tester/go.sum
+++ b/tools/integration-tests/tester/go.sum
@@ -403,6 +403,7 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/iotaledger/hive.go v0.0.0-20210623095912-c1c6f098a6db h1:qXA5CyDaVBF5c/DncHYcEFHOo8jdyFZ4a24VdGn+rRA=
 github.com/iotaledger/hive.go v0.0.0-20210623095912-c1c6f098a6db/go.mod h1:NyBg/Ny7FFAdDs59zdwTVoysU2ZbJVQnRwyLIDFKJYA=
+github.com/iotaledger/hive.go v0.0.0-20210708115003-f1a9732260a8/go.mod h1:NyBg/Ny7FFAdDs59zdwTVoysU2ZbJVQnRwyLIDFKJYA=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.2/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.3/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=

--- a/tools/integration-tests/tester/go.sum
+++ b/tools/integration-tests/tester/go.sum
@@ -403,6 +403,7 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/iotaledger/hive.go v0.0.0-20210623095912-c1c6f098a6db h1:qXA5CyDaVBF5c/DncHYcEFHOo8jdyFZ4a24VdGn+rRA=
 github.com/iotaledger/hive.go v0.0.0-20210623095912-c1c6f098a6db/go.mod h1:NyBg/Ny7FFAdDs59zdwTVoysU2ZbJVQnRwyLIDFKJYA=
+github.com/iotaledger/hive.go v0.0.0-20210708115003-f1a9732260a8 h1:+hyYZ4T/cvH6H1fsBwsRnD37Q9ejGKomSaGZ6vSHZbs=
 github.com/iotaledger/hive.go v0.0.0-20210708115003-f1a9732260a8/go.mod h1:NyBg/Ny7FFAdDs59zdwTVoysU2ZbJVQnRwyLIDFKJYA=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.2/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=


### PR DESCRIPTION
This PR is adding an `EligibilityManager` into the tangle package that is responsible for changing eligible flag of the meassage. Fixes #1494 

It is attached to two events:
 - MessageSolid 
 - TransactionConfirmed

It emits `MessageEligible` event

Dependencies are stored in `unconfirmedTransactionDependencies` objectStorage that maps dependency txID to the map of all dependent on it transactions IDs

After message solidification event is triggered the message is eligible:
 - if it is not a transaction
 - if all of its dependencies are confirmed
 - if all dependencies are directly approved by the message

If none of these conditions is met, dependencies are saved in object storage

Whenever transaction is confirmed Eligibility manager checks if there are any transactions dependent on the message that triggered the event and updates their eligibility status. After this it removes confirmed transactionID from the objectStorage

## Type of change
- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested
We added unit tests fro the manager and object storage, (listed in the issue comment)

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
