### PR TITLE
Release/v0.7.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# v0.7.5 - 2021-08-09
+* Move the scheduler of the congestion control at the end of data flow
+* Add new metrics collection
+* Add alias initial state validation
+* Add creation of new marker sequence after maxVerticesWithoutFutureMarker threshold
+* Fix booking of transactions in multiple conflict sets
+* Fix manual peering parsing from config.json
+* Update JS dependencies
+* Update Dockerfile to explicitly expose used ports
+* Update docs to docusaurus
+* Update snapshot file with DevNet UTXO at 2021-08-09 13:33 UTC
+* **Breaking**: bumps network and database versions
+
 # v0.7.4 - 2021-07-08
 * Add ParametersDefinition structs in integration test framework
 * Add UTXO-DAG interface

--- a/plugins/autopeering/discovery/parameters.go
+++ b/plugins/autopeering/discovery/parameters.go
@@ -5,7 +5,7 @@ import "github.com/iotaledger/hive.go/configuration"
 // ParametersDefinitionDiscovery contains the definition of configuration parameters used by the autopeering peer discovery.
 type ParametersDefinitionDiscovery struct {
 	// NetworkVersion defines the config flag of the network version.
-	NetworkVersion int `default:"37" usage:"autopeering network version"`
+	NetworkVersion int `default:"38" usage:"autopeering network version"`
 
 	// EntryNodes defines the config flag of the entry nodes.
 	EntryNodes []string `default:"2PV5487xMw5rasGBXXWeqSi4hLz7r19YBt8Y1TGAsQbj@ressims.iota.cafe:15626,5EDH4uY78EA6wrBkHHAVBWBMDt7EcksRq6pjzipoW15B@entryshimmer.tanglebay.com:14646" usage:"list of trusted entry nodes for auto peering"`

--- a/plugins/banner/plugin.go
+++ b/plugins/banner/plugin.go
@@ -17,7 +17,7 @@ var (
 	once   sync.Once
 
 	// AppVersion version number
-	AppVersion = "v0.7.4"
+	AppVersion = "v0.7.5"
 	// SimplifiedAppVersion is the version number without commit hash
 	SimplifiedAppVersion = simplifiedVersion(AppVersion)
 )

--- a/plugins/database/versioning.go
+++ b/plugins/database/versioning.go
@@ -11,7 +11,7 @@ import (
 const (
 	// DBVersion defines the version of the database schema this version of GoShimmer supports.
 	// Every time there's a breaking change regarding the stored data, this version flag should be adjusted.
-	DBVersion = 39
+	DBVersion = 40
 )
 
 var (


### PR DESCRIPTION
# v0.7.5 - 2021-08-09
* Move the scheduler of the congestion control at the end of data flow
* Add new metrics collection
* Add alias initial state validation
* Add creation of new marker sequence after maxVerticesWithoutFutureMarker threshold
* Fix booking of transactions in multiple conflict sets
* Fix manual peering parsing from config.json
* Update JS dependencies
* Update Dockerfile to explicitly expose used ports
* Update docs to docusaurus
* Update snapshot file with DevNet UTXO at 2021-08-09 13:33 UTC
* **Breaking**: bumps network and database versions