### PR TITLE
Feat: New solidification logic

### DIFF
--- a/packages/ledgerstate/temp.go
+++ b/packages/ledgerstate/temp.go
@@ -1,0 +1,69 @@
+package ledgerstate
+
+import (
+	"sync"
+
+	"github.com/iotaledger/hive.go/events"
+)
+
+// region eventsQueue //////////////////////////////////////////////////////////////////////////////////////////////////
+
+// eventsQueue represents an Event
+type eventsQueue struct {
+	queuedElements      []*eventsQueueElement
+	queuedElementsMutex sync.Mutex
+}
+
+// eventsNewQueue returns an empty eventsQueue.
+func eventsNewQueue() *eventsQueue {
+	return (&eventsQueue{}).clear()
+}
+
+// Queue enqueues an Event to be triggered later (using the Trigger function).
+func (q *eventsQueue) Queue(event *events.Event, params ...interface{}) {
+	q.queuedElementsMutex.Lock()
+	defer q.queuedElementsMutex.Unlock()
+
+	q.queuedElements = append(q.queuedElements, &eventsQueueElement{
+		event:  event,
+		params: params,
+	})
+}
+
+// Trigger triggers all queued Events and empties the eventsQueue.
+func (q *eventsQueue) Trigger() {
+	q.queuedElementsMutex.Lock()
+	defer q.queuedElementsMutex.Unlock()
+
+	for _, queuedElement := range q.queuedElements {
+		queuedElement.event.Trigger(queuedElement.params...)
+	}
+	q.clear()
+}
+
+// Clear removes all elements from the eventsQueue.
+func (q *eventsQueue) Clear() {
+	q.queuedElementsMutex.Lock()
+	defer q.queuedElementsMutex.Unlock()
+
+	q.clear()
+}
+
+// clear removes all elements from the eventsQueue without locking it.
+func (q *eventsQueue) clear() *eventsQueue {
+	q.queuedElements = make([]*eventsQueueElement, 0)
+
+	return q
+}
+
+// endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// region eventsQueueElement ///////////////////////////////////////////////////////////////////////////////////////////
+
+// eventsQueueElement is a struct that holds the information about a triggered Event.
+type eventsQueueElement struct {
+	event  *events.Event
+	params []interface{}
+}
+
+// endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/packages/ledgerstate/transaction.go
+++ b/packages/ledgerstate/transaction.go
@@ -15,6 +15,7 @@ import (
 	"github.com/iotaledger/hive.go/marshalutil"
 	"github.com/iotaledger/hive.go/objectstorage"
 	"github.com/iotaledger/hive.go/stringify"
+	"github.com/iotaledger/hive.go/syncutils"
 	"github.com/iotaledger/hive.go/types"
 	"github.com/iotaledger/hive.go/typeutils"
 	"github.com/mr-tron/base58"
@@ -161,6 +162,8 @@ type Transaction struct {
 	idMutex      sync.RWMutex
 	essence      *TransactionEssence
 	unlockBlocks UnlockBlocks
+	lock         []interface{}
+	lockMutex    sync.Mutex
 
 	objectstorage.StorableObjectFlags
 }
@@ -361,6 +364,24 @@ func (t *Transaction) ReferencedTransactionIDs() (referencedTransactionIDs Trans
 	}
 
 	return
+}
+
+// Locks returns a list of identifiers of the entities that this Transaction depends on and that should be locked before
+// modifying any of the Transactions properties.
+func (t *Transaction) Locks() (lock []interface{}) {
+	t.lockMutex.Lock()
+	defer t.lockMutex.Unlock()
+
+	if t.lock == nil {
+		lockBuilder := (&syncutils.MultiMutexLockBuilder{}).AddLock(t.ID())
+		for referencedTransactionID := range t.ReferencedTransactionIDs() {
+			lockBuilder = lockBuilder.AddLock(referencedTransactionID)
+		}
+
+		t.lock = lockBuilder.Build()
+	}
+
+	return t.lock
 }
 
 // Bytes returns a marshaled version of the Transaction.
@@ -691,12 +712,10 @@ type TransactionMetadata struct {
 	id                      TransactionID
 	branchID                BranchID
 	branchIDMutex           sync.RWMutex
-	solid                   bool
-	solidMutex              sync.RWMutex
+	solidityType            SolidityType
+	solidityTypeMutex       sync.RWMutex
 	solidificationTime      time.Time
 	solidificationTimeMutex sync.RWMutex
-	lazyBooked              bool
-	lazyBookedMutex         sync.RWMutex
 	gradeOfFinality         gof.GradeOfFinality
 	gradeOfFinalityTime     time.Time
 	gradeOfFinalityMutex    sync.RWMutex
@@ -734,16 +753,12 @@ func TransactionMetadataFromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (t
 		err = errors.Errorf("failed to parse BranchID: %w", err)
 		return
 	}
-	if transactionMetadata.solid, err = marshalUtil.ReadBool(); err != nil {
-		err = errors.Errorf("failed to parse solid flag (%v): %w", err, cerrors.ErrParseBytesFailed)
+	if transactionMetadata.solidityType, err = SolidityTypeFromMarshalUtil(marshalUtil); err != nil {
+		err = errors.Errorf("failed to parse SolidityType from MarshalUtil: %w", err)
 		return
 	}
 	if transactionMetadata.solidificationTime, err = marshalUtil.ReadTime(); err != nil {
 		err = errors.Errorf("failed to parse solidification time (%v): %w", err, cerrors.ErrParseBytesFailed)
-		return
-	}
-	if transactionMetadata.lazyBooked, err = marshalUtil.ReadBool(); err != nil {
-		err = errors.Errorf("failed to parse lazy booked flag (%v): %w", err, cerrors.ErrParseBytesFailed)
 		return
 	}
 	gradeOfFinality, err := marshalUtil.ReadUint8()
@@ -799,35 +814,33 @@ func (t *TransactionMetadata) SetBranchID(branchID BranchID) (modified bool) {
 	return
 }
 
-// Solid returns true if the Transaction has been marked as solid.
-func (t *TransactionMetadata) Solid() bool {
-	t.solidMutex.RLock()
-	defer t.solidMutex.RUnlock()
+// SetSolidityType updates the SolidityType of the Transaction. It returns the previous value.
+func (t *TransactionMetadata) SetSolidityType(solidityType SolidityType) (previousValue SolidityType) {
+	t.solidityTypeMutex.Lock()
+	defer t.solidityTypeMutex.Unlock()
 
-	return t.solid
-}
-
-// SetSolid updates the solid flag of the Transaction. It returns true if the solid flag was modified and updates the
-// solidification time if the Transaction was marked as solid.
-func (t *TransactionMetadata) SetSolid(solid bool) (modified bool) {
-	t.solidMutex.Lock()
-	defer t.solidMutex.Unlock()
-
-	if t.solid == solid {
+	if previousValue = t.solidityType; previousValue >= solidityType {
 		return
 	}
 
-	if solid {
+	if (previousValue == UndefinedSolidityType || previousValue == Unsolid) && solidityType >= LazySolid {
 		t.solidificationTimeMutex.Lock()
 		t.solidificationTime = time.Now()
 		t.solidificationTimeMutex.Unlock()
 	}
 
-	t.solid = solid
+	t.solidityType = solidityType
 	t.SetModified()
-	modified = true
 
 	return
+}
+
+// SolidityType returns the SolidityType of the given Transaction.
+func (t *TransactionMetadata) SolidityType() (solidityType SolidityType) {
+	t.solidityTypeMutex.RLock()
+	defer t.solidityTypeMutex.RUnlock()
+
+	return t.solidityType
 }
 
 // SolidificationTime returns the time when the Transaction was marked as solid.
@@ -836,31 +849,6 @@ func (t *TransactionMetadata) SolidificationTime() time.Time {
 	defer t.solidificationTimeMutex.RUnlock()
 
 	return t.solidificationTime
-}
-
-// LazyBooked returns a boolean flag that indicates if the Transaction has been analyzed regarding the conflicting
-// status of its consumed Branches.
-func (t *TransactionMetadata) LazyBooked() (lazyBooked bool) {
-	t.lazyBookedMutex.RLock()
-	defer t.lazyBookedMutex.RUnlock()
-
-	return t.lazyBooked
-}
-
-// SetLazyBooked updates the lazy booked flag of the Output. It returns true if the value was modified.
-func (t *TransactionMetadata) SetLazyBooked(lazyBooked bool) (modified bool) {
-	t.lazyBookedMutex.Lock()
-	defer t.lazyBookedMutex.Unlock()
-
-	if t.lazyBooked == lazyBooked {
-		return
-	}
-
-	t.lazyBooked = lazyBooked
-	t.SetModified()
-	modified = true
-
-	return
 }
 
 // GradeOfFinality returns the grade of finality.
@@ -904,9 +892,8 @@ func (t *TransactionMetadata) String() string {
 	return stringify.Struct("TransactionMetadata",
 		stringify.StructField("id", t.ID()),
 		stringify.StructField("branchID", t.BranchID()),
-		stringify.StructField("solid", t.Solid()),
+		stringify.StructField("solidityType", t.SolidityType()),
 		stringify.StructField("solidificationTime", t.SolidificationTime()),
-		stringify.StructField("lazyBooked", t.LazyBooked()),
 		stringify.StructField("gradeOfFinality", t.GradeOfFinality()),
 		stringify.StructField("gradeOfFinalityTime", t.GradeOfFinalityTime()),
 	)
@@ -928,9 +915,8 @@ func (t *TransactionMetadata) ObjectStorageKey() []byte {
 func (t *TransactionMetadata) ObjectStorageValue() []byte {
 	return marshalutil.New().
 		Write(t.BranchID()).
-		WriteBool(t.Solid()).
+		Write(t.SolidityType()).
 		WriteTime(t.SolidificationTime()).
-		WriteBool(t.LazyBooked()).
 		WriteUint8(uint8(t.GradeOfFinality())).
 		WriteTime(t.GradeOfFinalityTime()).
 		Bytes()

--- a/packages/ledgerstate/transaction_test.go
+++ b/packages/ledgerstate/transaction_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/iotaledger/hive.go/identity"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/iotaledger/goshimmer/packages/consensus/gof"
 )
 
 var sampleColor = Color{2}
@@ -18,7 +20,7 @@ func TestTransaction_Bytes(t *testing.T) {
 
 	wallets := createWallets(2)
 	input := generateOutput(utxoDAG, wallets[0].address, 0)
-	tx, _ := singleInputTransaction(utxoDAG, wallets[0], wallets[1], input, false)
+	tx, _ := singleInputTransaction(utxoDAG, wallets[0], wallets[1], input, gof.Low)
 	bytes := tx.Bytes()
 	_tx, _, err := TransactionFromBytes(bytes)
 	assert.NoError(t, err)

--- a/packages/ledgerstate/utxo_dag.go
+++ b/packages/ledgerstate/utxo_dag.go
@@ -405,9 +405,10 @@ func (u *UTXODAG) bookTransaction(transaction *Transaction, transactionMetadata 
 
 		return InvalidBranchID, nil
 	}
-
+	fmt.Println("WUSE")
 	// check if transaction is attaching to something rejected
 	if rejected, rejectedBranch := u.inputsInRejectedBranch(inputsMetadata); rejected {
+		fmt.Println("WASE")
 		u.bookRejectedTransaction(transaction, transactionMetadata, rejectedBranch)
 
 		return rejectedBranch, nil
@@ -417,6 +418,7 @@ func (u *UTXODAG) bookTransaction(transaction *Transaction, transactionMetadata 
 	if inputsSpentByConfirmedTransaction, tmpErr := u.inputsSpentByConfirmedTransaction(inputsMetadata); tmpErr != nil {
 		return BranchID{}, errors.Errorf("failed to check if inputs were spent by confirmed Transaction: %w", err)
 	} else if inputsSpentByConfirmedTransaction {
+		fmt.Println("DRUSE")
 		return u.bookRejectedConflictingTransaction(transaction, transactionMetadata)
 	}
 
@@ -840,6 +842,7 @@ func (u *UTXODAG) inputsSpentByConfirmedTransaction(inputsMetadata OutputsMetada
 					err = errors.Errorf("failed to determine InclusionState of Transaction with %s: %w", consumer.TransactionID(), inclusionStateErr)
 					return
 				}
+				fmt.Println(inclusionState)
 				if inclusionState == gof.High {
 					cachedConsumers.Release()
 					inputsSpentByConfirmedTransaction = true

--- a/packages/ledgerstate/utxo_dag.go
+++ b/packages/ledgerstate/utxo_dag.go
@@ -10,11 +10,13 @@ import (
 	"github.com/iotaledger/hive.go/byteutils"
 	"github.com/iotaledger/hive.go/cerrors"
 	"github.com/iotaledger/hive.go/datastructure/set"
+	"github.com/iotaledger/hive.go/datastructure/walker"
 	"github.com/iotaledger/hive.go/events"
 	"github.com/iotaledger/hive.go/kvstore"
 	"github.com/iotaledger/hive.go/marshalutil"
 	"github.com/iotaledger/hive.go/objectstorage"
 	"github.com/iotaledger/hive.go/stringify"
+	"github.com/iotaledger/hive.go/syncutils"
 	"github.com/iotaledger/hive.go/types"
 	"github.com/iotaledger/hive.go/typeutils"
 
@@ -32,10 +34,11 @@ type IUTXODAG interface {
 	Events() *UTXODAGEvents
 	// Shutdown shuts down the UTXODAG and persists its state.
 	Shutdown()
+	// StoreTransaction adds a new Transaction to the ledger state. It returns a boolean that indicates whether the
+	// Transaction was stored, its SolidityType and an error value that contains the cause for possibly exceptions.
+	StoreTransaction(transaction *Transaction) (stored bool, solidityType SolidityType, err error)
 	// CheckTransaction contains fast checks that have to be performed before booking a Transaction.
 	CheckTransaction(transaction *Transaction) (err error)
-	// BookTransaction books a Transaction into the ledger state.
-	BookTransaction(transaction *Transaction) (targetBranch BranchID, err error)
 	// CachedTransaction retrieves the Transaction with the given TransactionID from the object storage.
 	CachedTransaction(transactionID TransactionID) (cachedTransaction *CachedTransaction)
 	// Transaction returns a specific transaction, consumed.
@@ -43,13 +46,13 @@ type IUTXODAG interface {
 	// Transactions returns all the transactions, consumed.
 	Transactions() (transactions map[TransactionID]*Transaction)
 	// CachedTransactionMetadata retrieves the TransactionMetadata with the given TransactionID from the object storage.
-	CachedTransactionMetadata(transactionID TransactionID) (cachedTransactionMetadata *CachedTransactionMetadata)
+	CachedTransactionMetadata(transactionID TransactionID, computeIfAbsentCallback ...func(transactionID TransactionID) *TransactionMetadata) (cachedTransactionMetadata *CachedTransactionMetadata)
 	// CachedOutput retrieves the Output with the given OutputID from the object storage.
 	CachedOutput(outputID OutputID) (cachedOutput *CachedOutput)
 	// CachedOutputMetadata retrieves the OutputMetadata with the given OutputID from the object storage.
 	CachedOutputMetadata(outputID OutputID) (cachedOutput *CachedOutputMetadata)
 	// CachedConsumers retrieves the Consumers of the given OutputID from the object storage.
-	CachedConsumers(outputID OutputID) (cachedConsumers CachedConsumers)
+	CachedConsumers(outputID OutputID, optionalSolidityType ...SolidityType) (cachedConsumers CachedConsumers)
 	// LoadSnapshot creates a set of outputs in the UTXO-DAG, that are forming the genesis for future transactions.
 	LoadSnapshot(snapshot *Snapshot)
 	// CachedAddressOutputMapping retrieves the outputs for the given address.
@@ -75,6 +78,8 @@ type UTXODAG struct {
 	addressOutputMappingStorage *objectstorage.ObjectStorage
 	branchDAG                   *BranchDAG
 	shutdownOnce                sync.Once
+
+	syncutils.MultiMutex
 }
 
 // NewUTXODAG create a new UTXODAG from the given details.
@@ -84,6 +89,7 @@ func NewUTXODAG(store kvstore.KVStore, cacheProvider *database.CacheTimeProvider
 	utxoDAG = &UTXODAG{
 		events: &UTXODAGEvents{
 			TransactionBranchIDUpdated: events.NewEvent(TransactionIDEventHandler),
+			TransactionSolid:           events.NewEvent(TransactionIDEventHandler),
 		},
 		transactionStorage:          osFactory.New(PrefixTransactionStorage, TransactionFromObjectStorage, options.transactionStorageOptions...),
 		transactionMetadataStorage:  osFactory.New(PrefixTransactionMetadataStorage, TransactionMetadataFromObjectStorage, options.transactionMetadataStorageOptions...),
@@ -113,7 +119,48 @@ func (u *UTXODAG) Shutdown() {
 	})
 }
 
-// CheckTransaction contains fast checks that have to be performed before booking a Transaction.
+// StoreTransaction adds a new Transaction to the ledger state. It returns a boolean that indicates whether the
+// Transaction was stored, its SolidityType and an error value that contains the cause for possibly exceptions.
+func (u *UTXODAG) StoreTransaction(transaction *Transaction) (stored bool, solidityType SolidityType, err error) {
+	propagationWalker := walker.New(true)
+
+	eventQueue := eventsNewQueue()
+
+	u.LockEntity(transaction)
+	u.CachedTransactionMetadata(transaction.ID(), func(transactionID TransactionID) *TransactionMetadata {
+		u.transactionStorage.Store(transaction).Release()
+		transactionMetadata := NewTransactionMetadata(transactionID)
+
+		err = u.solidifyTransaction(transaction, transactionMetadata, eventQueue, propagationWalker)
+		stored = true
+
+		return transactionMetadata
+	}).Consume(func(transactionMetadata *TransactionMetadata) {
+		solidityType = transactionMetadata.SolidityType()
+	})
+	u.UnlockEntity(transaction)
+
+	eventQueue.Trigger()
+
+	for propagationWalker.HasNext() {
+		transactionID := propagationWalker.Next().(TransactionID)
+
+		u.CachedTransaction(transactionID).Consume(func(transaction *Transaction) {
+			defer eventQueue.Trigger()
+
+			u.LockEntity(transaction)
+			defer u.UnlockEntity(transaction)
+
+			u.CachedTransactionMetadata(transactionID).Consume(func(transactionMetadata *TransactionMetadata) {
+				_ = u.solidifyTransaction(transaction, transactionMetadata, eventQueue, propagationWalker)
+			})
+		})
+	}
+
+	return stored, solidityType, err
+}
+
+// CheckTransaction checks if a Transaction is objectively valid.
 func (u *UTXODAG) CheckTransaction(transaction *Transaction) (err error) {
 	cachedConsumedOutputs := u.ConsumedOutputs(transaction)
 	defer cachedConsumedOutputs.Release()
@@ -123,92 +170,8 @@ func (u *UTXODAG) CheckTransaction(transaction *Transaction) (err error) {
 	if !u.allOutputsExist(consumedOutputs) {
 		return errors.Errorf("not all consumedOutputs of transaction are solid: %w", ErrTransactionNotSolid)
 	}
-	if !TransactionBalancesValid(consumedOutputs, transaction.Essence().Outputs()) {
-		return errors.Errorf("sum of consumed and spent balances is not 0: %w", ErrTransactionInvalid)
-	}
-	if !UnlockBlocksValid(consumedOutputs, transaction) {
-		return errors.Errorf("spending of referenced consumedOutputs is not authorized: %w", ErrTransactionInvalid)
-	}
-	if !AliasInitialStateValid(consumedOutputs, transaction) {
-		return errors.Errorf("initial state of created alias output is invalid: %w", ErrTransactionInvalid)
-	}
 
-	return nil
-}
-
-// BookTransaction books a Transaction into the ledger state.
-func (u *UTXODAG) BookTransaction(transaction *Transaction) (targetBranch BranchID, err error) {
-	cachedConsumedOutputs := u.ConsumedOutputs(transaction)
-	defer cachedConsumedOutputs.Release()
-	consumedOutputs := cachedConsumedOutputs.Unwrap()
-
-	// store TransactionMetadata
-	transactionMetadata := NewTransactionMetadata(transaction.ID())
-	transactionMetadata.SetSolid(true)
-	newTransaction := false
-	cachedTransactionMetadata := &CachedTransactionMetadata{CachedObject: u.transactionMetadataStorage.ComputeIfAbsent(transaction.ID().Bytes(), func(key []byte) objectstorage.StorableObject {
-		newTransaction = true
-
-		transactionMetadata.Persist()
-		transactionMetadata.SetModified()
-
-		return transactionMetadata
-	})}
-	if !newTransaction {
-		if !cachedTransactionMetadata.Consume(func(transactionMetadata *TransactionMetadata) {
-			targetBranch = transactionMetadata.BranchID()
-		}) {
-			err = errors.Errorf("failed to load TransactionMetadata with %s: %w", transaction.ID(), cerrors.ErrFatal)
-		}
-		return
-	}
-	defer cachedTransactionMetadata.Release()
-
-	// store Transaction
-	u.transactionStorage.Store(transaction).Release()
-
-	// retrieve the metadata of the Inputs
-	cachedInputsMetadata := u.transactionInputsMetadata(transaction)
-	defer cachedInputsMetadata.Release()
-	inputsMetadata := cachedInputsMetadata.Unwrap()
-
-	// check if Transaction is attaching to something invalid
-	if u.inputsInInvalidBranch(inputsMetadata) {
-		u.bookInvalidTransaction(transaction, transactionMetadata, inputsMetadata)
-		targetBranch = InvalidBranchID
-		return
-	}
-
-	// mark transaction as "permanently rejected"
-	if !u.consumedOutputsPastConeValid(consumedOutputs, inputsMetadata) {
-		u.bookInvalidTransaction(transaction, transactionMetadata, inputsMetadata)
-		targetBranch = InvalidBranchID
-		return
-	}
-
-	// determine the booking details before we book
-	branchesOfInputsConflicting, normalizedBranchIDs, conflictingInputs, err := u.determineBookingDetails(inputsMetadata)
-	if err != nil {
-		err = errors.Errorf("failed to determine book details of Transaction with %s: %w", transaction.ID(), err)
-		return
-	}
-
-	// are branches of inputs conflicting
-	if branchesOfInputsConflicting {
-		u.bookInvalidTransaction(transaction, transactionMetadata, inputsMetadata)
-		targetBranch = InvalidBranchID
-		err = errors.Errorf("branches of inputs are conflicting: %w", err)
-		return
-	}
-
-	switch len(conflictingInputs) {
-	case 0:
-		targetBranch = u.bookNonConflictingTransaction(transaction, transactionMetadata, inputsMetadata, normalizedBranchIDs)
-	default:
-		targetBranch = u.bookConflictingTransaction(transaction, transactionMetadata, inputsMetadata, normalizedBranchIDs, conflictingInputs.ByID())
-	}
-
-	return
+	return u.transactionObjectivelyValid(transaction, consumedOutputs)
 }
 
 // InclusionState returns the InclusionState of the Transaction with the given TransactionID which can either be
@@ -261,7 +224,13 @@ func (u *UTXODAG) Transactions() (transactions map[TransactionID]*Transaction) {
 }
 
 // CachedTransactionMetadata retrieves the TransactionMetadata with the given TransactionID from the object storage.
-func (u *UTXODAG) CachedTransactionMetadata(transactionID TransactionID) (cachedTransactionMetadata *CachedTransactionMetadata) {
+func (u *UTXODAG) CachedTransactionMetadata(transactionID TransactionID, computeIfAbsentCallback ...func(transactionID TransactionID) *TransactionMetadata) (cachedTransactionMetadata *CachedTransactionMetadata) {
+	if len(computeIfAbsentCallback) >= 1 {
+		return &CachedTransactionMetadata{u.transactionMetadataStorage.ComputeIfAbsent(transactionID.Bytes(), func(key []byte) objectstorage.StorableObject {
+			return computeIfAbsentCallback[0](transactionID)
+		})}
+	}
+
 	return &CachedTransactionMetadata{CachedObject: u.transactionMetadataStorage.Load(transactionID.Bytes())}
 }
 
@@ -276,13 +245,20 @@ func (u *UTXODAG) CachedOutputMetadata(outputID OutputID) (cachedOutput *CachedO
 }
 
 // CachedConsumers retrieves the Consumers of the given OutputID from the object storage.
-func (u *UTXODAG) CachedConsumers(outputID OutputID) (cachedConsumers CachedConsumers) {
+func (u *UTXODAG) CachedConsumers(outputID OutputID, optionalSolidityType ...SolidityType) (cachedConsumers CachedConsumers) {
+	var iterationPrefix []byte
+	if len(optionalSolidityType) >= 1 {
+		iterationPrefix = byteutils.ConcatBytes(outputID.Bytes(), optionalSolidityType[0].Bytes())
+	} else {
+		iterationPrefix = outputID.Bytes()
+	}
+
 	cachedConsumers = make(CachedConsumers, 0)
 	u.consumerStorage.ForEach(func(key []byte, cachedObject objectstorage.CachedObject) bool {
 		cachedConsumers = append(cachedConsumers, &CachedConsumer{CachedObject: cachedObject})
 
 		return true
-	}, objectstorage.WithIteratorPrefix(outputID.Bytes()))
+	}, objectstorage.WithIteratorPrefix(iterationPrefix))
 
 	return
 }
@@ -312,7 +288,6 @@ func (u *UTXODAG) LoadSnapshot(snapshot *Snapshot) {
 			// store OutputMetadata
 			metadata := NewOutputMetadata(output.ID())
 			metadata.SetBranchID(MasterBranchID)
-			metadata.SetSolid(true)
 			metadata.SetGradeOfFinality(gof.High)
 			cachedMetadata, stored := u.outputMetadataStorage.StoreIfAbsent(metadata)
 			if stored {
@@ -322,7 +297,7 @@ func (u *UTXODAG) LoadSnapshot(snapshot *Snapshot) {
 
 		// store TransactionMetadata
 		txMetadata := NewTransactionMetadata(txID)
-		txMetadata.SetSolid(true)
+		txMetadata.SetSolidityType(Solid)
 		txMetadata.SetBranchID(MasterBranchID)
 		txMetadata.SetGradeOfFinality(gof.High)
 
@@ -345,15 +320,178 @@ func (u *UTXODAG) CachedAddressOutputMapping(address Address) (cachedAddressOutp
 
 // region booking functions ////////////////////////////////////////////////////////////////////////////////////////////
 
+func (u *UTXODAG) solidifyTransaction(transaction *Transaction, transactionMetadata *TransactionMetadata, eventsQueue *eventsQueue, propagationWalker *walker.Walker) (err error) {
+	cachedConsumedOutputs := u.ConsumedOutputs(transaction)
+	defer cachedConsumedOutputs.Release()
+	consumedOutputs := cachedConsumedOutputs.Unwrap()
+
+	if !u.allOutputsExist(consumedOutputs) {
+		previousSolidityType := transactionMetadata.SetSolidityType(Unsolid)
+		if previousSolidityType >= Unsolid {
+			return
+		}
+
+		u.updateConsumers(transaction, previousSolidityType, Unsolid)
+
+		return
+	}
+
+	if validErr := u.transactionObjectivelyValid(transaction, consumedOutputs); validErr != nil {
+		eventsQueue.Queue(u.Events().TransactionInvalid, transaction, validErr)
+
+		return
+	}
+
+	if _, err = u.bookTransaction(transaction, transactionMetadata, consumedOutputs); err != nil {
+		err = errors.Errorf("failed to book Transaction with %s: %w", transaction.ID(), err)
+
+		eventsQueue.Queue(u.Events().Error, transaction, err)
+
+		return
+	}
+
+	for _, output := range transaction.Essence().Outputs() {
+		u.ManageStoreAddressOutputMapping(output)
+	}
+
+	eventsQueue.Queue(u.Events().TransactionSolid, transaction.ID())
+
+	for transactionID := range u.consumingTransactionIDs(transaction, Unsolid) {
+		propagationWalker.Push(transactionID)
+	}
+
+	return err
+}
+
+func (u *UTXODAG) updateConsumers(transaction *Transaction, previousSolidityType, newSolidityType SolidityType) {
+	if previousSolidityType == newSolidityType {
+		return
+	}
+
+	for _, input := range transaction.Essence().Inputs() {
+		if previousSolidityType != UndefinedSolidityType {
+			u.consumerStorage.Delete(NewConsumer(input.(*UTXOInput).ReferencedOutputID(), transaction.ID(), previousSolidityType).Bytes())
+		}
+
+		u.consumerStorage.Store(NewConsumer(input.(*UTXOInput).ReferencedOutputID(), transaction.ID(), newSolidityType)).Release()
+	}
+}
+
+func (u *UTXODAG) transactionObjectivelyValid(transaction *Transaction, consumedOutputs Outputs) (err error) {
+	if !TransactionBalancesValid(consumedOutputs, transaction.Essence().Outputs()) {
+		return errors.Errorf("sum of consumed and spent balances is not 0: %w", ErrTransactionInvalid)
+	}
+
+	if !UnlockBlocksValid(consumedOutputs, transaction) {
+		return errors.Errorf("spending of referenced consumedOutputs is not authorized: %w", ErrTransactionInvalid)
+	}
+
+	if !AliasInitialStateValid(consumedOutputs, transaction) {
+		return errors.Errorf("initial state of created alias output is invalid: %w", ErrTransactionInvalid)
+	}
+
+	return nil
+}
+
+func (u *UTXODAG) bookTransaction(transaction *Transaction, transactionMetadata *TransactionMetadata, consumedOutputs Outputs) (targetBranch BranchID, err error) {
+	// retrieve the metadata of the Inputs
+	cachedInputsMetadata := u.transactionInputsMetadata(transaction)
+	defer cachedInputsMetadata.Release()
+	inputsMetadata := cachedInputsMetadata.Unwrap()
+
+	// check if Transaction is attaching to something invalid
+	if u.inputsInInvalidBranch(inputsMetadata) {
+		u.bookInvalidTransaction(transaction, transactionMetadata)
+
+		return InvalidBranchID, nil
+	}
+
+	// check if transaction is attaching to something rejected
+	if rejected, rejectedBranch := u.inputsInRejectedBranch(inputsMetadata); rejected {
+		u.bookRejectedTransaction(transaction, transactionMetadata, rejectedBranch)
+
+		return rejectedBranch, nil
+	}
+
+	// check if any Input was spent by a confirmed Transaction already
+	if inputsSpentByConfirmedTransaction, tmpErr := u.inputsSpentByConfirmedTransaction(inputsMetadata); tmpErr != nil {
+		return BranchID{}, errors.Errorf("failed to check if inputs were spent by confirmed Transaction: %w", err)
+	} else if inputsSpentByConfirmedTransaction {
+		return u.bookRejectedConflictingTransaction(transaction, transactionMetadata)
+	}
+
+	// mark transaction as "permanently rejected"
+	if !u.consumedOutputsPastConeValid(consumedOutputs, inputsMetadata) {
+		u.bookInvalidTransaction(transaction, transactionMetadata)
+
+		return InvalidBranchID, nil
+	}
+
+	// determine the booking details before we book
+	branchesOfInputsConflicting, normalizedBranchIDs, conflictingInputs, err := u.determineBookingDetails(inputsMetadata)
+	if err != nil {
+		return BranchID{}, errors.Errorf("failed to determine booking details of Transaction with %s: %w", transaction.ID(), err)
+	}
+
+	// are branches of inputs conflicting
+	if branchesOfInputsConflicting {
+		u.bookInvalidTransaction(transaction, transactionMetadata)
+
+		return InvalidBranchID, nil
+	}
+
+	if len(conflictingInputs) != 0 {
+		return u.bookConflictingTransaction(transaction, transactionMetadata, inputsMetadata, normalizedBranchIDs, conflictingInputs.ByID()), nil
+	}
+
+	return u.bookNonConflictingTransaction(transaction, transactionMetadata, inputsMetadata, normalizedBranchIDs), nil
+}
+
+func (u *UTXODAG) consumingTransactionIDs(transaction *Transaction, optionalSolidityType ...SolidityType) (consumingTransactionIDs TransactionIDs) {
+	consumingTransactionIDs = make(TransactionIDs)
+	for _, output := range transaction.Essence().Outputs() {
+		u.CachedConsumers(output.ID(), optionalSolidityType...).Consume(func(consumer *Consumer) {
+			consumingTransactionIDs[consumer.TransactionID()] = types.Void
+		})
+	}
+
+	return consumingTransactionIDs
+}
+
 // bookInvalidTransaction is an internal utility function that books the given Transaction into the Branch identified by
 // the InvalidBranchID.
-func (u *UTXODAG) bookInvalidTransaction(transaction *Transaction, transactionMetadata *TransactionMetadata, inputsMetadata OutputsMetadata) {
+func (u *UTXODAG) bookInvalidTransaction(transaction *Transaction, transactionMetadata *TransactionMetadata) {
 	transactionMetadata.SetBranchID(InvalidBranchID)
-	transactionMetadata.SetSolid(true)
+	u.updateConsumers(transaction, transactionMetadata.SetSolidityType(Invalid), Invalid)
 	transactionMetadata.SetGradeOfFinality(gof.High)
 
-	u.bookConsumers(inputsMetadata, transaction.ID(), types.False)
 	u.bookOutputs(transaction, InvalidBranchID)
+}
+
+// bookRejectedTransaction is an internal utility function that "lazy" books the given Transaction into a rejected
+// Branch.
+func (u *UTXODAG) bookRejectedTransaction(transaction *Transaction, transactionMetadata *TransactionMetadata, rejectedBranch BranchID) {
+	transactionMetadata.SetBranchID(rejectedBranch)
+	u.updateConsumers(transaction, transactionMetadata.SetSolidityType(LazySolid), LazySolid)
+
+	u.bookOutputs(transaction, rejectedBranch)
+}
+
+// bookRejectedConflictingTransaction is an internal utility function that "lazy" books the given Transaction into its
+// own ConflictBranch which is immediately rejected and only kept in the DAG for possible reorgs.
+func (u *UTXODAG) bookRejectedConflictingTransaction(transaction *Transaction, transactionMetadata *TransactionMetadata) (targetBranch BranchID, err error) {
+	targetBranch = NewBranchID(transaction.ID())
+	cachedConflictBranch, _, conflictBranchErr := u.branchDAG.CreateConflictBranch(targetBranch, NewBranchIDs(LazyBookedConflictsBranchID), nil)
+	if conflictBranchErr != nil {
+		err = errors.Errorf("failed to create ConflictBranch for lazy booked Transaction with %s: %w", transaction.ID(), conflictBranchErr)
+		return
+	}
+	if !cachedConflictBranch.Consume(func(branch Branch) {
+		u.bookRejectedTransaction(transaction, transactionMetadata, targetBranch)
+	}) {
+		err = errors.Errorf("failed to load ConflictBranch with %s: %w", cachedConflictBranch.ID(), cerrors.ErrFatal)
+	}
+	return
 }
 
 // bookNonConflictingTransaction is an internal utility function that books the Transaction into the Branch that is
@@ -368,8 +506,13 @@ func (u *UTXODAG) bookNonConflictingTransaction(transaction *Transaction, transa
 		targetBranch = branch.ID()
 
 		transactionMetadata.SetBranchID(targetBranch)
-		transactionMetadata.SetSolid(true)
-		u.bookConsumers(inputsMetadata, transaction.ID(), types.True)
+		if previousSolidityType := transactionMetadata.SetSolidityType(Solid); previousSolidityType != Solid {
+			u.updateConsumers(transaction, previousSolidityType, Solid)
+
+			for _, inputMetadata := range inputsMetadata {
+				inputMetadata.RegisterConsumer(transaction.ID())
+			}
+		}
 		u.bookOutputs(transaction, targetBranch)
 	}) {
 		panic(fmt.Errorf("failed to load AggregatedBranch with %s", cachedAggregatedBranch.ID()))
@@ -387,7 +530,7 @@ func (u *UTXODAG) bookConflictingTransaction(transaction *Transaction, transacti
 		u.forkConsumer(transactionID, conflictingInputs)
 
 		return
-	}, types.True)
+	}, Solid)
 
 	// create new ConflictBranch
 	targetBranch = NewBranchID(transaction.ID())
@@ -399,8 +542,13 @@ func (u *UTXODAG) bookConflictingTransaction(transaction *Transaction, transacti
 	// book Transaction into new ConflictBranch
 	if !cachedConflictBranch.Consume(func(branch Branch) {
 		transactionMetadata.SetBranchID(targetBranch)
-		transactionMetadata.SetSolid(true)
-		u.bookConsumers(inputsMetadata, transaction.ID(), types.True)
+		if previousSolidityType := transactionMetadata.SetSolidityType(Solid); previousSolidityType != Solid {
+			u.updateConsumers(transaction, previousSolidityType, Solid)
+
+			for _, inputMetadata := range inputsMetadata {
+				inputMetadata.RegisterConsumer(transaction.ID())
+			}
+		}
 		u.bookOutputs(transaction, targetBranch)
 	}) {
 		panic(fmt.Errorf("failed to load ConflictBranch with %s", cachedConflictBranch.ID()))
@@ -447,7 +595,7 @@ func (u *UTXODAG) forkConsumer(transactionID TransactionID, conflictingInputs Ou
 			}
 		}
 
-		u.walkFutureCone(outputIds, u.propagateBranchUpdates, types.True)
+		u.walkFutureCone(outputIds, u.propagateBranchUpdates, Solid)
 	}) {
 		panic(fmt.Errorf("failed to load TransactionMetadata of Transaction with %s", transactionID))
 	}
@@ -500,28 +648,6 @@ func (u *UTXODAG) updateBranchOfTransaction(transactionID TransactionID, branchI
 	}
 
 	return
-}
-
-// bookConsumers creates the reference between an Output and its spending Transaction. It increases the ConsumerCount if
-// the Transaction is a valid spend.
-func (u *UTXODAG) bookConsumers(inputsMetadata OutputsMetadata, transactionID TransactionID, valid types.TriBool) {
-	for _, inputMetadata := range inputsMetadata {
-		if valid == types.True {
-			inputMetadata.RegisterConsumer(transactionID)
-		}
-
-		newConsumer := NewConsumer(inputMetadata.ID(), transactionID, valid)
-		if !(&CachedConsumer{CachedObject: u.consumerStorage.ComputeIfAbsent(newConsumer.ObjectStorageKey(), func(key []byte) objectstorage.StorableObject {
-			newConsumer.Persist()
-			newConsumer.SetModified()
-
-			return newConsumer
-		})}).Consume(func(consumer *Consumer) {
-			consumer.SetValid(valid)
-		}) {
-			panic("failed to update valid flag of Consumer")
-		}
-	}
 }
 
 // bookOutputs creates the Outputs and their corresponding OutputsMetadata in the object storage.
@@ -616,6 +742,26 @@ func (u *UTXODAG) inputsInInvalidBranch(inputsMetadata OutputsMetadata) (invalid
 	return
 }
 
+// inputsInRejectedBranch checks if any of the Inputs is booked into a rejected Branch.
+func (u *UTXODAG) inputsInRejectedBranch(inputsMetadata OutputsMetadata) (rejected bool, rejectedBranch BranchID) {
+	seenBranchIDs := set.New()
+	for _, inputMetadata := range inputsMetadata {
+		if rejectedBranch = inputMetadata.BranchID(); !seenBranchIDs.Add(rejectedBranch) {
+			continue
+		}
+
+		u.branchDAG.ForEachConflictingBranchID(rejectedBranch, func(conflictingBranchID BranchID) {
+			u.branchDAG.Branch(conflictingBranchID).Consume(func(branch Branch) {
+				rejected = rejected || branch.GradeOfFinality() == gof.High
+			})
+		})
+		if rejected {
+			return
+		}
+	}
+	return
+}
+
 // consumedOutputsPastConeValid is an internal utility function that checks if the given Outputs do not directly or
 // indirectly reference each other in their own past cone.
 func (u *UTXODAG) consumedOutputsPastConeValid(outputs Outputs, outputsMetadata OutputsMetadata) (pastConeValid bool) {
@@ -680,6 +826,32 @@ func (u *UTXODAG) outputsUnspent(outputsMetadata OutputsMetadata) (outputsUnspen
 	return true
 }
 
+// inputsSpentByConfirmedTransaction is an internal utility function that checks if any of the given inputs was spent by
+// a confirmed Transaction already.
+func (u *UTXODAG) inputsSpentByConfirmedTransaction(inputsMetadata OutputsMetadata) (inputsSpentByConfirmedTransaction bool, err error) {
+	for _, inputMetadata := range inputsMetadata {
+		if inputMetadata.ConsumerCount() >= 1 {
+			cachedConsumers := u.CachedConsumers(inputMetadata.ID())
+			consumers := cachedConsumers.Unwrap()
+			for _, consumer := range consumers {
+				inclusionState, inclusionStateErr := u.GradeOfFinality(consumer.TransactionID())
+				if inclusionStateErr != nil {
+					cachedConsumers.Release()
+					err = errors.Errorf("failed to determine InclusionState of Transaction with %s: %w", consumer.TransactionID(), inclusionStateErr)
+					return
+				}
+				if inclusionState == gof.High {
+					cachedConsumers.Release()
+					inputsSpentByConfirmedTransaction = true
+					return
+				}
+			}
+			cachedConsumers.Release()
+		}
+	}
+	return
+}
+
 // consumedOutputIDsOfTransaction is an internal utility function returns a list of OutputIDs that were consumed by a
 // given Transaction. If the Transaction can not be found, it returns an empty list.
 func (u *UTXODAG) consumedOutputIDsOfTransaction(transactionID TransactionID) (inputIDs []OutputID) {
@@ -709,7 +881,7 @@ func (u *UTXODAG) createdOutputIDsOfTransaction(transactionID TransactionID) (ou
 // walkFutureCone is an internal utility function that walks through the future cone of the given Outputs and calling
 // the callback function on each step. It is possible to provide an optional filter for the valid flag of the Consumer
 // to only walk through matching Consumers.
-func (u *UTXODAG) walkFutureCone(entryPoints []OutputID, callback func(transactionID TransactionID) (nextOutputsToVisit []OutputID), optionalValidFlagFilter ...types.TriBool) {
+func (u *UTXODAG) walkFutureCone(entryPoints []OutputID, callback func(transactionID TransactionID) (nextOutputsToVisit []OutputID), optionalValidFlagFilter ...SolidityType) {
 	stack := list.New()
 	for _, outputID := range entryPoints {
 		stack.PushBack(outputID)
@@ -725,7 +897,7 @@ func (u *UTXODAG) walkFutureCone(entryPoints []OutputID, callback func(transacti
 				return
 			}
 
-			if len(optionalValidFlagFilter) >= 1 && consumer.Valid() != optionalValidFlagFilter[0] {
+			if len(optionalValidFlagFilter) >= 1 && consumer.SolidityType() != optionalValidFlagFilter[0] {
 				return
 			}
 
@@ -809,6 +981,15 @@ func (u *UTXODAG) lockTransaction(transaction *Transaction) {
 
 // UTXODAGEvents is a container for all of the UTXODAG related events.
 type UTXODAGEvents struct {
+	// Error is triggered when an unexpected error occurred in the component.
+	Error *events.Event
+
+	// TransactionInvalid gets triggered whenever an objectively invalid Transaction is detected.
+	TransactionInvalid *events.Event
+
+	// TransactionSolid gets triggered whenever a Transaction becomes LazySolid, Solid, or Invalid.
+	TransactionSolid *events.Event
+
 	// TransactionBranchIDUpdated gets triggered when the BranchID of a Transaction is changed after the initial booking.
 	TransactionBranchIDUpdated *events.Event
 }
@@ -902,7 +1083,7 @@ func (a *AddressOutputMapping) String() (humanReadableConsumer string) {
 }
 
 // Update is disabled and panics if it ever gets called - it is required to match the StorableObject interface.
-func (a *AddressOutputMapping) Update(other objectstorage.StorableObject) {
+func (a *AddressOutputMapping) Update(objectstorage.StorableObject) {
 	panic("updates disabled")
 }
 
@@ -1024,29 +1205,100 @@ func (c CachedAddressOutputMappings) String() string {
 
 // endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+// region SolidityType /////////////////////////////////////////////////////////////////////////////////////////////////
+
+// SolidityType is a type that specifies the types of solid states that a transaction can be in.
+type SolidityType uint8
+
+// SolidityTypeLength defines the amount of bytes of a marshaled SolidityType.
+const SolidityTypeLength = 1
+
+const (
+	// UndefinedSolidityType represents the zero value of the SolidityType.
+	UndefinedSolidityType SolidityType = iota
+
+	// Unsolid represents transactions that are not solid, yet.
+	Unsolid
+
+	// LazySolid represents transactions that are solid but not fully booked because they spend funds of rejected or
+	// invalid Branches.
+	LazySolid
+
+	// Solid represents transaction that are solid and fully booked.
+	Solid
+
+	// Invalid represents transactions that are solid and fully booked but spend outputs from conflicting branches.
+	Invalid
+)
+
+// SolidityTypeFromBytes unmarshals a SolidityType from a sequence of bytes.
+func SolidityTypeFromBytes(solidityTypeBytes []byte) (solidityType SolidityType, consumedBytes int, err error) {
+	marshalUtil := marshalutil.New(solidityTypeBytes)
+	if solidityType, err = SolidityTypeFromMarshalUtil(marshalUtil); err != nil {
+		err = errors.Errorf("failed to parse SolidityType from MarshalUtil: %w", err)
+		return
+	}
+	consumedBytes = marshalUtil.ReadOffset()
+
+	return
+}
+
+// SolidityTypeFromMarshalUtil unmarshals a SolidityType using a MarshalUtil (for easier unmarshaling).
+func SolidityTypeFromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (solidityType SolidityType, err error) {
+	untypedSolidityType, err := marshalUtil.ReadUint8()
+	if err != nil {
+		err = errors.Errorf("failed to parse SolidityType (%v): %w", err, cerrors.ErrParseBytesFailed)
+		return
+	}
+
+	return SolidityType(untypedSolidityType), nil
+}
+
+// Bytes returns a marshaled version of the SolidityType.
+func (c SolidityType) Bytes() (marshaledSolidityType []byte) {
+	return []byte{uint8(c)}
+}
+
+// String returns a human readable version of the SolidityType.
+func (c SolidityType) String() (humanReadableSolidityType string) {
+	switch c {
+	case UndefinedSolidityType:
+		return "SolidityType(UndefinedSolidityType)"
+	case Unsolid:
+		return "SolidityType(Unsolid)"
+	case Solid:
+		return "SolidityType(Solid)"
+	case LazySolid:
+		return "SolidityType(LazySolid)"
+	default:
+		return "SolidityType(" + strconv.Itoa(int(c)) + ")"
+	}
+}
+
+// endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 // region Consumer /////////////////////////////////////////////////////////////////////////////////////////////////////
 
 // ConsumerPartitionKeys defines the "layout" of the key. This enables prefix iterations in the objectstorage.
-var ConsumerPartitionKeys = objectstorage.PartitionKey([]int{OutputIDLength, TransactionIDLength}...)
+var ConsumerPartitionKeys = objectstorage.PartitionKey([]int{OutputIDLength, SolidityTypeLength, TransactionIDLength}...)
 
 // Consumer represents the relationship between an Output and its spending Transactions. Since an Output can have a
 // potentially unbounded amount of spending Transactions, we store this as a separate k/v pair instead of a marshaled
 // list of spending Transactions inside the Output.
 type Consumer struct {
+	solidityType  SolidityType
 	consumedInput OutputID
 	transactionID TransactionID
-	validMutex    sync.RWMutex
-	valid         types.TriBool
 
 	objectstorage.StorableObjectFlags
 }
 
 // NewConsumer creates a Consumer object from the given information.
-func NewConsumer(consumedInput OutputID, transactionID TransactionID, valid types.TriBool) *Consumer {
+func NewConsumer(consumedInput OutputID, transactionID TransactionID, solidityType SolidityType) *Consumer {
 	return &Consumer{
 		consumedInput: consumedInput,
 		transactionID: transactionID,
-		valid:         valid,
+		solidityType:  solidityType,
 	}
 }
 
@@ -1069,12 +1321,12 @@ func ConsumerFromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (consumer *Co
 		err = errors.Errorf("failed to parse consumed Input from MarshalUtil: %w", err)
 		return
 	}
-	if consumer.transactionID, err = TransactionIDFromMarshalUtil(marshalUtil); err != nil {
-		err = errors.Errorf("failed to parse TransactionID from MarshalUtil: %w", err)
+	if consumer.solidityType, err = SolidityTypeFromMarshalUtil(marshalUtil); err != nil {
+		err = errors.Errorf("failed to parse SolidityType from MarshalUtil: %w", err)
 		return
 	}
-	if consumer.valid, err = types.TriBoolFromMarshalUtil(marshalUtil); err != nil {
-		err = errors.Errorf("failed to parse valid flag (%v): %w", err, cerrors.ErrParseBytesFailed)
+	if consumer.transactionID, err = TransactionIDFromMarshalUtil(marshalUtil); err != nil {
+		err = errors.Errorf("failed to parse TransactionID from MarshalUtil: %w", err)
 		return
 	}
 
@@ -1097,33 +1349,14 @@ func (c *Consumer) ConsumedInput() OutputID {
 	return c.consumedInput
 }
 
+// SolidityType returns the type of the Consumer.
+func (c *Consumer) SolidityType() (solidityType SolidityType) {
+	return c.solidityType
+}
+
 // TransactionID returns the TransactionID of the consuming Transaction.
 func (c *Consumer) TransactionID() TransactionID {
 	return c.transactionID
-}
-
-// Valid returns a flag that indicates if the spending Transaction is valid or not.
-func (c *Consumer) Valid() (valid types.TriBool) {
-	c.validMutex.RLock()
-	defer c.validMutex.RUnlock()
-
-	return c.valid
-}
-
-// SetValid updates the valid flag of the Consumer and returns true if the value was changed.
-func (c *Consumer) SetValid(valid types.TriBool) (updated bool) {
-	c.validMutex.Lock()
-	defer c.validMutex.Unlock()
-
-	if valid == c.valid {
-		return
-	}
-
-	c.valid = valid
-	c.SetModified()
-	updated = true
-
-	return
 }
 
 // Bytes marshals the Consumer into a sequence of bytes.
@@ -1135,27 +1368,26 @@ func (c *Consumer) Bytes() []byte {
 func (c *Consumer) String() (humanReadableConsumer string) {
 	return stringify.Struct("Consumer",
 		stringify.StructField("consumedInput", c.consumedInput),
+		stringify.StructField("solidityType", c.solidityType),
 		stringify.StructField("transactionID", c.transactionID),
 	)
 }
 
 // Update is disabled and panics if it ever gets called - it is required to match the StorableObject interface.
-func (c *Consumer) Update(other objectstorage.StorableObject) {
+func (c *Consumer) Update(objectstorage.StorableObject) {
 	panic("updates disabled")
 }
 
 // ObjectStorageKey returns the key that is used to store the object in the database. It is required to match the
 // StorableObject interface.
 func (c *Consumer) ObjectStorageKey() []byte {
-	return byteutils.ConcatBytes(c.consumedInput.Bytes(), c.transactionID.Bytes())
+	return byteutils.ConcatBytes(c.consumedInput.Bytes(), c.solidityType.Bytes(), c.transactionID.Bytes())
 }
 
 // ObjectStorageValue marshals the Consumer into a sequence of bytes that are used as the value part in the object
 // storage.
 func (c *Consumer) ObjectStorageValue() []byte {
-	return marshalutil.New(marshalutil.BoolSize).
-		Write(c.Valid()).
-		Bytes()
+	return nil
 }
 
 // code contract (make sure the struct implements all required methods)

--- a/packages/ledgerstate/utxo_dag_test.go
+++ b/packages/ledgerstate/utxo_dag_test.go
@@ -34,18 +34,27 @@ func TestExampleC(t *testing.T) {
 	{
 		outputs["A"] = generateOutput(utxoDAG, wallets[0].address, 0)
 		transactions["TX1"] = buildTransaction(utxoDAG, wallets[0], wallets[0], []*SigLockedSingleOutput{outputs["A"]})
-		targetBranch1, err := utxoDAG.BookTransaction(transactions["TX1"])
+		stored, solidityType, err := utxoDAG.StoreTransaction(transactions["TX1"])
+		require.True(t, stored)
+		require.Equal(t, solidityType, Solid)
 		require.NoError(t, err)
-		assert.Equal(t, MasterBranchID, targetBranch1)
+		require.True(t, utxoDAG.CachedTransactionMetadata(transactions["TX1"].ID()).Consume(func(transactionMetadata *TransactionMetadata) {
+			assert.Equal(t, MasterBranchID, transactionMetadata.BranchID())
+		}))
 	}
 
 	// Prepare and book TX2
 	{
 		outputs["B"] = generateOutput(utxoDAG, wallets[0].address, 1)
 		transactions["TX2"] = buildTransaction(utxoDAG, wallets[0], wallets[0], []*SigLockedSingleOutput{outputs["B"]})
-		targetBranch2, err := utxoDAG.BookTransaction(transactions["TX2"])
+		stored, solidityType, err := utxoDAG.StoreTransaction(transactions["TX2"])
 		require.NoError(t, err)
-		assert.Equal(t, MasterBranchID, targetBranch2)
+		require.True(t, stored)
+		require.Equal(t, solidityType, Solid)
+		require.NoError(t, err)
+		require.True(t, utxoDAG.CachedTransactionMetadata(transactions["TX2"].ID()).Consume(func(transactionMetadata *TransactionMetadata) {
+			assert.Equal(t, MasterBranchID, transactionMetadata.BranchID())
+		}))
 	}
 
 	// Prepare and book TX3
@@ -54,25 +63,40 @@ func TestExampleC(t *testing.T) {
 		outputs["D"] = transactions["TX2"].Essence().Outputs()[0].(*SigLockedSingleOutput)
 
 		transactions["TX3"] = buildTransaction(utxoDAG, wallets[0], wallets[0], []*SigLockedSingleOutput{outputs["C"], outputs["D"]})
-		targetBranch3, err := utxoDAG.BookTransaction(transactions["TX3"])
+		stored, solidityType, err := utxoDAG.StoreTransaction(transactions["TX3"])
 		require.NoError(t, err)
-		assert.Equal(t, MasterBranchID, targetBranch3)
+		require.True(t, stored)
+		require.Equal(t, solidityType, Solid)
+		require.NoError(t, err)
+		require.True(t, utxoDAG.CachedTransactionMetadata(transactions["TX3"].ID()).Consume(func(transactionMetadata *TransactionMetadata) {
+			assert.Equal(t, MasterBranchID, transactionMetadata.BranchID())
+		}))
 	}
 
 	// Prepare and book Tx4 (double spending B)
 	{
 		transactions["TX4"] = buildTransaction(utxoDAG, wallets[0], wallets[1], []*SigLockedSingleOutput{outputs["B"]})
-		targetBranch4, err := utxoDAG.BookTransaction(transactions["TX4"])
+		stored, solidityType, err := utxoDAG.StoreTransaction(transactions["TX4"])
 		require.NoError(t, err)
-		assert.Equal(t, NewBranchID(transactions["TX4"].ID()), targetBranch4)
+		require.True(t, stored)
+		require.Equal(t, solidityType, Solid)
+		require.NoError(t, err)
+		require.True(t, utxoDAG.CachedTransactionMetadata(transactions["TX4"].ID()).Consume(func(transactionMetadata *TransactionMetadata) {
+			assert.Equal(t, NewBranchID(transactions["TX4"].ID()), transactionMetadata.BranchID())
+		}))
 	}
 
 	// Prepare and book TX5 (double spending A)
 	{
 		transactions["TX5"] = buildTransaction(utxoDAG, wallets[0], wallets[1], []*SigLockedSingleOutput{outputs["A"]})
-		targetBranch5, err := utxoDAG.BookTransaction(transactions["TX5"])
+		stored, solidityType, err := utxoDAG.StoreTransaction(transactions["TX5"])
 		require.NoError(t, err)
-		assert.Equal(t, NewBranchID(transactions["TX5"].ID()), targetBranch5)
+		require.True(t, stored)
+		require.Equal(t, solidityType, Solid)
+		require.NoError(t, err)
+		require.True(t, utxoDAG.CachedTransactionMetadata(transactions["TX5"].ID()).Consume(func(transactionMetadata *TransactionMetadata) {
+			assert.Equal(t, NewBranchID(transactions["TX5"].ID()), transactionMetadata.BranchID())
+		}))
 	}
 
 	// Checking TX3
@@ -112,18 +136,28 @@ func TestExampleB(t *testing.T) {
 	{
 		outputs["A"] = generateOutput(utxoDAG, wallets[0].address, 0)
 		transactions["TX1"] = buildTransaction(utxoDAG, wallets[0], wallets[0], []*SigLockedSingleOutput{outputs["A"]})
-		targetBranch1, err := utxoDAG.BookTransaction(transactions["TX1"])
+		stored, solidityType, err := utxoDAG.StoreTransaction(transactions["TX1"])
 		require.NoError(t, err)
-		assert.Equal(t, MasterBranchID, targetBranch1)
+		require.True(t, stored)
+		require.Equal(t, solidityType, Solid)
+		require.NoError(t, err)
+		require.True(t, utxoDAG.CachedTransactionMetadata(transactions["TX1"].ID()).Consume(func(transactionMetadata *TransactionMetadata) {
+			assert.Equal(t, MasterBranchID, transactionMetadata.BranchID())
+		}))
 	}
 
 	// Prepare and book TX2
 	{
 		outputs["B"] = generateOutput(utxoDAG, wallets[0].address, 1)
 		transactions["TX2"] = buildTransaction(utxoDAG, wallets[0], wallets[0], []*SigLockedSingleOutput{outputs["B"]})
-		targetBranch2, err := utxoDAG.BookTransaction(transactions["TX2"])
+		stored, solidityType, err := utxoDAG.StoreTransaction(transactions["TX2"])
 		require.NoError(t, err)
-		assert.Equal(t, MasterBranchID, targetBranch2)
+		require.True(t, stored)
+		require.Equal(t, solidityType, Solid)
+		require.NoError(t, err)
+		require.True(t, utxoDAG.CachedTransactionMetadata(transactions["TX2"].ID()).Consume(func(transactionMetadata *TransactionMetadata) {
+			assert.Equal(t, MasterBranchID, transactionMetadata.BranchID())
+		}))
 	}
 
 	// Prepare and book TX3
@@ -132,17 +166,27 @@ func TestExampleB(t *testing.T) {
 		outputs["D"] = transactions["TX2"].Essence().Outputs()[0].(*SigLockedSingleOutput)
 
 		transactions["TX3"] = buildTransaction(utxoDAG, wallets[0], wallets[0], []*SigLockedSingleOutput{outputs["C"], outputs["D"]})
-		targetBranch3, err := utxoDAG.BookTransaction(transactions["TX3"])
+		stored, solidityType, err := utxoDAG.StoreTransaction(transactions["TX3"])
 		require.NoError(t, err)
-		assert.Equal(t, MasterBranchID, targetBranch3)
+		require.True(t, stored)
+		require.Equal(t, solidityType, Solid)
+		require.NoError(t, err)
+		require.True(t, utxoDAG.CachedTransactionMetadata(transactions["TX3"].ID()).Consume(func(transactionMetadata *TransactionMetadata) {
+			assert.Equal(t, MasterBranchID, transactionMetadata.BranchID())
+		}))
 	}
 
 	// Prepare and book Tx4
 	{
 		transactions["TX4"] = buildTransaction(utxoDAG, wallets[0], wallets[1], []*SigLockedSingleOutput{outputs["D"]})
-		targetBranch4, err := utxoDAG.BookTransaction(transactions["TX4"])
+		stored, solidityType, err := utxoDAG.StoreTransaction(transactions["TX4"])
 		require.NoError(t, err)
-		assert.Equal(t, NewBranchID(transactions["TX4"].ID()), targetBranch4)
+		require.True(t, stored)
+		require.Equal(t, solidityType, Solid)
+		require.NoError(t, err)
+		require.True(t, utxoDAG.CachedTransactionMetadata(transactions["TX4"].ID()).Consume(func(transactionMetadata *TransactionMetadata) {
+			assert.Equal(t, NewBranchID(transactions["TX4"].ID()), transactionMetadata.BranchID())
+		}))
 	}
 
 	// Checking TX3
@@ -175,9 +219,14 @@ func TestExampleB(t *testing.T) {
 	// Prepare and book TX5
 	{
 		transactions["TX5"] = buildTransaction(utxoDAG, wallets[0], wallets[1], []*SigLockedSingleOutput{outputs["B"]})
-		targetBranch5, err := utxoDAG.BookTransaction(transactions["TX5"])
+		stored, solidityType, err := utxoDAG.StoreTransaction(transactions["TX5"])
 		require.NoError(t, err)
-		assert.Equal(t, NewBranchID(transactions["TX5"].ID()), targetBranch5)
+		require.True(t, stored)
+		require.Equal(t, solidityType, Solid)
+		require.NoError(t, err)
+		require.True(t, utxoDAG.CachedTransactionMetadata(transactions["TX5"].ID()).Consume(func(transactionMetadata *TransactionMetadata) {
+			assert.Equal(t, NewBranchID(transactions["TX5"].ID()), transactionMetadata.BranchID())
+		}))
 	}
 
 	// Checking that the BranchID of TX2 is correct and it is the parent of both TX3 and TX4.
@@ -211,18 +260,28 @@ func TestExampleA(t *testing.T) {
 	{
 		outputs["A"] = generateOutput(utxoDAG, wallets[0].address, 0)
 		transactions["TX1"] = buildTransaction(utxoDAG, wallets[0], wallets[0], []*SigLockedSingleOutput{outputs["A"]})
-		targetBranch1, err := utxoDAG.BookTransaction(transactions["TX1"])
+		stored, solidityType, err := utxoDAG.StoreTransaction(transactions["TX1"])
 		require.NoError(t, err)
-		assert.Equal(t, MasterBranchID, targetBranch1)
+		require.True(t, stored)
+		require.Equal(t, solidityType, Solid)
+		require.NoError(t, err)
+		require.True(t, utxoDAG.CachedTransactionMetadata(transactions["TX1"].ID()).Consume(func(transactionMetadata *TransactionMetadata) {
+			assert.Equal(t, MasterBranchID, transactionMetadata.BranchID())
+		}))
 	}
 
 	// Prepare and book TX2
 	{
 		outputs["B"] = generateOutput(utxoDAG, wallets[0].address, 1)
 		transactions["TX2"] = buildTransaction(utxoDAG, wallets[0], wallets[0], []*SigLockedSingleOutput{outputs["B"]})
-		targetBranch2, err := utxoDAG.BookTransaction(transactions["TX2"])
+		stored, solidityType, err := utxoDAG.StoreTransaction(transactions["TX2"])
 		require.NoError(t, err)
-		assert.Equal(t, MasterBranchID, targetBranch2)
+		require.True(t, stored)
+		require.Equal(t, solidityType, Solid)
+		require.NoError(t, err)
+		require.True(t, utxoDAG.CachedTransactionMetadata(transactions["TX2"].ID()).Consume(func(transactionMetadata *TransactionMetadata) {
+			assert.Equal(t, MasterBranchID, transactionMetadata.BranchID())
+		}))
 	}
 
 	// Prepare and book TX3
@@ -231,17 +290,27 @@ func TestExampleA(t *testing.T) {
 		outputs["D"] = transactions["TX2"].Essence().Outputs()[0].(*SigLockedSingleOutput)
 
 		transactions["TX3"] = buildTransaction(utxoDAG, wallets[0], wallets[0], []*SigLockedSingleOutput{outputs["C"], outputs["D"]})
-		targetBranch3, err := utxoDAG.BookTransaction(transactions["TX3"])
+		stored, solidityType, err := utxoDAG.StoreTransaction(transactions["TX3"])
 		require.NoError(t, err)
-		assert.Equal(t, MasterBranchID, targetBranch3)
+		require.True(t, stored)
+		require.Equal(t, solidityType, Solid)
+		require.NoError(t, err)
+		require.True(t, utxoDAG.CachedTransactionMetadata(transactions["TX3"].ID()).Consume(func(transactionMetadata *TransactionMetadata) {
+			assert.Equal(t, MasterBranchID, transactionMetadata.BranchID())
+		}))
 	}
 
 	// Prepare and book Tx4 (double spending B)
 	{
 		transactions["TX4"] = buildTransaction(utxoDAG, wallets[0], wallets[1], []*SigLockedSingleOutput{outputs["B"]})
-		targetBranch4, err := utxoDAG.BookTransaction(transactions["TX4"])
+		stored, solidityType, err := utxoDAG.StoreTransaction(transactions["TX4"])
 		require.NoError(t, err)
-		assert.Equal(t, NewBranchID(transactions["TX4"].ID()), targetBranch4)
+		require.True(t, stored)
+		require.Equal(t, solidityType, Solid)
+		require.NoError(t, err)
+		require.True(t, utxoDAG.CachedTransactionMetadata(transactions["TX4"].ID()).Consume(func(transactionMetadata *TransactionMetadata) {
+			assert.Equal(t, NewBranchID(transactions["TX4"].ID()), transactionMetadata.BranchID())
+		}))
 	}
 
 	// Checking TX2
@@ -267,7 +336,7 @@ func TestExampleA(t *testing.T) {
 	}
 }
 
-func TestBookTransaction(t *testing.T) {
+func TestStoreTransaction(t *testing.T) {
 	branchDAG, utxoDAG := setupDependencies(t)
 	defer branchDAG.Shutdown()
 
@@ -275,9 +344,14 @@ func TestBookTransaction(t *testing.T) {
 	input := generateOutput(utxoDAG, wallets[0].address, 0)
 
 	tx := buildTransaction(utxoDAG, wallets[0], wallets[0], []*SigLockedSingleOutput{input})
-	targetBranch, err := utxoDAG.BookTransaction(tx)
+	stored, solidityType, err := utxoDAG.StoreTransaction(tx)
 	require.NoError(t, err)
-	assert.Equal(t, MasterBranchID, targetBranch)
+	require.True(t, stored)
+	require.Equal(t, solidityType, Solid)
+	require.NoError(t, err)
+	require.True(t, utxoDAG.CachedTransactionMetadata(tx.ID()).Consume(func(transactionMetadata *TransactionMetadata) {
+		assert.Equal(t, MasterBranchID, transactionMetadata.BranchID())
+	}))
 }
 
 func TestBookInvalidTransaction(t *testing.T) {
@@ -297,11 +371,36 @@ func TestBookInvalidTransaction(t *testing.T) {
 		inputsMetadata = append(inputsMetadata, metadata)
 	})
 
-	utxoDAG.bookInvalidTransaction(tx, txMetadata, inputsMetadata)
+	utxoDAG.bookInvalidTransaction(tx, txMetadata)
 
 	assert.Equal(t, InvalidBranchID, txMetadata.branchID)
-	assert.True(t, txMetadata.Solid())
+	assert.Equal(t, Invalid, txMetadata.SolidityType())
 	assert.Greater(t, txMetadata.GradeOfFinality(), gof.Medium)
+
+	// check that the inputs are still marked as unspent
+	assert.True(t, utxoDAG.outputsUnspent(inputsMetadata))
+}
+
+func TestBookRejectedTransaction(t *testing.T) {
+	branchDAG, utxoDAG := setupDependencies(t)
+	defer branchDAG.Shutdown()
+	wallets := createWallets(1)
+	input := generateOutput(utxoDAG, wallets[0].address, 0)
+	tx, _ := singleInputTransaction(utxoDAG, wallets[0], wallets[0], input, false)
+	rejectedBranch := NewConflictBranch(BranchID(tx.ID()), nil, nil)
+	utxoDAG.branchDAG.branchStorage.Store(rejectedBranch).Release()
+	cachedTxMetadata := utxoDAG.CachedTransactionMetadata(tx.ID())
+	defer cachedTxMetadata.Release()
+	txMetadata := cachedTxMetadata.Unwrap()
+	inputsMetadata := OutputsMetadata{}
+	utxoDAG.transactionInputsMetadata(tx).Consume(func(metadata *OutputMetadata) {
+		inputsMetadata = append(inputsMetadata, metadata)
+	})
+
+	utxoDAG.bookRejectedTransaction(tx, txMetadata, rejectedBranch.ID())
+
+	assert.Equal(t, rejectedBranch.ID(), txMetadata.branchID)
+	assert.Equal(t, LazySolid, txMetadata.SolidityType())
 
 	// check that the inputs are still marked as unspent
 	assert.True(t, utxoDAG.outputsUnspent(inputsMetadata))
@@ -330,7 +429,7 @@ func TestBookNonConflictingTransaction(t *testing.T) {
 
 	utxoDAG.branchDAG.Branch(txMetadata.BranchID()).Consume(func(branch Branch) {
 		assert.Equal(t, MasterBranchID, txMetadata.BranchID())
-		assert.True(t, txMetadata.Solid())
+		assert.Equal(t, Solid, txMetadata.SolidityType())
 	})
 
 	finality, err := utxoDAG.GradeOfFinality(tx.ID())
@@ -383,7 +482,7 @@ func TestBookConflictingTransaction(t *testing.T) {
 
 	utxoDAG.branchDAG.Branch(txMetadata2.BranchID()).Consume(func(branch Branch) {
 		assert.Equal(t, targetBranch2, txMetadata2.BranchID())
-		assert.True(t, txMetadata2.Solid())
+		assert.Equal(t, Solid, txMetadata2.SolidityType())
 	})
 
 	assert.NotEqual(t, MasterBranchID, txMetadata.BranchID())
@@ -835,7 +934,6 @@ func singleInputTransaction(utxoDAG *UTXODAG, a, b wallet, outputToSpend *SigLoc
 
 	// store TransactionMetadata
 	transactionMetadata := NewTransactionMetadata(tx.ID())
-	transactionMetadata.SetSolid(true)
 	transactionMetadata.SetBranchID(MasterBranchID)
 
 	if highgof {
@@ -880,7 +978,6 @@ func multipleInputsTransaction(utxoDAG *UTXODAG, a, b wallet, outputsToSpend []*
 
 	// store TransactionMetadata
 	transactionMetadata := NewTransactionMetadata(tx.ID())
-	transactionMetadata.SetSolid(true)
 	transactionMetadata.SetBranchID(branchID)
 	if highgof {
 		transactionMetadata.SetGradeOfFinality(gof.High)


### PR DESCRIPTION
# Description of change

This PR modifies the solidification logic to not solidify past weak parents. This allows us to use the weak parents as a way to exclude undesired messages from the tangle (e.g. as part of the congestion control).

It introduces the following changes to the definition of being solid:

1. A message is solid, if its strong parents are solid and its weak parents are at least weakly solid.
2. A message is weakly solid if it either has a data payload or if its weak parents are at least weakly solid.
3. A message is invalid if any of its weak parents doesn't pass the parents age check, or if it doesn't have weak parents and its strong parents don't pass the parents age check.

If the Solidifier requests missing weak parents, then he skips downloading their strong past cone unless another message references the same message with a strong parent.

The UTXODAG now also has a concept of Solidity and instead of booking the Transactions, we just store them and let them wait to become solid (we do not actively request transactions).

Messages only become solid after their transaction has become solid, which means that by the time we reach the Booker, the Transaction is already fully booked and associated to a branch.

## Type of change

- Enhancement (a non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
