### PR TITLE
Makes golint report upper case error msgs

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -59,6 +59,8 @@ linters-settings:
                 checks: argument,case,condition,return
     govet:
         check-shadowing: true
+    golint:
+        min-confidence: 0.5
     misspell:
         locale: US
     nolintlint:


### PR DESCRIPTION
# Description of change

What's in the title.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Ran `golangci-lint` locally with and without the change on a file with an upper cased error msg and it did report when the confidence level was reduced.
