### PR TITLE
(txbuilder) Improvement: added addConsumable to txbuilder

### DIFF
--- a/packages/ledgerstate/utxoutil/build.go
+++ b/packages/ledgerstate/utxoutil/build.go
@@ -42,6 +42,11 @@ func NewBuilder(inputs ...ledgerstate.Output) *Builder {
 	return ret
 }
 
+// AddConsumable adds a new consumable output to the builder
+func (b *Builder) AddConsumable(input ledgerstate.Output) {
+	b.consumables = append(b.consumables, NewConsumable(input))
+}
+
 // Clone creates deep copy of the builder
 func (b *Builder) Clone() *Builder {
 	ret := *b

--- a/packages/ledgerstate/utxoutil/consumable.go
+++ b/packages/ledgerstate/utxoutil/consumable.go
@@ -17,15 +17,21 @@ type ConsumableOutput struct {
 func NewConsumables(out ...ledgerstate.Output) []*ConsumableOutput {
 	ret := make([]*ConsumableOutput, len(out))
 	for i, o := range out {
-		ret[i] = &ConsumableOutput{
-			output:    o,
-			remaining: make(map[ledgerstate.Color]uint64),
-		}
-		o.Balances().ForEach(func(col ledgerstate.Color, bal uint64) bool {
-			ret[i].remaining[col] = bal
-			return true
-		})
+		ret[i] = NewConsumable(o)
 	}
+	return ret
+}
+
+// NewConsumable creates a consumable out of an output object
+func NewConsumable(output ledgerstate.Output) *ConsumableOutput {
+	ret := &ConsumableOutput{
+		output:    output,
+		remaining: make(map[ledgerstate.Color]uint64),
+	}
+	output.Balances().ForEach(func(col ledgerstate.Color, bal uint64) bool {
+		ret.remaining[col] = bal
+		return true
+	})
 	return ret
 }
 


### PR DESCRIPTION
# Description of change

Adds `addConsumable` to txBuilder, so we can add new consumables after the builder is instantiated (previously it was only possible to add consumables on `NewBuilder`).

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Within Wasp

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works (on wasp)
- [x] New and existing unit tests pass locally with my changes
