### PR TITLE
Deploy metrics changes together with new Goshimmer version

### DIFF
--- a/deploy/ansible/deploy.yml
+++ b/deploy/ansible/deploy.yml
@@ -1,5 +1,11 @@
 ---
-## This playbook deploys new Goshimmer version.
+## This playbook deploys new changes to the environment.
+
+- hosts: metrics
+  vars:
+    removeData: no
+  roles:
+    - metrics
 
 - hosts: supports
   roles:

--- a/deploy/ansible/initial-setup.yml
+++ b/deploy/ansible/initial-setup.yml
@@ -1,7 +1,9 @@
 ---
-## This playbook sets up the whole network stack.
+## This playbook sets up the whole environment stack from scratch.
 
 - hosts: metrics
+  vars:
+    removeData: yes
   roles:
     - metrics
 

--- a/deploy/ansible/roles/metrics/tasks/main.yml
+++ b/deploy/ansible/roles/metrics/tasks/main.yml
@@ -58,7 +58,7 @@
   community.general.docker_compose:
     project_src: /opt/metrics
     state: absent
-    remove_volumes: {{ removeData }}
+    remove_volumes: "{{ removeData }}"
 
 - name: Run services
   community.general.docker_compose:

--- a/deploy/ansible/roles/metrics/tasks/main.yml
+++ b/deploy/ansible/roles/metrics/tasks/main.yml
@@ -58,7 +58,7 @@
   community.general.docker_compose:
     project_src: /opt/metrics
     state: absent
-    remove_volumes: yes
+    remove_volumes: {{ removeData }}
 
 - name: Run services
   community.general.docker_compose:


### PR DESCRIPTION
This change allows deploying new metrics dashboards automatically on every commit to the `develop` branch. Originally requested by @piotrm50 