### PR TITLE
Fix Dockerfile build arg check whether to download snapshot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN --mount=target=. \
 
 # Enable building the image without downloading the snapshot.
 # If built with dummy snapshot then a snapshot needs to be mounted into the resulting image.
-RUN if (( $DOWNLOAD_SNAPSHOT == 1 )); then \
+RUN if [ $DOWNLOAD_SNAPSHOT -gt 0 ]; then \
     wget -O /tmp/snapshot.bin https://dbfiles-goshimmer.s3.eu-central-1.amazonaws.com/snapshots/nectar/snapshot-latest.bin ;  \
     else  \
     touch /tmp/snapshot.bin ; \


### PR DESCRIPTION
# Description of change

This PR fixes a bug when building the Docker image with the build arg `ARG DOWNLOAD_SNAPSHOT=1` which resulted in an invalid bash command.

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

```bash
# no snapshot download
docker build . -t iotaledger/goshimmer  --build-arg DOWNLOAD_SNAPSHOT=0 --no-cache
# snapshot download
docker build . -t iotaledger/goshimmer  --build-arg DOWNLOAD_SNAPSHOT=1 --no-cache
```