### PR TITLE
Add scheduledBypass flag

### DIFF
--- a/client/diagnostics.go
+++ b/client/diagnostics.go
@@ -36,7 +36,7 @@ const (
 // Returns CSV with the following fields:
 //
 //	ID IssuerID IssuerPublicKey IssuanceTime ArrivalTime SolidTime ScheduledTime BookedTime OpinionFormedTime
-//	FinalizedTime StrongParents WeakParents StrongApprovers WeakApprovers BranchID InclusionState Scheduled Booked
+//	FinalizedTime StrongParents WeakParents StrongApprovers WeakApprovers BranchID InclusionState Scheduled ScheduledBypass Booked
 //	Eligible Invalid Finalized Rank IsPastMarker PastMarkers PMHI PMLI FutureMarkers FMHI FMLI PayloadType TransactionID
 //	PayloadOpinionFormed TimestampOpinionFormed MessageOpinionFormed MessageOpinionTriggered TimestampOpinion
 //	TimestampLoK

--- a/packages/jsonmodels/tangle.go
+++ b/packages/jsonmodels/tangle.go
@@ -36,6 +36,7 @@ type MessageMetadata struct {
 	BranchID           string            `json:"branchID"`
 	Scheduled          bool              `json:"scheduled"`
 	ScheduledTime      int64             `json:"scheduledTime"`
+	ScheduledBypass    bool              `json:"scheduledBypass"`
 	Booked             bool              `json:"booked"`
 	BookedTime         int64             `json:"bookedTime"`
 	Eligible           bool              `json:"eligible"`

--- a/packages/tangle/message.go
+++ b/packages/tangle/message.go
@@ -669,6 +669,7 @@ type MessageMetadata struct {
 	branchID           ledgerstate.BranchID
 	scheduled          bool
 	scheduledTime      time.Time
+	scheduledBypass    bool
 	booked             bool
 	bookedTime         time.Time
 	eligible           bool
@@ -682,6 +683,7 @@ type MessageMetadata struct {
 	branchIDMutex           sync.RWMutex
 	scheduledMutex          sync.RWMutex
 	scheduledTimeMutex      sync.RWMutex
+	scheduledBypassMutex    sync.RWMutex
 	bookedMutex             sync.RWMutex
 	bookedTimeMutex         sync.RWMutex
 	eligibleMutex           sync.RWMutex
@@ -741,6 +743,10 @@ func MessageMetadataFromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (resul
 	}
 	if result.scheduledTime, err = marshalUtil.ReadTime(); err != nil {
 		err = fmt.Errorf("failed to parse scheduled time of message metadata: %w", err)
+		return
+	}
+	if result.scheduledBypass, err = marshalUtil.ReadBool(); err != nil {
+		err = fmt.Errorf("failed to parse scheduledBypass flag of message metadata: %w", err)
 		return
 	}
 	if result.booked, err = marshalUtil.ReadBool(); err != nil {
@@ -924,6 +930,31 @@ func (m *MessageMetadata) ScheduledTime() time.Time {
 	return m.scheduledTime
 }
 
+// SetScheduledBypass sets the message associated with this metadata as scheduledBypass.
+// It returns true if the scheduledBypass status is modified. False otherwise.
+func (m *MessageMetadata) SetScheduledBypass(scheduledBypass bool) (modified bool) {
+	m.scheduledBypassMutex.Lock()
+	defer m.scheduledBypassMutex.Unlock()
+
+	if m.scheduledBypass == scheduledBypass {
+		return false
+	}
+
+	m.scheduledBypass = scheduledBypass
+	m.SetModified()
+	modified = true
+
+	return
+}
+
+// ScheduledBypass returns true if the message represented by this metadata was scheduledBypassed. False otherwise.
+func (m *MessageMetadata) ScheduledBypass() (result bool) {
+	m.scheduledBypassMutex.RLock()
+	defer m.scheduledBypassMutex.RUnlock()
+
+	return m.scheduledBypass
+}
+
 // SetBooked sets the message associated with this metadata as booked.
 // It returns true if the booked status is modified. False otherwise.
 func (m *MessageMetadata) SetBooked(booked bool) (modified bool) {
@@ -1063,6 +1094,7 @@ func (m *MessageMetadata) ObjectStorageValue() []byte {
 		Write(m.BranchID()).
 		WriteBool(m.Scheduled()).
 		WriteTime(m.ScheduledTime()).
+		WriteBool(m.ScheduledBypass()).
 		WriteBool(m.IsBooked()).
 		WriteTime(m.BookedTime()).
 		WriteBool(m.IsEligible()).
@@ -1089,6 +1121,7 @@ func (m *MessageMetadata) String() string {
 		stringify.StructField("branchID", m.BranchID()),
 		stringify.StructField("scheduled", m.Scheduled()),
 		stringify.StructField("scheduledTime", m.ScheduledTime()),
+		stringify.StructField("scheduledBypass", m.ScheduledBypass()),
 		stringify.StructField("booked", m.IsBooked()),
 		stringify.StructField("bookedTime", m.BookedTime()),
 		stringify.StructField("eligible", m.IsEligible()),

--- a/packages/tangle/orderer.go
+++ b/packages/tangle/orderer.go
@@ -79,7 +79,7 @@ func (o *Orderer) parentsToGossip(messageID MessageID) (parents MessageIDs) {
 	o.tangle.Storage.Message(messageID).Consume(func(message *Message) {
 		message.ForEachParent(func(parent Parent) {
 			o.tangle.Storage.MessageMetadata(parent.ID).Consume(func(messageMetadata *MessageMetadata) {
-				if !messageMetadata.Scheduled() {
+				if !messageMetadata.Scheduled() && !messageMetadata.ScheduledBypass() {
 					parents = append(parents, parent.ID)
 				}
 			})

--- a/packages/tangle/scheduler.go
+++ b/packages/tangle/scheduler.go
@@ -117,7 +117,7 @@ func (s *Scheduler) Setup() {
 		})
 		if skipScheduler {
 			s.tangle.Storage.MessageMetadata(messageID).Consume(func(messageMetadata *MessageMetadata) {
-				messageMetadata.SetScheduled(true)
+				messageMetadata.SetScheduledBypass(true)
 			})
 			return
 		}

--- a/packages/tangle/scheduler.go
+++ b/packages/tangle/scheduler.go
@@ -116,6 +116,9 @@ func (s *Scheduler) Setup() {
 			skipScheduler = clock.Since(message.IssuingTime()) > oldMessageThreshold
 		})
 		if skipScheduler {
+			s.tangle.Storage.MessageMetadata(messageID).Consume(func(messageMetadata *MessageMetadata) {
+				messageMetadata.SetScheduled(true)
+			})
 			return
 		}
 

--- a/plugins/dashboard/explorer_routes.go
+++ b/plugins/dashboard/explorer_routes.go
@@ -42,13 +42,14 @@ type ExplorerMessage struct {
 	// WeakApprovers are the weak approvers of the message.
 	WeakApprovers []string `json:"weakApprovers"`
 	// Solid defines the solid status of the message.
-	Solid     bool   `json:"solid"`
-	BranchID  string `json:"branchID"`
-	Scheduled bool   `json:"scheduled"`
-	Booked    bool   `json:"booked"`
-	Eligible  bool   `json:"eligible"`
-	Invalid   bool   `json:"invalid"`
-	Finalized bool   `json:"finalized"`
+	Solid           bool   `json:"solid"`
+	BranchID        string `json:"branchID"`
+	Scheduled       bool   `json:"scheduled"`
+	ScheduledBypass bool   `json:"scheduledBypass"`
+	Booked          bool   `json:"booked"`
+	Eligible        bool   `json:"eligible"`
+	Invalid         bool   `json:"invalid"`
+	Finalized       bool   `json:"finalized"`
 	// PayloadType defines the type of the payload.
 	PayloadType uint32 `json:"payload_type"`
 	// Payload is the content of the payload.
@@ -89,6 +90,7 @@ func createExplorerMessage(msg *tangle.Message) *ExplorerMessage {
 		Solid:                   messageMetadata.IsSolid(),
 		BranchID:                branchID.Base58(),
 		Scheduled:               messageMetadata.Scheduled(),
+		ScheduledBypass:         messageMetadata.ScheduledBypass(),
 		Booked:                  messageMetadata.IsBooked(),
 		Eligible:                messageMetadata.IsEligible(),
 		Invalid:                 messageMetadata.IsInvalid(),

--- a/plugins/dashboard/frontend/src/app/components/ExplorerMessageQueryResult.tsx
+++ b/plugins/dashboard/frontend/src/app/components/ExplorerMessageQueryResult.tsx
@@ -137,6 +137,9 @@ export class ExplorerMessageQueryResult extends React.Component<Props, any> {
                                         Scheduled: {msg.scheduled ? 'Yes' : 'No'}
                                     </ListGroup.Item>
                                     <ListGroup.Item>
+                                        ScheduledBypass: {msg.scheduledBypass ? 'Yes' : 'No'}
+                                    </ListGroup.Item>
+                                    <ListGroup.Item>
                                         Booked: {msg.booked ? 'Yes' : 'No'}
                                     </ListGroup.Item>
                                     <ListGroup.Item>

--- a/plugins/dashboard/frontend/src/app/stores/ExplorerStore.tsx
+++ b/plugins/dashboard/frontend/src/app/stores/ExplorerStore.tsx
@@ -32,6 +32,7 @@ export class Message {
     solid: boolean;
     branchID: string;
     scheduled: boolean;
+    scheduledBypass: boolean;
     booked: boolean;
     eligible: boolean;
     invalid: boolean;

--- a/plugins/webapi/message/plugin.go
+++ b/plugins/webapi/message/plugin.go
@@ -116,6 +116,7 @@ func NewMessageMetadata(metadata *tangle.MessageMetadata) jsonmodels.MessageMeta
 		BranchID:           branchID.String(),
 		Scheduled:          metadata.Scheduled(),
 		ScheduledTime:      metadata.ScheduledTime().Unix(),
+		ScheduledBypass:    metadata.ScheduledBypass(),
 		Booked:             metadata.IsBooked(),
 		BookedTime:         metadata.BookedTime().Unix(),
 		Eligible:           metadata.IsEligible(),

--- a/plugins/webapi/tools/message/diagnostic_messages.go
+++ b/plugins/webapi/tools/message/diagnostic_messages.go
@@ -310,6 +310,7 @@ func (d *DiagnosticMessagesInfo) toCSVRow() (row []string) {
 		d.BranchID,
 		d.InclusionState,
 		fmt.Sprint(d.Scheduled),
+		fmt.Sprint(d.ScheduledBypass),
 		fmt.Sprint(d.Booked),
 		fmt.Sprint(d.Eligible),
 		fmt.Sprint(d.Invalid),

--- a/plugins/webapi/tools/message/diagnostic_messages.go
+++ b/plugins/webapi/tools/message/diagnostic_messages.go
@@ -154,6 +154,7 @@ var DiagnosticMessagesTableDescription = []string{
 	"BranchID",
 	"InclusionState",
 	"Scheduled",
+	"ScheduledBypass",
 	"Booked",
 	"Eligible",
 	"Invalid",
@@ -195,6 +196,7 @@ type DiagnosticMessagesInfo struct {
 	BranchID          string
 	InclusionState    string
 	Scheduled         bool
+	ScheduledBypass   bool
 	Booked            bool
 	Eligible          bool
 	Invalid           bool
@@ -245,6 +247,7 @@ func getDiagnosticMessageInfo(messageID tangle.MessageID) *DiagnosticMessagesInf
 		msgInfo.BranchID = branchID.String()
 		msgInfo.Scheduled = metadata.Scheduled()
 		msgInfo.ScheduledTime = metadata.ScheduledTime()
+		msgInfo.ScheduledBypass = metadata.ScheduledBypass()
 		msgInfo.BookedTime = metadata.BookedTime()
 		msgInfo.OpinionFormedTime = messagelayer.ConsensusMechanism().OpinionFormedTime(messageID)
 		msgInfo.FinalizedTime = metadata.FinalizedTime()

--- a/tools/integration-tests/tester/tests/diagnostics/diagnostics_test.go
+++ b/tools/integration-tests/tester/tests/diagnostics/diagnostics_test.go
@@ -16,7 +16,7 @@ var (
 	messageHeader = []string{
 		"ID", "IssuerID", "IssuerPublicKey", "IssuanceTime", "ArrivalTime", "SolidTime",
 		"ScheduledTime", "BookedTime", "OpinionFormedTime", "FinalizedTime", "StrongParents", "WeakParents",
-		"StrongApprovers", "WeakApprovers", "BranchID", "InclusionState", "Scheduled", "Booked", "Eligible", "Invalid",
+		"StrongApprovers", "WeakApprovers", "BranchID", "InclusionState", "Scheduled", "ScheduledBypass", "Booked", "Eligible", "Invalid",
 		"Finalized", "Rank", "IsPastMarker", "PastMarkers", "PMHI", "PMLI", "FutureMarkers", "FMHI", "FMLI", "PayloadType",
 		"TransactionID", "PayloadOpinionFormed", "TimestampOpinionFormed", "MessageOpinionFormed",
 		"MessageOpinionTriggered", "TimestampOpinion", "TimestampLoK",


### PR DESCRIPTION
When bypassing the scheduler because a message is too old (oldMessageThreshold), we do not set the scheduled flag to its metadata. Now let's suppose that its child is fresh enough and should get scheduled, once that is done the orderer will look for its parents dependencies and notice that its parent has not been scheduled and never send out via gossip the message. 
Thus, this PR adds a new flag "schedulerBypass"  and updates the check together with the scheduled flag in the orderer. 
This would let us know what message is bypassed and what not if we need that info