### PR TITLE
Fix: plugin were skipped in docker network

### DIFF
--- a/tools/docker-network/docker-compose.yml
+++ b/tools/docker-network/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       --metrics.local=false
       --metrics.manaResearch=false
       --node.disablePlugins=clock
-      --node.enablePlugins=analysis-server,analysis-dashboard,prometheus,spammer,"webapi tools endpoint",activity,snapshot
+      --node.enablePlugins=analysis-server,analysis-dashboard,prometheus,spammer,activity,snapshot,"webapi tools endpoint"
       --prometheus.bindAddress=0.0.0.0:9311
       --prometheus.processMetrics=false
       --statement.writeManaThreshold=1.0
@@ -114,7 +114,7 @@ services:
       --config=/run/secrets/goshimmer.config.json
       --database.directory=/tmp/mainnetdb
       --autopeering.seed=base58:3YX6e7AL28hHihZewKdq6CMkEYVsTJBLgRiprUNiNq5E
-      --node.enablePlugins=bootstrap,"webapi tools endpoint",faucet,activity
+      --node.enablePlugins=bootstrap,faucet,activity,"webapi tools endpoint"
       --messageLayer.snapshot.file=/run/secrets/goshimmer.message.snapshot.bin
       --messageLayer.startSynced=true
       --faucet.seed=7R1itJx5hVuo9w9hjg5cwKFmek4HMSoBDgJZN8hKGxih


### PR DESCRIPTION
# Description of change
After introducing waiting for MongoDB script in 1e39278709dcabb297432dfe18f01a5aac9e6c7e there was a problem that some pulgins were not starting in the docker network

```
command: >
      /run/entrypoint.sh /go/bin/goshimmer
```
The script did not handle the parameters correctly because of the spaces in the plugin name: "webapi tools endpoint" this PR is the temporary solution. It just moves the webapi plugin name at the end, so plugins listed after that are not skipped.

Proper solution - removing MongoDB will be addressed by issue: #1660

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

