### PR TITLE
DOCS - use absolute image paths 

### DIFF
--- a/documentation/blog/2021-07-08_new-release-v0.7.4.md
+++ b/documentation/blog/2021-07-08_new-release-v0.7.4.md
@@ -20,7 +20,7 @@ We have released GoShimmer v0.7.4:
 - Update snapshot file with DevNet UTXO at 2021-07-08 07:09 UTC
 
 :::warning
-Breaking changes: You must update your GoShimmer installation if you want to keep participating in the network. Follow the steps in the [official documentation](http://goshimmer.docs.iota.org/tutorials/setup.html#managing-the-goshimmer-node-lifecycle) to upgrade your node. 
+Breaking changes: You must update your GoShimmer installation if you want to keep participating in the network. Follow the steps in the [official documentation](https://goshimmer.docs.iota.org/docs/tutorials/setup#managing-the-goshimmer-node-lifecycle) to upgrade your node. 
 :::
 
 For those compiling from source, make sure to download the latest snapshot that we have updated. You can find more info on how to do that in the README.

--- a/documentation/docs/protocol_specification/advanced_outputs.md
+++ b/documentation/docs/protocol_specification/advanced_outputs.md
@@ -180,18 +180,18 @@ spend the 10 Mi from his alias account to his address account.
 
 1. Bob creates an alias where `aliasID=BobAliasID` with Transaction A.
 
-![Bob creates an alias](../../static/img/protocol_specification/bob_alias.png "Bob creates an alias")
+![Bob creates an alias](/img/protocol_specification/bob_alias.png "Bob creates an alias")
 
 2. Bob shares `BobAliasID` with Alice.
 3. Alice sends 10 Mi to Bob by sending Transaction B that creates an `ExtendedLockedOutput`, specifying the balance,
    and `aliasID=BobAliasID`.
 
-![Alice sends 10 Mi to Bob](../../static/img/protocol_specification/alice_sends_10_mi.png "Alice sends 10 Mi to Bob")
+![Alice sends 10 Mi to Bob](/img/protocol_specification/alice_sends_10_mi.png "Alice sends 10 Mi to Bob")
 
 4. Bob can spend the outputs created by Alice by creating Transaction C that moves his `BobAlias` (to the very same
    address), and including the  `ExtendedLockedOutput` with `aliasID=BobAliasID`.
 
-![Bob can spend the outputs created by Alice by creating Transaction C](../../static/img/protocol_specification/bob_can_spend_outputs_created_by_alice.png "Bob can spend the outputs created by Alice by creating Transaction C")
+![Bob can spend the outputs created by Alice by creating Transaction C](/img/protocol_specification/bob_can_spend_outputs_created_by_alice.png "Bob can spend the outputs created by Alice by creating Transaction C")
 
 In a simple scenario, a user wishing to send a request to a smart contract creates an extended output. The output
 contains the AliasID of the smart contract chain account, the layer 2 request as metadata, and some tokens to pay

--- a/documentation/docs/protocol_specification/autopeering.md
+++ b/documentation/docs/protocol_specification/autopeering.md
@@ -18,7 +18,7 @@ Once a peer has been verified, it can be queried to discover new peers by sendin
 
 This process is summarized in the following figure and detailed in the following subsections:
 
-![Peer discovery](../../static/img/protocol_specification/peer_discovery.png "Peer discovery")
+![Peer discovery](/img/protocol_specification/peer_discovery.png "Peer discovery")
 
 
 ### Verification

--- a/documentation/docs/protocol_specification/components.md
+++ b/documentation/docs/protocol_specification/components.md
@@ -2,7 +2,7 @@
 # Components of the Protocol
 This section provides a high-level description of the interaction between components of the currently implemented GoShimmer protocol. The protocol can be divided into three main elements: a P2P overlay network, an immutable data structure, and a consensus mechanism. We abstract these three elements into layers, where—similarly to other architectures—upper layers build on the functionality provided by the layers below them. The definition of the different layers is merely about the convenience of creating a clear separation of concerns.
 
-![Components of the Protocol](../../static/img/protocol_specification/layers.png "Components of the Protocol")
+![Components of the Protocol](/img/protocol_specification/layers.png "Components of the Protocol")
 
 ## Network Layer
 The network is maintained by the network layer modules, which can be characterized as a pure P2P overlay network, meaning that it is a system that runs on top of another network (e.g., the internet), and where all nodes have the same roles and perform the same actions (in contrast to client-server systems). GoShimmer's Network Layer consists of three basic modules: the [peer discovery](autopeering.md#peer-discovery) module (which provides a list of nodes actively using the network), and the [neighbor selection](autopeering.md#neighbor-selection) module (also known as autopeering), which actually selects peers. Finally, the P2P Communication manages a node's neighbors, either selected via [autopeering](autopeering.md) or [manual peering](../tutorials/manual_peering.md).
@@ -25,7 +25,7 @@ The diagram below represents the interaction between the different modules in th
 
 As an example, take the Parser component. The function `ProcessGossipMessage` will trigger the method `Parse`, which is the only entry to the component. There are three possible outcomes to the `Parser`: triggering a `ParsingFailed` event, a `MessageRejected` event, or a `MessageParsed` event. In the last case, the event will trigger the `StoreMessage` method (which is the entry to the Storage component), whereas the first two events do not trigger any other component.
 
-![Data Flow - Overview](../../static/img/protocol_specification/data-flow.png "Data Flow - Overview")
+![Data Flow - Overview](/img/protocol_specification/data-flow.png "Data Flow - Overview")
 
 We call this the data flow, i.e., the [life cycle of a message](protocol.md), from message reception (meaning that we focus here on the point of view of a node receiving a message issued by another node) up until acceptance in the Tangle. Notice that any message, either created locally by the node or received from a neighbor needs to pass through the data flow.
 
@@ -79,7 +79,7 @@ At this point, the missing steps are the most computationally expensive:
 7.  Inputs' conflicting branches check: it checks if the branches of the inputs are conflicting. As in the last step, if the message does not pass this check, the message is marked as `invalid` and not booked. If it passes the check, it goes to the next step.
 8. Conflict check: it checks if the inputs are conflicting with an unconfirmed transaction. In this step, the branch to which the message belongs is computed. In both cases (passing the check or not), the transaction is booked into the ledger state and the message is booked into the Tangle, but its branch ID will be different depending on the outcome of the check.
 
-![Booker](../../static/img/protocol_specification/booker.png "Booker")
+![Booker](/img/protocol_specification/booker.png "Booker")
 
 Finally, after a message is booked, it might become a [marker](markers.md) (depending on the marker policy) and can be gossiped.
 
@@ -90,7 +90,7 @@ Afterwards, we form opinions in two independent processes, that can be done in p
 
 In parallel to the message timestamp opinion setting, a payload evaluation is also done. If the message does not contain a transaction payload, the payload opinion is automatically set to `liked`. Otherwise, it has to pass the FCoB rule (and possibly, an FPC voting) in order to be `liked`, as described [here](consensus_mechanism.md#fpc).
 
-![Consensus Mechanism](../../static/img/protocol_specification/consensus_mechanism.png "Consensus Mechanism")
+![Consensus Mechanism](/img/protocol_specification/consensus_mechanism.png "Consensus Mechanism")
 
 
 ### Tip Manager

--- a/documentation/docs/protocol_specification/congestion_control.md
+++ b/documentation/docs/protocol_specification/congestion_control.md
@@ -6,7 +6,7 @@ Every network has to deal with its intrinsic limited resources in terms of bandw
 *   _Fairness_. Nodes can obtain a share of the available throughput depending on their access Mana. Throughput is shared in such a way that an attempt to increase the allocation of any node necessarily results in the decrease in the allocation of some other node with an equal or smaller allocation (max-min fairness).
 *   _Security_. Malicious nodes shall be unable to interfere with either of the above requirements.
 
-![Congestion Control](../../static/img/protocol_specification/congestion_control_algorithm_infographic.png)
+![Congestion Control](/img/protocol_specification/congestion_control_algorithm_infographic.png)
 
 Further information can be found in the paper [Access Control for Distributed Ledgers in the Internet of Things: A Networking Approach](https://arxiv.org/abs/2005.07778).
 

--- a/documentation/docs/protocol_specification/consensus_mechanism.md
+++ b/documentation/docs/protocol_specification/consensus_mechanism.md
@@ -19,7 +19,7 @@ For these reasons, we use [FCoB](#fcob) to manage FPC.
 
 The following flow diagram shows the current implemention of the FCoB protocol.
 
-![FCoB](../../static/img/protocol_specification/FCOB.png)
+![FCoB](/img/protocol_specification/FCOB.png)
 
 Each opinion is associated to a *Level of Knowledge* (LoK) that defines how confident a node is with respect to the value of the opinion. We can distinguish 3 levels:
 * Level 1 means that the node only knows that it holds this opinion.
@@ -149,7 +149,7 @@ Approval weight is tracked with the help of supporters that cast votes for branc
 Tracking supporters of branches and following the heavier branch effectively is On Tangle Voting. It allows nodes to express their opinion simply by attaching a statement to a branch they like. This statement needs to propagate down the branch DAG, adding support to each of the branch parents. In case a supporter changes their opinion, support needs to be revoked from all conflicting branches and their children. Thus, a node can only support one branch of a conflict set. 
 
 To make this more clear consider the following example:
-![Branch Supporter](../../static/img/protocol_specification/branches.png)
+![Branch Supporter](/img/protocol_specification/branches.png)
 
 The green node issued **statement 1** and attached it to the aggregated branch `Branch 1.1 + Branch 4.1.1`. Thus, the green node is a supporter of all the aggregated branch's parent branches, which are (from top to bottom) `Branch 4.1.1`, `Branch 1.1`, `Branch 4.1`, `Branch 1`, and `Branch 4`.
 

--- a/documentation/docs/protocol_specification/ledgerstate.md
+++ b/documentation/docs/protocol_specification/ledgerstate.md
@@ -5,7 +5,7 @@ A transaction must consume the entirety of the specified inputs. The section unl
 
 The following image depicts the flow of funds using UTXO:
 
-![Flow of funds using UTXO](../../static/img/protocol_specification/utxo_fund_flow.png "Flow of funds using UTXO")
+![Flow of funds using UTXO](/img/protocol_specification/utxo_fund_flow.png "Flow of funds using UTXO")
 ## Transaction Layout
 
 A _Transaction_ payload is made up of two parts:

--- a/documentation/docs/protocol_specification/mana.md
+++ b/documentation/docs/protocol_specification/mana.md
@@ -63,7 +63,7 @@ module (FPC, Autopeering, DRNG, Rate Control, tools, etc.).
 
 Following figure summarizes how `Access Mana` and `Consensus Mana` is derived from a transaction:
 
-![Mana](../../static/img/protocol_specification/mana.png "Mana")
+![Mana](/img/protocol_specification/mana.png "Mana")
 
 The reason for having two separate `Base Mana Vectors` is the fact, that `accessMana` and `consensusMana` can be pledged
 to different nodes.

--- a/documentation/docs/protocol_specification/markers.md
+++ b/documentation/docs/protocol_specification/markers.md
@@ -127,15 +127,15 @@ The rank of a sequence graph is the number of sequences from the starting point 
 Here is an example of how the markers and sequences structures would look in the Tangle:
 The purple colored messages are markers.
 
-![Example 1](../../static/img/protocol_specification/example_1.png "Example 1")
+![Example 1](/img/protocol_specification/example_1.png "Example 1")
 
 ## Example 2: Test for the Mapping interaction with the Booker
 
 The Marker tool implementation is tested for correct Marker and Booker mapping. A transaction-by-transaction discussion of the test can be found [here](https://github.com/iotaledger/goshimmer/blob/develop/packages/tangle/images/TestBookerMarkerMappings.md) and can be viewed by opening the file locally in a browser. Transactions arrive in the order of the their transaction number. The end result and the values in the various fields is shown in the following figures:
 
-![Example 2.1](../../static/img/protocol_specification/example_2_1.png "Example 2.1")
+![Example 2.1](/img/protocol_specification/example_2_1.png "Example 2.1")
 
-![Example 2.2](../../static/img/protocol_specification/example_2_2.png "Example 2.2")
+![Example 2.2](/img/protocol_specification/example_2_2.png "Example 2.2")
 
 ## Implementation details
 In the following we describe some of the functions in more detail.

--- a/documentation/docs/protocol_specification/protocol.md
+++ b/documentation/docs/protocol_specification/protocol.md
@@ -5,7 +5,7 @@ Here, the node must choose a certain number (from two to eight) of other message
 An honest node must always choose tips uniformly at random from a tip pool, i.e., from a set of still unreferenced messages that satisfy a certain set of conditions, as discussed on the [Tangle](tangle.md) component. 
 In the diagram below, the issuance process being described now is represented in the context of the complete protocol. 
 
-![Protocol high-level overview](../../static/img/protocol_specification/Protocol_overview_own_message.png "Protocol high-level overview")
+![Protocol high-level overview](/img/protocol_specification/Protocol_overview_own_message.png "Protocol high-level overview")
 
 Each node in the network has limited bandwidth, CPU, and memory. In order to avoid any node from being overloaded, the right to write in everybody else's Tangle is regulated by the **Rate and Congestion Control Modules**. 
 The first one dictates the maximum rate of issuance of messages by the introduction of a small amount of proof of work. 
@@ -22,7 +22,7 @@ Since we deal with a large number of nodes, the communication graph cannot be [c
 Thus, the [network topology](https://en.wikipedia.org/wiki/Network_topology) will be dictated by the [**Neighbor Selection**](autopeering.md) (aka Autopeering) module. 
 
 
-![Protocol Overview Received Message](../../static/img/protocol_specification/Protocol_overview_received_message.png "Protocol Overview Received Message")
+![Protocol Overview Received Message](/img/protocol_specification/Protocol_overview_received_message.png "Protocol Overview Received Message")
 
 We turn our attention now to another point of view: the one of the nodes receiving new messages, represented in the diagram above. 
 After receiving a message, the node will perform several **syntactical verifications**, that will act as a filter to the messages. Additionally, the message has to be **solidified**, meaning that the node must know all the past cone of the message (i.e., the set of all messages directly or indirectly referenced by the message in question). 
@@ -39,7 +39,7 @@ At this point (if the message passes these checks), the message will be **booked
 Additionally, in the case of a value transfer, the **ledger state** and two vectors called Access Mana Vector and **Consensus Mana** Vector are updated accordingly. 
 The Consensus Mana is another Sybil protection mechanism which&mdash;since it is applied to different modules than Access Mana&mdash;has the need of a different calculation. 
 
-![Protocol Overview Booking](../../static/img/protocol_specification/Protocol_overview_booking.png "Protocol Overview Booking")
+![Protocol Overview Booking](/img/protocol_specification/Protocol_overview_booking.png "Protocol Overview Booking")
 
 After having the message booked, the node is free to **gossip** it, but a crucial step of the protocol is still missing: the **Opinion Setter** and the voting protocol, that deal with the most subjective parts of the consensus mechanism (notice that, until now, the protocol has mostly dealt with objective checks). 
 The voting protocol used here is the FPC (or **Fast Probabilistic Consensus**), which is a binary voting protocol that allows a large group of nodes to come to a consensus on the value of a single bit. 
@@ -61,7 +61,7 @@ Unless the attacker controls more than 1/3 of the Consensus Mana in the system, 
 2. **Agreement**: all honest nodes will finalize on the same opinion.
 3. **Integrity**: if a super majority of nodes&mdash;e.g. more than 90% weighted by Consensus Mana&mdash;, have the same initial opinion, then FPC will terminate with that value.
 
-![Protocol Overview Consensus](../../static/img/protocol_specification/Protocol_overview_consensus.png "Protocol Overview Consensus")
+![Protocol Overview Consensus](/img/protocol_specification/Protocol_overview_consensus.png "Protocol Overview Consensus")
 
 Analogously to Bitcoin's [six blocks rule](https://en.bitcoin.it/wiki/Confirmation), our protocol has certain measures of the probability of a certain message being considered valid permanently by all nodes. 
 This is achieved by the use of the [**Approval Weight**](consensus_mechanism.md#approval-weight-aw). 

--- a/documentation/docs/protocol_specification/tangle.md
+++ b/documentation/docs/protocol_specification/tangle.md
@@ -145,7 +145,7 @@ Each message can express two levels of approval with respect to its parents:
 
 Let's consider the following example:
 
-![Detailed Design Example](../../static/img/protocol_specification/detailed_desing.png "Detailed Design Example")
+![Detailed Design Example](/img/protocol_specification/detailed_desing.png "Detailed Design Example")
 
 Message *D* contains a transaction that has been rejected, thus, due to the monotonicity rule, its future cone must be orphaned. Both messages *F* (transaction) and *E* (data) directly reference *D* and, traditionally, they should not be considered for tip selection. However, by introducing the approval switch, these messages can be picked up via a **weak** reference as messages *G* and *H* show.
 
@@ -183,7 +183,7 @@ A message inherits the branch of its strong parents, while it does not inherit t
 The approval weight of a given message takes into account all of its future cone built over all its strong approvers.
 Let's consider the following example:
 
-![Approval Weight](../../static/img/protocol_specification/approval_weight_example.png "Approval Weight")
+![Approval Weight](/img/protocol_specification/approval_weight_example.png "Approval Weight")
 
 *E* is a weak message strongly approving *B* and *D*. When considering the approval weight of *B*, only the strong approvers of its future cone are used, thus, *D, E, F*. Note that, the approval weight of *E* would instead be built over *G, H, I*. Therefore, its approval weight does not add up to its own weight (for instance, when looking at the approval weight of *B*).
 
@@ -272,4 +272,4 @@ func Synced() bool {
 ```
 
 The following figure displays the Tangle Time visually: 
-![Tangle Time Example](../../static/img/protocol_specification/tangle_time.jpg "Tangle Time Example")
+![Tangle Time Example](/img/protocol_specification/tangle_time.jpg "Tangle Time Example")

--- a/documentation/docs/tooling/docker_private_network.md
+++ b/documentation/docs/tooling/docker_private_network.md
@@ -2,7 +2,7 @@
 
 We provide a tool at `tools/docker-network` with which a local test network can be set up locally with docker. 
  
-![Docker network](../../static/img/tooling/docker-network.png "Docker network")
+![Docker network](/img/tooling/docker-network.png "Docker network")
 
 
 ## How to use the tool

--- a/documentation/docs/tooling/integration_tests.md
+++ b/documentation/docs/tooling/integration_tests.md
@@ -1,6 +1,6 @@
 # Integration tests with Docker
 
-![Integration testing](../../static/img/tooling/integration-testing.png "Integration testing")
+![Integration testing](/img/tooling/integration-testing.png "Integration testing")
 
 Running the integration tests spins up a `tester` container within which every test can specify its own GoShimmer network with Docker as schematically shown in the figure above.
 

--- a/documentation/docs/tutorials/obtain_tokens.md
+++ b/documentation/docs/tutorials/obtain_tokens.md
@@ -45,13 +45,13 @@ You can request funds by pressing the `Request Funds` in the wallet.
 
 **Note**: You need to create a wallet first before requesting funds.
 
-![Pollen Wallet](../../static/img/tutorials/request_funds/pollen_wallet.png "Pollen Wallet")
+![Pollen Wallet](/img/tutorials/request_funds/pollen_wallet.png "Pollen Wallet")
 
 
 This may take a while to receive funds:
 
-![Pollen Wallet requesting funds](../../static/img/tutorials/request_funds/pollen_wallet_requesting_funds.png "Pollen Wallet requesting funds")
+![Pollen Wallet requesting funds](/img/tutorials/request_funds/pollen_wallet_requesting_funds.png "Pollen Wallet requesting funds")
 
 When the faucet request is successful, you can check the received balances:
 
-![Pollen Wallet transfer success](../../static/img/tutorials/request_funds/pollen_wallet_transfer_success.png "Pollen Wallet requesting transfer success")
+![Pollen Wallet transfer success](/img/tutorials/request_funds/pollen_wallet_transfer_success.png "Pollen Wallet requesting transfer success")

--- a/documentation/docusaurus.config.js
+++ b/documentation/docusaurus.config.js
@@ -119,7 +119,7 @@ module.exports = {
           sidebarPath: require.resolve('./sidebars.js'),
           // Please change this to your repo.
           editUrl:
-            'https://github.com/iotaledger/Goshimmer/tree/develop/docOps/',
+            'https://github.com/iotaledger/goshimmer/tree/develop/documentation/',
         },
         theme: {
           customCss: require.resolve('./src/css/iota.css'),

--- a/documentation/sidebars.js
+++ b/documentation/sidebars.js
@@ -32,7 +32,7 @@ module.exports = {
     {
       type: 'doc',
       label: 'Obtain tokens',
-      id: 'tutorials/send_transaction',
+      id: 'tutorials/obtain_tokens',
     },
     {
       type: 'doc',


### PR DESCRIPTION
# Description of change

* Updated all docs images to use absolute paths instead of relative so they can be integrated into the upcoming wiki
* Fixed broken links

## Type of change

- [ ] Documentation Fix

## How the change has been tested
Changes were tested on a local docs site. 


## Change checklist
Add an `x` to the boxes that are relevant to your changes.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes