### PR TITLE
Add a lock file to the wallet to enable one instance

### DIFF
--- a/tools/cli-wallet/lib.go
+++ b/tools/cli-wallet/lib.go
@@ -18,6 +18,9 @@ import (
 	walletseed "github.com/iotaledger/goshimmer/client/wallet/packages/seed"
 )
 
+// Exit should be used inside panic intead of os.Exit(). This will allow to call deferred statements.
+type Exit struct{ Code int }
+
 func printBanner() {
 	fmt.Println("IOTA 2.0 DevNet CLI-Wallet 0.2")
 }
@@ -200,10 +203,10 @@ func printUsage(command *flag.FlagSet, optionalErrorMessage ...string) {
 		flag.PrintDefaults()
 
 		if len(optionalErrorMessage) >= 1 {
-			os.Exit(1)
+			panic(Exit{1})
 		}
 
-		os.Exit(0)
+		panic(Exit{0})
 	}
 
 	fmt.Println()
@@ -214,8 +217,8 @@ func printUsage(command *flag.FlagSet, optionalErrorMessage ...string) {
 	command.PrintDefaults()
 
 	if len(optionalErrorMessage) >= 1 {
-		os.Exit(1)
+		panic(Exit{1})
 	}
 
-	os.Exit(0)
+	panic(Exit{0})
 }

--- a/tools/cli-wallet/main.go
+++ b/tools/cli-wallet/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 )
 
 // entry point for the program
@@ -15,12 +16,18 @@ func main() {
 		}
 	}()
 
+	setCWD()
+
 	// Make sure only one instance of the wallet runs
-	file, err := os.OpenFile("wallet.LOCK", os.O_CREATE|os.O_EXCL, 0o644)
+	file, err := os.OpenFile("wallet.LOCK", os.O_CREATE|os.O_EXCL|os.O_RDONLY, 0o644)
 	if err != nil {
 		panic(err)
 	}
-	defer os.Remove(file.Name())
+	defer func() {
+		if err := os.Remove(file.Name()); err != nil {
+			panic(err)
+		}
+	}()
 
 	// print banner + initialize framework
 	printBanner()
@@ -112,4 +119,19 @@ func main() {
 	default:
 		printUsage(nil, "unknown [COMMAND]: "+os.Args[1])
 	}
+}
+
+// ensures the cwd is where the actual go executable
+func setCWD() {
+	var dirAbsPath string
+	ex, err := os.Executable()
+	if err != nil {
+		fmt.Println(err)
+		fmt.Println(ex)
+	}
+	dirAbsPath = filepath.Dir(ex)
+	if err := os.Chdir(dirAbsPath); err != nil {
+		panic(err)
+	}
+	return
 }

--- a/tools/cli-wallet/main.go
+++ b/tools/cli-wallet/main.go
@@ -11,6 +11,9 @@ import (
 func main() {
 	defer func() {
 		if r := recover(); r != nil {
+			if exit, ok := r.(Exit); ok == true {
+				os.Exit(exit.Code)
+			}
 			_, _ = fmt.Fprintf(os.Stderr, "\nFATAL ERROR: "+r.(error).Error())
 			os.Exit(1)
 		}
@@ -122,16 +125,15 @@ func main() {
 }
 
 // ensures the cwd is where the actual go executable
+// currently doesn't work well with symlinks (or shortcuts)
 func setCWD() {
 	var dirAbsPath string
 	ex, err := os.Executable()
 	if err != nil {
-		fmt.Println(err)
-		fmt.Println(ex)
+		panic(err)
 	}
 	dirAbsPath = filepath.Dir(ex)
 	if err := os.Chdir(dirAbsPath); err != nil {
 		panic(err)
 	}
-	return
 }

--- a/tools/cli-wallet/main.go
+++ b/tools/cli-wallet/main.go
@@ -15,6 +15,13 @@ func main() {
 		}
 	}()
 
+	// Make sure only one instance of the wallet runs
+	file, err := os.OpenFile("wallet.LOCK", os.O_CREATE|os.O_EXCL, 0o644)
+	if err != nil {
+		panic(err)
+	}
+	defer os.Remove(file.Name())
+
 	// print banner + initialize framework
 	printBanner()
 	loadConfig()

--- a/tools/cli-wallet/main.go
+++ b/tools/cli-wallet/main.go
@@ -15,7 +15,7 @@ const (
 func main() {
 	defer func() {
 		if r := recover(); r != nil {
-			if exit, ok := r.(Exit); ok == true {
+			if exit, ok := r.(Exit); ok {
 				os.Exit(exit.Code)
 			}
 			_, _ = fmt.Fprintf(os.Stderr, "\nFATAL ERROR: "+r.(error).Error())

--- a/tools/cli-wallet/main.go
+++ b/tools/cli-wallet/main.go
@@ -131,12 +131,11 @@ func main() {
 // ensures the cwd is where the actual go executable
 // currently doesn't work well with symlinks (or shortcuts)
 func setCWD() {
-	var dirAbsPath string
 	ex, err := os.Executable()
 	if err != nil {
 		panic(err)
 	}
-	dirAbsPath = filepath.Dir(ex)
+	dirAbsPath := filepath.Dir(ex)
 	if err := os.Chdir(dirAbsPath); err != nil {
 		panic(err)
 	}

--- a/tools/cli-wallet/main.go
+++ b/tools/cli-wallet/main.go
@@ -26,7 +26,7 @@ func main() {
 	setCWD()
 
 	// Make sure only one instance of the wallet runs
-	file, err := os.OpenFile(lockFile, os.O_CREATE|os.O_EXCL|os.O_RDONLY, 0o644)
+	file, err := os.OpenFile(lockFile, os.O_CREATE|os.O_EXCL|os.O_RDONLY, 0o600)
 	if err != nil {
 		panic(err)
 	}

--- a/tools/cli-wallet/main.go
+++ b/tools/cli-wallet/main.go
@@ -7,6 +7,10 @@ import (
 	"path/filepath"
 )
 
+const (
+	lockFile = "wallet.LOCK"
+)
+
 // entry point for the program
 func main() {
 	defer func() {
@@ -22,7 +26,7 @@ func main() {
 	setCWD()
 
 	// Make sure only one instance of the wallet runs
-	file, err := os.OpenFile("wallet.LOCK", os.O_CREATE|os.O_EXCL|os.O_RDONLY, 0o644)
+	file, err := os.OpenFile(lockFile, os.O_CREATE|os.O_EXCL|os.O_RDONLY, 0o644)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
# Description of change

1. Adds a `wallet.Lock` next to `wallet.dat` so only one process can run at a time
2. Makes sure that the current working directory will be where the executable is placed
3. Uses `panic` with a custom Exit struct. This was required to make the functionality works with no bugs since

fixes #1519 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Ran wallets with a split CLI

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
