### PR TITLE
fix: Fix the link to goshimmer document

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <h2 align="center">Prototype node software for an IOTA network without the Coordinator</h2>
 
 <p align="center">
-    <a href="https://goshimmer.docs.iota.org/goshimmer.html" style="text-decoration:none;">
+    <a href="https://goshimmer.docs.iota.org" style="text-decoration:none;">
     <img src="https://img.shields.io/badge/Documentation%20portal-blue.svg?style=for-the-badge" alt="Developer documentation portal">
 </p>
 <p align="center">


### PR DESCRIPTION
# Description of change
Fix the link of `Documentation Portal`

## Type of change

- Documentation Fix

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
