### PR TITLE
Improve spammer precision

### DIFF
--- a/client/spammer.go
+++ b/client/spammer.go
@@ -12,19 +12,19 @@ const (
 )
 
 // ToggleSpammer toggles the node internal spammer.
-func (api *GoShimmerAPI) ToggleSpammer(enable bool, rate int, timeUnit string, imif string) (*jsonmodels.SpammerResponse, error) {
+func (api *GoShimmerAPI) ToggleSpammer(enable bool, rate int, unit, imif string) (*jsonmodels.SpammerResponse, error) {
 	// set default imif in case of incorrect imif value
 	if imif != "poisson" {
 		imif = "uniform"
 	}
 	// set default time unit in case of incorrect unit value
-	if timeUnit != "mpm" {
-		timeUnit = "mps"
+	if unit != "mpm" {
+		unit = "mps"
 	}
 	res := &jsonmodels.SpammerResponse{}
 	if err := api.do(http.MethodGet, func() string {
 		if enable {
-			return fmt.Sprintf("%s?cmd=start&rate=%d&imif=%s&unit=%s", routeSpammer, rate, imif, timeUnit)
+			return fmt.Sprintf("%s?cmd=start&rate=%d&imif=%s&unit=%s", routeSpammer, rate, imif, unit)
 		}
 		return fmt.Sprintf("%s?cmd=stop", routeSpammer)
 	}(), nil, res); err != nil {

--- a/client/spammer.go
+++ b/client/spammer.go
@@ -12,11 +12,15 @@ const (
 )
 
 // ToggleSpammer toggles the node internal spammer.
-func (api *GoShimmerAPI) ToggleSpammer(enable bool, mpm int) (*jsonmodels.SpammerResponse, error) {
+func (api *GoShimmerAPI) ToggleSpammer(enable bool, mps int, imif string) (*jsonmodels.SpammerResponse, error) {
+	// set default imif in case of incorrect imif value
+	if imif != "poisson" && imif != "uniform" {
+		imif = "uniform"
+	}
 	res := &jsonmodels.SpammerResponse{}
 	if err := api.do(http.MethodGet, func() string {
 		if enable {
-			return fmt.Sprintf("%s?cmd=start&mpm=%d", routeSpammer, mpm)
+			return fmt.Sprintf("%s?cmd=start&mps=%d&imif=%s", routeSpammer, mps, imif)
 		}
 		return fmt.Sprintf("%s?cmd=stop", routeSpammer)
 	}(), nil, res); err != nil {

--- a/client/spammer.go
+++ b/client/spammer.go
@@ -12,15 +12,19 @@ const (
 )
 
 // ToggleSpammer toggles the node internal spammer.
-func (api *GoShimmerAPI) ToggleSpammer(enable bool, mps int, imif string) (*jsonmodels.SpammerResponse, error) {
+func (api *GoShimmerAPI) ToggleSpammer(enable bool, rate int, timeUnit string, imif string) (*jsonmodels.SpammerResponse, error) {
 	// set default imif in case of incorrect imif value
-	if imif != "poisson" && imif != "uniform" {
+	if imif != "poisson" {
 		imif = "uniform"
+	}
+	// set default time unit in case of incorrect unit value
+	if timeUnit != "mpm" {
+		timeUnit = "mps"
 	}
 	res := &jsonmodels.SpammerResponse{}
 	if err := api.do(http.MethodGet, func() string {
 		if enable {
-			return fmt.Sprintf("%s?cmd=start&mps=%d&imif=%s", routeSpammer, mps, imif)
+			return fmt.Sprintf("%s?cmd=start&rate=%d&imif=%s&unit=%s", routeSpammer, rate, imif, timeUnit)
 		}
 		return fmt.Sprintf("%s?cmd=stop", routeSpammer)
 	}(), nil, res); err != nil {

--- a/documentation/docs/apis/spammer.md
+++ b/documentation/docs/apis/spammer.md
@@ -28,7 +28,7 @@ In order to start the spammer, you need to send GET requests to a `/spammer` API
 | **Parameter**            | `mpm`      |
 |--------------------------|----------------|
 | **Required or Optional** | optional       |
-| **Description**          | Messages per minute. Only applicable when `cmd=start`. (default: 1)  |
+| **Description**          | Messages per second. Only applicable when `cmd=start`. (default: 1)  |
 | **Type**                 | `int`         |
 
 
@@ -36,7 +36,7 @@ In order to start the spammer, you need to send GET requests to a `/spammer` API
 | **Parameter**            | `imif` (Inter Message Issuing Function)     |
 |--------------------------|----------------|
 | **Required or Optional** | optional       |
-| **Description**          | Parameter indicating time interval between issued messages. Possible values: `poisson`, `uniform`. Field only available in HTTP API. |
+| **Description**          | Parameter indicating time interval between issued messages. Possible values: `poisson`, `uniform`. |
 | **Type**                 | `string`         |
 
 
@@ -49,16 +49,16 @@ Description of `imif` values:
 #### cURL
 
 ```shell
-curl --location 'http://localhost:8080/spammer?cmd=start&mpm=1000'
-curl --location 'http://localhost:8080/spammer?cmd=start&mpm=1000&imif=uniform'
-curl --location 'http://localhost:8080/spammer?cmd=shutdown'
+curl --location 'http://localhost:8080/spammer?cmd=start&mps=100'
+curl --location 'http://localhost:8080/spammer?cmd=start&mps=100&imif=uniform'
+curl --location 'http://localhost:8080/spammer?cmd=stop'
 ```
 
 #### Client lib - `ToggleSpammer()`
 
-Spammer can be enabled and disabled via `ToggleSpammer(enable bool, mpm int) (*jsonmodels.SpammerResponse, error)`
+Spammer can be enabled and disabled via `ToggleSpammer(enable bool, mps int, imif string) (*jsonmodels.SpammerResponse, error)`
 ```go
-res, err := goshimAPI.ToggleSpammer(true, 100)
+res, err := goshimAPI.ToggleSpammer(true, 100, "uniform")
 if err != nil {
     // return error
 }

--- a/documentation/docs/apis/spammer.md
+++ b/documentation/docs/apis/spammer.md
@@ -64,7 +64,7 @@ curl --location 'http://localhost:8080/spammer?cmd=stop'
 
 Spammer can be enabled and disabled via `ToggleSpammer(enable bool, rate int, imif string) (*jsonmodels.SpammerResponse, error)`
 ```go
-res, err := goshimAPI.ToggleSpammer(true, 100, "uniform")
+res, err := goshimAPI.ToggleSpammer(true, 100, "mps", "uniform")
 if err != nil {
     // return error
 }

--- a/documentation/docs/apis/spammer.md
+++ b/documentation/docs/apis/spammer.md
@@ -25,12 +25,18 @@ In order to start the spammer, you need to send GET requests to a `/spammer` API
 
 
 
-| **Parameter**            | `mpm`      |
+| **Parameter**            | `rate`      |
 |--------------------------|----------------|
 | **Required or Optional** | optional       |
-| **Description**          | Messages per second. Only applicable when `cmd=start`. (default: 1)  |
+| **Description**          | Messages per time unit. Only applicable when `cmd=start`. (default: 1)  |
 | **Type**                 | `int`         |
 
+
+| **Parameter**            | `unit`      |
+|--------------------------|----------------|
+| **Required or Optional** | optional       |
+| **Description**          | Indicates the unit for the spam rate: message per minute or second. One of two possible values: `mpm` and `mps`. (default: `mps`) |
+| **Type**                 | `string`         |
 
 
 | **Parameter**            | `imif` (Inter Message Issuing Function)     |
@@ -49,14 +55,14 @@ Description of `imif` values:
 #### cURL
 
 ```shell
-curl --location 'http://localhost:8080/spammer?cmd=start&mps=100'
-curl --location 'http://localhost:8080/spammer?cmd=start&mps=100&imif=uniform'
+curl --location 'http://localhost:8080/spammer?cmd=start&rate=100'
+curl --location 'http://localhost:8080/spammer?cmd=start&rate=100&imif=uniform&unit=mpm'
 curl --location 'http://localhost:8080/spammer?cmd=stop'
 ```
 
 #### Client lib - `ToggleSpammer()`
 
-Spammer can be enabled and disabled via `ToggleSpammer(enable bool, mps int, imif string) (*jsonmodels.SpammerResponse, error)`
+Spammer can be enabled and disabled via `ToggleSpammer(enable bool, rate int, imif string) (*jsonmodels.SpammerResponse, error)`
 ```go
 res, err := goshimAPI.ToggleSpammer(true, 100, "uniform")
 if err != nil {

--- a/packages/jsonmodels/spammer.go
+++ b/packages/jsonmodels/spammer.go
@@ -10,5 +10,6 @@ type SpammerResponse struct {
 type SpammerRequest struct {
 	Cmd  string `json:"cmd"`
 	IMIF string `json:"imif"`
-	MPS  int    `json:"mps"`
+	Rate int    `json:"rate"`
+	Unit string `json:"unit"`
 }

--- a/packages/jsonmodels/spammer.go
+++ b/packages/jsonmodels/spammer.go
@@ -10,5 +10,5 @@ type SpammerResponse struct {
 type SpammerRequest struct {
 	Cmd  string `json:"cmd"`
 	IMIF string `json:"imif"`
-	MPM  int    `json:"mpm"`
+	MPS  int    `json:"mps"`
 }

--- a/packages/spammer/spammer.go
+++ b/packages/spammer/spammer.go
@@ -1,10 +1,11 @@
 package spammer
 
 import (
-	"go.uber.org/atomic"
 	"math/rand"
 	"sync"
 	"time"
+
+	"go.uber.org/atomic"
 
 	"github.com/cockroachdb/errors"
 	"github.com/iotaledger/hive.go/logger"

--- a/plugins/spammer/webapi.go
+++ b/plugins/spammer/webapi.go
@@ -17,21 +17,21 @@ func handleRequest(c echo.Context) error {
 
 	switch request.Cmd {
 	case "start":
-		if request.MPM == 0 {
-			request.MPM = 1
+		if request.MPS == 0 {
+			request.MPS = 1
 		}
 
 		// IMIF: Inter Message Issuing Function
 		switch request.IMIF {
-		case "exponential":
+		case "poisson":
 			break
 		default:
 			request.IMIF = "uniform"
 		}
 
 		messageSpammer.Shutdown()
-		messageSpammer.Start(request.MPM, time.Minute, request.IMIF)
-		log.Infof("Started spamming messages with %d MPM and %s inter-message issuing function", request.MPM, request.IMIF)
+		messageSpammer.Start(request.MPS, time.Second, request.IMIF)
+		log.Infof("Started spamming messages with %d MPS and %s inter-message issuing function", request.MPS, request.IMIF)
 		return c.JSON(http.StatusOK, jsonmodels.SpammerResponse{Message: "started spamming messages"})
 	case "stop":
 		messageSpammer.Shutdown()

--- a/plugins/spammer/webapi.go
+++ b/plugins/spammer/webapi.go
@@ -17,8 +17,8 @@ func handleRequest(c echo.Context) error {
 
 	switch request.Cmd {
 	case "start":
-		if request.MPS == 0 {
-			request.MPS = 1
+		if request.Rate == 0 {
+			request.Rate = 1
 		}
 
 		// IMIF: Inter Message Issuing Function
@@ -29,9 +29,18 @@ func handleRequest(c echo.Context) error {
 			request.IMIF = "uniform"
 		}
 
+		var timeUnit time.Duration
+		switch request.Unit {
+		case "mpm":
+			timeUnit = time.Minute
+		default:
+			request.Unit = "mps"
+			timeUnit = time.Second
+		}
+
 		messageSpammer.Shutdown()
-		messageSpammer.Start(request.MPS, time.Second, request.IMIF)
-		log.Infof("Started spamming messages with %d MPS and %s inter-message issuing function", request.MPS, request.IMIF)
+		messageSpammer.Start(request.Rate, timeUnit, request.IMIF)
+		log.Infof("Started spamming messages with %d %s and %s inter-message issuing function", request.Rate, request.Unit, request.IMIF)
 		return c.JSON(http.StatusOK, jsonmodels.SpammerResponse{Message: "started spamming messages"})
 	case "stop":
 		messageSpammer.Shutdown()

--- a/tools/spammer/main.go
+++ b/tools/spammer/main.go
@@ -11,37 +11,40 @@ import (
 
 const (
 	cfgNodeURI = "nodeURIs"
-	cfgMPM     = "mpm"
+	cfgMPS     = "mps"
 	cfgEnable  = "enable"
+	cfgImif    = "imif"
 )
 
 func init() {
 	flag.StringSlice(cfgNodeURI, []string{"http://127.0.0.1:8080"}, "the URI of the node APIs")
-	flag.Int(cfgMPM, 1000, "spam count in messages per minute (MPM)")
+	flag.Int(cfgMPS, 1000, "spam count in messages per second (MPS)")
 	flag.Bool(cfgEnable, false, "enable/disable spammer")
+	flag.String(cfgImif, "uniform", "inter message issuing function: uniform or poisson")
 }
 
 func main() {
 	// example usage:
-	//   go run main.go --nodeURIs=http://127.0.0.1:8080 --mpm=600 --enable=true
+	//   go run main.go --nodeURIs=http://127.0.0.1:8080 --mps=600 --enable=true --imif=uniform
 	flag.Parse()
 	if err := viper.BindPFlags(flag.CommandLine); err != nil {
 		panic(err)
 	}
 
-	mpm := viper.GetInt(cfgMPM)
-	if mpm <= 0 {
-		panic("invalid value for `mpm` [>0]")
+	mps := viper.GetInt(cfgMPS)
+	if mps <= 0 {
+		panic("invalid value for `mps` [>0]")
 	}
 	enableSpammer := viper.GetBool(cfgEnable)
+	imif := viper.GetString(cfgImif)
 
-	apis := []*client.GoShimmerAPI{}
+	var apis []*client.GoShimmerAPI
 	for _, api := range viper.GetStringSlice(cfgNodeURI) {
 		apis = append(apis, client.NewGoShimmerAPI(api))
 	}
 
 	for _, api := range apis {
-		resp, err := api.ToggleSpammer(enableSpammer, mpm)
+		resp, err := api.ToggleSpammer(enableSpammer, mps, imif)
 		if err != nil {
 			fmt.Println(err)
 			continue

--- a/tools/spammer/main.go
+++ b/tools/spammer/main.go
@@ -11,32 +11,35 @@ import (
 
 const (
 	cfgNodeURI = "nodeURIs"
-	cfgMPS     = "mps"
+	cfgRate    = "rate"
 	cfgEnable  = "enable"
 	cfgImif    = "imif"
+	cfgUnit    = "unit"
 )
 
 func init() {
 	flag.StringSlice(cfgNodeURI, []string{"http://127.0.0.1:8080"}, "the URI of the node APIs")
-	flag.Int(cfgMPS, 1000, "spam count in messages per second (MPS)")
+	flag.Int(cfgRate, 100, "spam count in messages per time unit")
 	flag.Bool(cfgEnable, false, "enable/disable spammer")
 	flag.String(cfgImif, "uniform", "inter message issuing function: uniform or poisson")
+	flag.String(cfgUnit, "mps", "time unit of the spam rate: mpm or mps")
 }
 
 func main() {
 	// example usage:
-	//   go run main.go --nodeURIs=http://127.0.0.1:8080 --mps=600 --enable=true --imif=uniform
+	//   go run main.go --nodeURIs=http://127.0.0.1:8080 --rate=1000 --enable=true --imif=uniform --unit=mpm
 	flag.Parse()
 	if err := viper.BindPFlags(flag.CommandLine); err != nil {
 		panic(err)
 	}
 
-	mps := viper.GetInt(cfgMPS)
-	if mps <= 0 {
-		panic("invalid value for `mps` [>0]")
+	rate := viper.GetInt(cfgRate)
+	if rate <= 0 {
+		panic("invalid value for `rate` [>0]")
 	}
 	enableSpammer := viper.GetBool(cfgEnable)
 	imif := viper.GetString(cfgImif)
+	unit := viper.GetString(cfgUnit)
 
 	var apis []*client.GoShimmerAPI
 	for _, api := range viper.GetStringSlice(cfgNodeURI) {
@@ -44,7 +47,7 @@ func main() {
 	}
 
 	for _, api := range apis {
-		resp, err := api.ToggleSpammer(enableSpammer, mps, imif)
+		resp, err := api.ToggleSpammer(enableSpammer, rate, unit, imif)
 		if err != nil {
 			fmt.Println(err)
 			continue


### PR DESCRIPTION
# Description of change
Fixes #1592 

 - Change the spammer tool to use Ticker instead of waiting to control the rate
 - Add optional parameter to set the rate unit, default is mps
`curl --location 'http://localhost:8080/spammer?cmd=start&rate=1000&imif=poisson&unit=mpm'`
`curl --location 'http://localhost:8080/spammer?cmd=start&rate=100'`
 - Add missing imif flag to web API ToggleSpammer() client API

## Type of change
- Enhancement (a non-breaking change which adds functionality)
- Documentation Update

## How the change has been tested
HTTP, web API, spammer go script tested on local docker net
