### PR TITLE
Add Alias Initial State Validation

### DIFF
--- a/packages/ledgerstate/utxo_dag.go
+++ b/packages/ledgerstate/utxo_dag.go
@@ -136,6 +136,9 @@ func (u *UTXODAG) CheckTransaction(transaction *Transaction) (err error) {
 	if !UnlockBlocksValid(consumedOutputs, transaction) {
 		return errors.Errorf("spending of referenced consumedOutputs is not authorized: %w", ErrTransactionInvalid)
 	}
+	if !AliasInitialStateValid(consumedOutputs, transaction) {
+		return errors.Errorf("initial state of created alias output is invalid: %w", ErrTransactionInvalid)
+	}
 
 	return nil
 }


### PR DESCRIPTION
# Description of change

Aliases are like state machines operating on top of the UTXO ledger.
Allowed state transitions are checked when unlocking an input, but the correctness of the initial state of the state machine must be checked in the context of the transaction that creates it.

Note: Without this fix, it is possible to duplicate arbitrary aliases and unlock any non-alias outputs locked to that address. In the context of ISCP chains, this could mean stealing funds of requests and halting the chain.
