### PR TITLE
Fix: GradeOfFinality

### DIFF
--- a/packages/consensus/finality/finality_gadget.go
+++ b/packages/consensus/finality/finality_gadget.go
@@ -170,11 +170,8 @@ func (s *SimpleFinalityGadget) IsMessageConfirmed(msgID tangle.MessageID) (confi
 
 // IsBranchConfirmed returns whether the given branch is confirmed.
 func (s *SimpleFinalityGadget) IsBranchConfirmed(branchID ledgerstate.BranchID) (confirmed bool) {
-	branchGoF, err := s.tangle.LedgerState.UTXODAG.BranchGradeOfFinality(branchID)
-	if err != nil {
-		// TODO: HANDLE ERRORS INSTEAD?
-		return
-	}
+	// TODO: HANDLE ERRORS INSTEAD?
+	branchGoF, _ := s.tangle.LedgerState.UTXODAG.BranchGradeOfFinality(branchID)
 
 	return branchGoF >= s.opts.BranchGoFReachedLevel
 }

--- a/packages/consensus/finality/finality_gadget.go
+++ b/packages/consensus/finality/finality_gadget.go
@@ -170,12 +170,13 @@ func (s *SimpleFinalityGadget) IsMessageConfirmed(msgID tangle.MessageID) (confi
 
 // IsBranchConfirmed returns whether the given branch is confirmed.
 func (s *SimpleFinalityGadget) IsBranchConfirmed(branchID ledgerstate.BranchID) (confirmed bool) {
-	s.tangle.LedgerState.BranchDAG.Branch(branchID).Consume(func(branch ledgerstate.Branch) {
-		if branch.GradeOfFinality() >= s.opts.BranchGoFReachedLevel {
-			confirmed = true
-		}
-	})
-	return
+	branchGoF, err := s.tangle.LedgerState.UTXODAG.BranchGradeOfFinality(branchID)
+	if err != nil {
+		// TODO: HANDLE ERRORS INSTEAD?
+		return
+	}
+
+	return branchGoF >= s.opts.BranchGoFReachedLevel
 }
 
 // IsTransactionConfirmed returns whether the given transaction is confirmed.
@@ -250,25 +251,6 @@ func (s *SimpleFinalityGadget) HandleMarker(marker *markers.Marker, aw float64) 
 
 func (s *SimpleFinalityGadget) HandleBranch(branchID ledgerstate.BranchID, aw float64) (err error) {
 	newGradeOfFinality := s.opts.BranchTransFunc(branchID, aw)
-	var isAggrBranch bool
-	var gradeOfFinalityChanged bool
-	s.tangle.LedgerState.BranchDAG.Branch(branchID).Consume(func(branch ledgerstate.Branch) {
-		if branch.Type() == ledgerstate.AggregatedBranchType {
-			isAggrBranch = true
-			return
-		}
-		gradeOfFinalityChanged = branch.SetGradeOfFinality(newGradeOfFinality)
-	})
-
-	// we don't do anything if the branch is an aggr. one,
-	// as this function should be called with the parent branches at some point.
-	if isAggrBranch {
-		return errors.Errorf("%w: can not translate approval weight of an aggregated branch %s", ErrUnsupportedBranchType, branchID)
-	}
-
-	if !gradeOfFinalityChanged {
-		return
-	}
 
 	// update GoF of txs within the same branch
 	txGoFPropWalker := walker.New()

--- a/packages/consensus/finality/finality_gadget.go
+++ b/packages/consensus/finality/finality_gadget.go
@@ -284,7 +284,11 @@ func (s *SimpleFinalityGadget) forwardPropagateBranchGoFToTxs(candidateTxID ledg
 			return
 		}
 
-		transactionMetadata.SetGradeOfFinality(newGradeOfFinality)
+		// abort if the grade of finality did not change
+		if !transactionMetadata.SetGradeOfFinality(newGradeOfFinality) {
+			return
+		}
+
 		s.tangle.LedgerState.UTXODAG.CachedTransaction(transactionMetadata.ID()).Consume(func(transaction *ledgerstate.Transaction) {
 			// we use a set of consumer txs as our candidate tx can consume multiple outputs from the same txs,
 			// but we want to add such tx only once to the walker

--- a/packages/consensus/finality/finality_gadget_test.go
+++ b/packages/consensus/finality/finality_gadget_test.go
@@ -366,7 +366,7 @@ func assertBranchsGoFs(t *testing.T, testFramework *tangle.MessageTestFramework,
 	for expectedGoF, msgAliases := range expected {
 		for _, msgAlias := range msgAliases {
 			branch := testFramework.Branch(msgAlias)
-			actualGradeOfFinality := branch.GradeOfFinality()
+			actualGradeOfFinality := testFramework.TransactionMetadata(msgAlias).GradeOfFinality()
 			assert.Equal(t, expectedGoF, actualGradeOfFinality, "expected branch %s (via msg %s) GoF to be %s but is %s", branch.ID(), msgAlias, expectedGoF, actualGradeOfFinality)
 		}
 	}

--- a/packages/jsonmodels/ledgerstate.go
+++ b/packages/jsonmodels/ledgerstate.go
@@ -527,14 +527,15 @@ func NewConsumer(consumer *ledgerstate.Consumer) *Consumer {
 
 // Branch represents the JSON model of a ledgerstate.Branch.
 type Branch struct {
-	ID          string   `json:"id"`
-	Type        string   `json:"type"`
-	Parents     []string `json:"parents"`
-	ConflictIDs []string `json:"conflictIDs,omitempty"`
+	ID              string              `json:"id"`
+	Type            string              `json:"type"`
+	Parents         []string            `json:"parents"`
+	ConflictIDs     []string            `json:"conflictIDs,omitempty"`
+	GradeOfFinality gof.GradeOfFinality `json:"gradeOfFinality"`
 }
 
 // NewBranch returns a Branch from the given ledgerstate.Branch.
-func NewBranch(branch ledgerstate.Branch) Branch {
+func NewBranch(branch ledgerstate.Branch, gradeOfFinality gof.GradeOfFinality) Branch {
 	return Branch{
 		ID:   branch.ID().Base58(),
 		Type: branch.Type().String(),
@@ -558,6 +559,7 @@ func NewBranch(branch ledgerstate.Branch) Branch {
 
 			return conflictIDs
 		}(),
+		GradeOfFinality: gradeOfFinality,
 	}
 }
 

--- a/packages/jsonmodels/ledgerstate.go
+++ b/packages/jsonmodels/ledgerstate.go
@@ -527,11 +527,10 @@ func NewConsumer(consumer *ledgerstate.Consumer) *Consumer {
 
 // Branch represents the JSON model of a ledgerstate.Branch.
 type Branch struct {
-	ID              string              `json:"id"`
-	Type            string              `json:"type"`
-	Parents         []string            `json:"parents"`
-	ConflictIDs     []string            `json:"conflictIDs,omitempty"`
-	GradeOfFinality gof.GradeOfFinality `json:"gradeOfFinality"`
+	ID          string   `json:"id"`
+	Type        string   `json:"type"`
+	Parents     []string `json:"parents"`
+	ConflictIDs []string `json:"conflictIDs,omitempty"`
 }
 
 // NewBranch returns a Branch from the given ledgerstate.Branch.
@@ -559,7 +558,6 @@ func NewBranch(branch ledgerstate.Branch) Branch {
 
 			return conflictIDs
 		}(),
-		GradeOfFinality: branch.GradeOfFinality(),
 	}
 }
 

--- a/packages/ledgerstate/branch_dag.go
+++ b/packages/ledgerstate/branch_dag.go
@@ -12,7 +12,6 @@ import (
 	"github.com/iotaledger/hive.go/objectstorage"
 	"github.com/iotaledger/hive.go/types"
 
-	"github.com/iotaledger/goshimmer/packages/consensus/gof"
 	"github.com/iotaledger/goshimmer/packages/database"
 )
 
@@ -374,23 +373,17 @@ func (b *BranchDAG) Shutdown() {
 func (b *BranchDAG) init() {
 	cachedMasterBranch, stored := b.branchStorage.StoreIfAbsent(NewConflictBranch(MasterBranchID, nil, nil))
 	if stored {
-		(&CachedBranch{CachedObject: cachedMasterBranch}).Consume(func(branch Branch) {
-			branch.SetGradeOfFinality(gof.High)
-		})
+		cachedMasterBranch.Release()
 	}
 
 	cachedRejectedBranch, stored := b.branchStorage.StoreIfAbsent(NewConflictBranch(InvalidBranchID, nil, nil))
 	if stored {
-		(&CachedBranch{CachedObject: cachedRejectedBranch}).Consume(func(branch Branch) {
-			branch.SetGradeOfFinality(gof.None)
-		})
+		cachedRejectedBranch.Release()
 	}
 
 	cachedLazyBookedConflictsBranch, stored := b.branchStorage.StoreIfAbsent(NewConflictBranch(LazyBookedConflictsBranchID, nil, nil))
 	if stored {
-		(&CachedBranch{CachedObject: cachedLazyBookedConflictsBranch}).Consume(func(branch Branch) {
-			branch.SetGradeOfFinality(gof.None)
-		})
+		cachedLazyBookedConflictsBranch.Release()
 	}
 }
 

--- a/packages/ledgerstate/branch_dag_test.go
+++ b/packages/ledgerstate/branch_dag_test.go
@@ -3,7 +3,6 @@ package ledgerstate
 import (
 	"testing"
 
-	"github.com/iotaledger/goshimmer/packages/consensus/gof"
 	"github.com/iotaledger/goshimmer/packages/database"
 
 	"github.com/iotaledger/hive.go/events"
@@ -27,7 +26,6 @@ func TestBranchDAG_RetrieveConflictBranch(t *testing.T) {
 	assert.True(t, newBranchCreated)
 	assert.Equal(t, NewBranchIDs(MasterBranchID), conflictBranch2.Parents())
 	assert.Equal(t, ConflictBranchType, conflictBranch2.Type())
-	assert.Less(t, conflictBranch2.GradeOfFinality(), gof.Medium)
 	assert.Equal(t, NewConflictIDs(ConflictID{0}, ConflictID{1}), conflictBranch2.Conflicts())
 
 	cachedConflictBranch3, _, err := branchDAG.CreateConflictBranch(BranchID{3}, NewBranchIDs(conflictBranch2.ID()), NewConflictIDs(ConflictID{0}, ConflictID{1}, ConflictID{2}))
@@ -38,7 +36,6 @@ func TestBranchDAG_RetrieveConflictBranch(t *testing.T) {
 	assert.True(t, newBranchCreated)
 	assert.Equal(t, NewBranchIDs(conflictBranch2.ID()), conflictBranch3.Parents())
 	assert.Equal(t, ConflictBranchType, conflictBranch3.Type())
-	assert.Less(t, conflictBranch2.GradeOfFinality(), gof.Medium)
 	assert.Equal(t, NewConflictIDs(ConflictID{0}, ConflictID{1}, ConflictID{2}), conflictBranch3.Conflicts())
 
 	cachedConflictBranch2, newBranchCreated, err = branchDAG.CreateConflictBranch(BranchID{2}, NewBranchIDs(MasterBranchID), NewConflictIDs(ConflictID{0}, ConflictID{1}, ConflictID{2}))
@@ -549,28 +546,6 @@ func newTestBranchDAG(branchDAG *BranchDAG) (result *testBranchDAG, err error) {
 	RegisterBranchIDAlias(result.branch16.ID(), "Branch16 = Branch5 + Branch7 + Branch12")
 
 	return
-}
-
-func (t *testBranchDAG) AssertInitialState(testingT *testing.T) {
-	for _, branch := range []Branch{
-		t.branch2,
-		t.branch3,
-		t.branch4,
-		t.branch5,
-		t.branch6,
-		t.branch7,
-		t.branch8,
-		t.branch9,
-		t.branch10,
-		t.branch11,
-		t.branch12,
-		t.branch13,
-		t.branch14,
-		t.branch15,
-		t.branch16,
-	} {
-		assert.Less(testingT, branch.GradeOfFinality(), gof.Medium)
-	}
 }
 
 func (t *testBranchDAG) Release(force ...bool) {

--- a/packages/ledgerstate/transaction_test.go
+++ b/packages/ledgerstate/transaction_test.go
@@ -18,7 +18,7 @@ func TestTransaction_Bytes(t *testing.T) {
 
 	wallets := createWallets(2)
 	input := generateOutput(utxoDAG, wallets[0].address, 0)
-	tx, _ := singleInputTransaction(utxoDAG, wallets[0], wallets[1], input, false)
+	tx, _ := singleInputTransaction(utxoDAG, wallets[0], wallets[1], input)
 	bytes := tx.Bytes()
 	_tx, _, err := TransactionFromBytes(bytes)
 	assert.NoError(t, err)

--- a/packages/ledgerstate/utxo_dag.go
+++ b/packages/ledgerstate/utxo_dag.go
@@ -211,8 +211,7 @@ func (u *UTXODAG) BookTransaction(transaction *Transaction) (targetBranch Branch
 	return
 }
 
-// InclusionState returns the InclusionState of the Transaction with the given TransactionID which can either be
-// Pending, Confirmed or Rejected.
+// GradeOfFinality returns the GradeOfFinality of the Transaction with the given TransactionID.
 func (u *UTXODAG) GradeOfFinality(transactionID TransactionID) (gradeOfFinality gof.GradeOfFinality, err error) {
 	cachedTransactionMetadata := u.CachedTransactionMetadata(transactionID)
 	defer cachedTransactionMetadata.Release()

--- a/packages/ledgerstate/utxo_dag.go
+++ b/packages/ledgerstate/utxo_dag.go
@@ -231,6 +231,9 @@ func (u *UTXODAG) GradeOfFinality(transactionID TransactionID) (gradeOfFinality 
 	}
 
 	gradeOfFinality = branch.GradeOfFinality()
+	if transactionGoF := transactionMetadata.GradeOfFinality(); transactionGoF < gradeOfFinality {
+		gradeOfFinality = transactionGoF
+	}
 
 	return
 }

--- a/packages/ledgerstate/utxo_dag.go
+++ b/packages/ledgerstate/utxo_dag.go
@@ -60,6 +60,10 @@ type IUTXODAG interface {
 	ManageStoreAddressOutputMapping(output Output)
 	// StoreAddressOutputMapping stores the address-output mapping.
 	StoreAddressOutputMapping(address Address, outputID OutputID)
+	// TransactionGradeOfFinality returns the GradeOfFinality of the Transaction with the given TransactionID.
+	TransactionGradeOfFinality(transactionID TransactionID) (gradeOfFinality gof.GradeOfFinality, err error)
+	// BranchGradeOfFinality returns the GradeOfFinality of the Branch with the given BranchID.
+	BranchGradeOfFinality(branchID BranchID) (gradeOfFinality gof.GradeOfFinality, err error)
 }
 
 // UTXODAG represents the DAG that is formed by Transactions consuming Inputs and creating Outputs. It forms the core of
@@ -211,30 +215,41 @@ func (u *UTXODAG) BookTransaction(transaction *Transaction) (targetBranch Branch
 	return
 }
 
-// GradeOfFinality returns the GradeOfFinality of the Transaction with the given TransactionID.
-func (u *UTXODAG) GradeOfFinality(transactionID TransactionID) (gradeOfFinality gof.GradeOfFinality, err error) {
-	cachedTransactionMetadata := u.CachedTransactionMetadata(transactionID)
-	defer cachedTransactionMetadata.Release()
-	transactionMetadata := cachedTransactionMetadata.Unwrap()
-	if transactionMetadata == nil {
-		err = errors.Errorf("failed to load TransactionMetadata with %s: %w", transactionID, cerrors.ErrFatal)
-		return
-	}
-
-	cachedBranch := u.branchDAG.Branch(transactionMetadata.BranchID())
-	defer cachedBranch.Release()
-	branch := cachedBranch.Unwrap()
-	if branch == nil {
-		err = errors.Errorf("failed to load Branch with %s: %w", transactionMetadata.BranchID(), cerrors.ErrFatal)
-		return
-	}
-
-	gradeOfFinality = branch.GradeOfFinality()
-	if transactionGoF := transactionMetadata.GradeOfFinality(); transactionGoF < gradeOfFinality {
-		gradeOfFinality = transactionGoF
+// TransactionGradeOfFinality returns the GradeOfFinality of the Transaction with the given TransactionID.
+func (u *UTXODAG) TransactionGradeOfFinality(transactionID TransactionID) (gradeOfFinality gof.GradeOfFinality, err error) {
+	if !u.CachedTransactionMetadata(transactionID).Consume(func(transactionMetadata *TransactionMetadata) {
+		gradeOfFinality = transactionMetadata.GradeOfFinality()
+	}) {
+		return gof.None, errors.Errorf("failed to load TransactionMetadata with %s: %w", transactionID, cerrors.ErrFatal)
 	}
 
 	return
+}
+
+// BranchGradeOfFinality returns the GradeOfFinality of the Branch with the given BranchID.
+func (u *UTXODAG) BranchGradeOfFinality(branchID BranchID) (gradeOfFinality gof.GradeOfFinality, err error) {
+	if branchID == MasterBranchID {
+		return gof.High, nil
+	}
+
+	normalizedBranches, err := u.branchDAG.normalizeBranches(NewBranchIDs(branchID))
+	if err != nil {
+		return gof.None, errors.Errorf("failed to normalize %s: %w", branchID, err)
+	}
+
+	gradeOfFinality = gof.High
+	for conflictBranchID := range normalizedBranches {
+		conflictBranchGoF, gofErr := u.TransactionGradeOfFinality(conflictBranchID.TransactionID())
+		if gofErr != nil {
+			return gof.None, errors.Errorf("failed to normalize %s: %w", branchID, err)
+		}
+
+		if conflictBranchGoF < gradeOfFinality {
+			gradeOfFinality = conflictBranchGoF
+		}
+	}
+
+	return gradeOfFinality, nil
 }
 
 // CachedTransaction retrieves the Transaction with the given TransactionID from the object storage.
@@ -423,19 +438,13 @@ func (u *UTXODAG) forkConsumer(transactionID TransactionID, conflictingInputs Ou
 		if err != nil {
 			panic(fmt.Errorf("failed to create ConflictBranch when forking Transaction with %s: %w", transactionID, err))
 		}
+		cachedConsumingConflictBranch.Release()
+
 		// We don't need to propagate updates if the branch did already exist.
 		// Though CreateConflictBranch needs to be called so that conflict sets and conflict membership are properly updated.
 		if txMetadata.BranchID() == conflictBranchID {
-			cachedConsumingConflictBranch.Release()
 			return
 		}
-
-		cachedConsumingConflictBranch.Consume(func(newBranch Branch) {
-			// copying the branch metadata properties from the original branch to the newly created.
-			u.branchDAG.Branch(txMetadata.BranchID()).Consume(func(oldBranch Branch) {
-				newBranch.SetGradeOfFinality(oldBranch.GradeOfFinality())
-			})
-		})
 
 		txMetadata.SetBranchID(conflictBranchID)
 		u.Events().TransactionBranchIDUpdated.Trigger(transactionID)

--- a/packages/ledgerstate/utxo_dag_test.go
+++ b/packages/ledgerstate/utxo_dag_test.go
@@ -286,7 +286,7 @@ func TestBookInvalidTransaction(t *testing.T) {
 
 	wallets := createWallets(1)
 	input := generateOutput(utxoDAG, wallets[0].address, 0)
-	tx, _ := singleInputTransaction(utxoDAG, wallets[0], wallets[0], input, false)
+	tx, _ := singleInputTransaction(utxoDAG, wallets[0], wallets[0], input)
 
 	cachedTxMetadata := utxoDAG.CachedTransactionMetadata(tx.ID())
 	defer cachedTxMetadata.Release()
@@ -313,7 +313,7 @@ func TestBookNonConflictingTransaction(t *testing.T) {
 
 	wallets := createWallets(2)
 	input := generateOutput(utxoDAG, wallets[0].address, 0)
-	tx, _ := singleInputTransaction(utxoDAG, wallets[0], wallets[0], input, false)
+	tx, _ := singleInputTransaction(utxoDAG, wallets[0], wallets[0], input, gof.High)
 
 	cachedTxMetadata := utxoDAG.CachedTransactionMetadata(tx.ID())
 	defer cachedTxMetadata.Release()
@@ -347,7 +347,7 @@ func TestBookConflictingTransaction(t *testing.T) {
 
 	wallets := createWallets(2)
 	input := generateOutput(utxoDAG, wallets[0].address, 0)
-	tx1, _ := singleInputTransaction(utxoDAG, wallets[0], wallets[0], input, false)
+	tx1, _ := singleInputTransaction(utxoDAG, wallets[0], wallets[0], input, gof.High)
 
 	cachedTxMetadata := utxoDAG.CachedTransactionMetadata(tx1.ID())
 	defer cachedTxMetadata.Release()
@@ -363,7 +363,7 @@ func TestBookConflictingTransaction(t *testing.T) {
 	assert.Equal(t, MasterBranchID, txMetadata.BranchID())
 
 	// double spend
-	tx2, _ := singleInputTransaction(utxoDAG, wallets[0], wallets[1], input, false)
+	tx2, _ := singleInputTransaction(utxoDAG, wallets[0], wallets[1], input)
 
 	cachedTxMetadata2 := utxoDAG.CachedTransactionMetadata(tx2.ID())
 	defer cachedTxMetadata2.Release()
@@ -408,7 +408,7 @@ func TestConsumedBranchIDs(t *testing.T) {
 	wallets := createWallets(1)
 	branchIDs := BranchIDs{MasterBranchID: types.Void, InvalidBranchID: types.Void}
 	inputs := generateOutputs(utxoDAG, wallets[0].address, branchIDs)
-	tx := multipleInputsTransaction(utxoDAG, wallets[0], wallets[0], inputs, true)
+	tx := multipleInputsTransaction(utxoDAG, wallets[0], wallets[0], inputs, gof.High)
 
 	assert.Equal(t, branchIDs, utxoDAG.consumedBranchIDs(tx.ID()))
 }
@@ -419,7 +419,7 @@ func TestCreatedOutputIDsOfTransaction(t *testing.T) {
 
 	wallets := createWallets(1)
 	input := generateOutput(utxoDAG, wallets[0].address, 0)
-	tx, output := singleInputTransaction(utxoDAG, wallets[0], wallets[0], input, true)
+	tx, output := singleInputTransaction(utxoDAG, wallets[0], wallets[0], input, gof.High)
 
 	assert.Equal(t, []OutputID{output.ID()}, utxoDAG.createdOutputIDsOfTransaction(tx.ID()))
 }
@@ -430,7 +430,7 @@ func TestConsumedOutputIDsOfTransaction(t *testing.T) {
 
 	wallets := createWallets(1)
 	input := generateOutput(utxoDAG, wallets[0].address, 0)
-	tx, _ := singleInputTransaction(utxoDAG, wallets[0], wallets[0], input, true)
+	tx, _ := singleInputTransaction(utxoDAG, wallets[0], wallets[0], input, gof.High)
 
 	assert.Equal(t, []OutputID{input.ID()}, utxoDAG.consumedOutputIDsOfTransaction(tx.ID()))
 }
@@ -477,7 +477,7 @@ func TestConsumedOutputs(t *testing.T) {
 	input := generateOutput(utxoDAG, wallets[0].address, 0)
 
 	// testing when storing the inputs
-	tx, output := singleInputTransaction(utxoDAG, wallets[0], wallets[1], input, false)
+	tx, output := singleInputTransaction(utxoDAG, wallets[0], wallets[1], input)
 	cachedInputs := utxoDAG.ConsumedOutputs(tx)
 	inputs := cachedInputs.Unwrap()
 
@@ -486,7 +486,7 @@ func TestConsumedOutputs(t *testing.T) {
 	cachedInputs.Release(true)
 
 	// testing when not storing the inputs
-	tx, _ = singleInputTransaction(utxoDAG, wallets[1], wallets[0], output, false)
+	tx, _ = singleInputTransaction(utxoDAG, wallets[1], wallets[0], output)
 	cachedInputs = utxoDAG.ConsumedOutputs(tx)
 	inputs = cachedInputs.Unwrap()
 
@@ -503,7 +503,7 @@ func TestAllOutputsExist(t *testing.T) {
 	input := generateOutput(utxoDAG, wallets[0].address, 0)
 
 	// testing when storing the inputs
-	tx, output := singleInputTransaction(utxoDAG, wallets[0], wallets[1], input, false)
+	tx, output := singleInputTransaction(utxoDAG, wallets[0], wallets[1], input)
 	cachedInputs := utxoDAG.ConsumedOutputs(tx)
 	inputs := cachedInputs.Unwrap()
 
@@ -512,7 +512,7 @@ func TestAllOutputsExist(t *testing.T) {
 	cachedInputs.Release()
 
 	// testing when not storing the inputs
-	tx, _ = singleInputTransaction(utxoDAG, wallets[1], wallets[0], output, false)
+	tx, _ = singleInputTransaction(utxoDAG, wallets[1], wallets[0], output)
 	cachedInputs = utxoDAG.ConsumedOutputs(tx)
 	inputs = cachedInputs.Unwrap()
 
@@ -604,11 +604,11 @@ func TestUnlockBlocksValid(t *testing.T) {
 	input := generateOutput(utxoDAG, wallets[0].address, 0)
 
 	// testing valid signature
-	tx, _ := singleInputTransaction(utxoDAG, wallets[0], wallets[1], input, true)
+	tx, _ := singleInputTransaction(utxoDAG, wallets[0], wallets[1], input, gof.High)
 	assert.True(t, UnlockBlocksValid(Outputs{input}, tx))
 
 	// testing invalid signature
-	tx, _ = singleInputTransaction(utxoDAG, wallets[1], wallets[0], input, true)
+	tx, _ = singleInputTransaction(utxoDAG, wallets[1], wallets[0], input, gof.High)
 	assert.False(t, UnlockBlocksValid(Outputs{input}, tx))
 }
 
@@ -825,7 +825,7 @@ func generateOutputs(utxoDAG *UTXODAG, address Address, branchIDs BranchIDs) (ou
 	return
 }
 
-func singleInputTransaction(utxoDAG *UTXODAG, a, b wallet, outputToSpend *SigLockedSingleOutput, highgof bool) (*Transaction, *SigLockedSingleOutput) {
+func singleInputTransaction(utxoDAG *UTXODAG, a, b wallet, outputToSpend *SigLockedSingleOutput, optionalGradeOfFinality ...gof.GradeOfFinality) (*Transaction, *SigLockedSingleOutput) {
 	input := NewUTXOInput(outputToSpend.ID())
 	output := NewSigLockedSingleOutput(100, b.address)
 
@@ -838,8 +838,10 @@ func singleInputTransaction(utxoDAG *UTXODAG, a, b wallet, outputToSpend *SigLoc
 	transactionMetadata.SetSolid(true)
 	transactionMetadata.SetBranchID(MasterBranchID)
 
-	if highgof {
-		transactionMetadata.SetGradeOfFinality(gof.High)
+	if len(optionalGradeOfFinality) >= 1 {
+		transactionMetadata.SetGradeOfFinality(optionalGradeOfFinality[0])
+	} else {
+		transactionMetadata.SetGradeOfFinality(gof.Low)
 	}
 
 	cachedTransactionMetadata := &CachedTransactionMetadata{CachedObject: utxoDAG.transactionMetadataStorage.ComputeIfAbsent(tx.ID().Bytes(), func(key []byte) objectstorage.StorableObject {
@@ -854,7 +856,7 @@ func singleInputTransaction(utxoDAG *UTXODAG, a, b wallet, outputToSpend *SigLoc
 	return tx, output
 }
 
-func multipleInputsTransaction(utxoDAG *UTXODAG, a, b wallet, outputsToSpend []*SigLockedSingleOutput, highgof bool) *Transaction {
+func multipleInputsTransaction(utxoDAG *UTXODAG, a, b wallet, outputsToSpend []*SigLockedSingleOutput, optionalGradeOfFinality ...gof.GradeOfFinality) *Transaction {
 	inputs := make(Inputs, len(outputsToSpend))
 	branchIDs := make(BranchIDs, len(outputsToSpend))
 	for i, outputToSpend := range outputsToSpend {
@@ -882,8 +884,10 @@ func multipleInputsTransaction(utxoDAG *UTXODAG, a, b wallet, outputsToSpend []*
 	transactionMetadata := NewTransactionMetadata(tx.ID())
 	transactionMetadata.SetSolid(true)
 	transactionMetadata.SetBranchID(branchID)
-	if highgof {
-		transactionMetadata.SetGradeOfFinality(gof.High)
+	if len(optionalGradeOfFinality) >= 1 {
+		transactionMetadata.SetGradeOfFinality(optionalGradeOfFinality[0])
+	} else {
+		transactionMetadata.SetGradeOfFinality(gof.Low)
 	}
 
 	cachedTransactionMetadata := &CachedTransactionMetadata{CachedObject: utxoDAG.transactionMetadataStorage.ComputeIfAbsent(tx.ID().Bytes(), func(key []byte) objectstorage.StorableObject {

--- a/packages/ledgerstate/utxo_dag_test.go
+++ b/packages/ledgerstate/utxo_dag_test.go
@@ -333,7 +333,7 @@ func TestBookNonConflictingTransaction(t *testing.T) {
 		assert.True(t, txMetadata.Solid())
 	})
 
-	finality, err := utxoDAG.GradeOfFinality(tx.ID())
+	finality, err := utxoDAG.TransactionGradeOfFinality(tx.ID())
 	require.NoError(t, err)
 	assert.Greater(t, finality, gof.Medium)
 
@@ -388,11 +388,11 @@ func TestBookConflictingTransaction(t *testing.T) {
 
 	assert.NotEqual(t, MasterBranchID, txMetadata.BranchID())
 
-	finality, err := utxoDAG.GradeOfFinality(tx1.ID())
+	finality, err := utxoDAG.TransactionGradeOfFinality(tx1.ID())
 	require.NoError(t, err)
 	assert.Greater(t, finality, gof.Medium)
 
-	finality, err = utxoDAG.GradeOfFinality(tx2.ID())
+	finality, err = utxoDAG.TransactionGradeOfFinality(tx2.ID())
 	require.NoError(t, err)
 	assert.Less(t, finality, gof.Medium)
 

--- a/plugins/dashboard/conflicts_livefeed.go
+++ b/plugins/dashboard/conflicts_livefeed.go
@@ -186,9 +186,7 @@ func onBranchWeightChanged(e *tangle.BranchWeightChangedEvent) {
 	}
 
 	b.AW = math.Round(e.Weight*precision) / precision
-	messagelayer.Tangle().LedgerState.BranchDAG.Branch(b.BranchID).Consume(func(branch ledgerstate.Branch) {
-		b.GoF = branch.GradeOfFinality()
-	})
+	b.GoF, _ = messagelayer.Tangle().LedgerState.UTXODAG.BranchGradeOfFinality(b.BranchID)
 	sendBranchUpdate(b)
 
 	if messagelayer.FinalityGadget().IsBranchConfirmed(b.BranchID) {

--- a/plugins/webapi/ledgerstate/plugin.go
+++ b/plugins/webapi/ledgerstate/plugin.go
@@ -228,7 +228,9 @@ func GetBranch(c echo.Context) (err error) {
 	}
 
 	if messagelayer.Tangle().LedgerState.BranchDAG.Branch(branchID).Consume(func(branch ledgerstate.Branch) {
-		err = c.JSON(http.StatusOK, jsonmodels.NewBranch(branch))
+		branchGoF, _ := messagelayer.Tangle().LedgerState.UTXODAG.BranchGradeOfFinality(branch.ID())
+
+		err = c.JSON(http.StatusOK, jsonmodels.NewBranch(branch, branchGoF))
 	}) {
 		return
 	}

--- a/plugins/webapi/tools/message/diagnostic_branches.go
+++ b/plugins/webapi/tools/message/diagnostic_branches.go
@@ -112,7 +112,7 @@ func getDiagnosticConflictsInfo(branchID ledgerstate.BranchID) DiagnosticBranchI
 	}
 
 	messagelayer.Tangle().LedgerState.BranchDAG.Branch(branchID).Consume(func(branch ledgerstate.Branch) {
-		conflictInfo.GradeOfFinality = branch.GradeOfFinality()
+		conflictInfo.GradeOfFinality, _ = messagelayer.Tangle().LedgerState.UTXODAG.BranchGradeOfFinality(branch.ID())
 
 		if branch.Type() == ledgerstate.AggregatedBranchType {
 			return


### PR DESCRIPTION
# Description of change

This PR fixes a bug in the GradeOfFinality function that currently always returns the GradeOfFinality of the Branch instead of the Transaction. To simplify things, we furthermore removed the GradeOfFinality of the Branch as it can be inferred by the GradeOfFinality of the underlying transaction.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
