### PR TITLE
Fix cMana weight provider

### DIFF
--- a/packages/tangle/cmanaweightprovider.go
+++ b/packages/tangle/cmanaweightprovider.go
@@ -1,11 +1,13 @@
 package tangle
 
 import (
+	"container/heap"
 	"sync"
 	"time"
 
 	"github.com/cockroachdb/errors"
 	"github.com/iotaledger/hive.go/cerrors"
+	"github.com/iotaledger/hive.go/datastructure/set"
 	"github.com/iotaledger/hive.go/identity"
 	"github.com/iotaledger/hive.go/kvstore"
 	"github.com/iotaledger/hive.go/marshalutil"
@@ -24,7 +26,7 @@ const (
 type CManaWeightProvider struct {
 	store             kvstore.KVStore
 	mutex             sync.RWMutex
-	activeNodes       map[identity.ID]time.Time
+	activeNodes       map[identity.ID]*activityLog
 	manaRetrieverFunc ManaRetrieverFunc
 	timeRetrieverFunc TimeRetrieverFunc
 }
@@ -32,45 +34,51 @@ type CManaWeightProvider struct {
 // NewCManaWeightProvider is the constructor for CManaWeightProvider.
 func NewCManaWeightProvider(manaRetrieverFunc ManaRetrieverFunc, timeRetrieverFunc TimeRetrieverFunc, store ...kvstore.KVStore) (cManaWeightProvider *CManaWeightProvider) {
 	cManaWeightProvider = &CManaWeightProvider{
-		activeNodes:       make(map[identity.ID]time.Time),
+		activeNodes:       make(map[identity.ID]*activityLog),
 		manaRetrieverFunc: manaRetrieverFunc,
 		timeRetrieverFunc: timeRetrieverFunc,
 	}
-	if len(store) == 0 {
-		return
-	}
-
-	cManaWeightProvider.store = store[0]
-
-	marshaledActiveNodes, err := cManaWeightProvider.store.Get(kvstore.Key(activeNodesKey))
-	if err != nil && !errors.Is(err, kvstore.ErrKeyNotFound) {
-		panic(err)
-	}
-	// Load from storage if key was found.
-	if marshaledActiveNodes != nil {
-		if cManaWeightProvider.activeNodes, err = activeNodesFromBytes(marshaledActiveNodes); err != nil {
-			panic(err)
-		}
-		return
-	}
+	//TODO:
+	//if len(store) == 0 {
+	//	return
+	//}
+	//
+	//cManaWeightProvider.store = store[0]
+	//
+	//marshaledActiveNodes, err := cManaWeightProvider.store.Get(kvstore.Key(activeNodesKey))
+	//if err != nil && !errors.Is(err, kvstore.ErrKeyNotFound) {
+	//	panic(err)
+	//}
+	//// Load from storage if key was found.
+	//if marshaledActiveNodes != nil {
+	//	if cManaWeightProvider.activeNodes, err = activeNodesFromBytes(marshaledActiveNodes); err != nil {
+	//		panic(err)
+	//	}
+	//	return
+	//}
 
 	return
 }
 
 // Update updates the underlying data structure and keeps track of active nodes.
 func (c *CManaWeightProvider) Update(t time.Time, nodeID identity.ID) {
-	// We don't want to add nodes as active if their message is in the future of the TangleTime so that we get a sliding
-	// window of how the tangle emerged.
-	if t.After(c.timeRetrieverFunc()) {
+	// We only want to log node activity that is relevant, i.e., node activity before TangleTime-activeTimeThreshold
+	// does not matter anymore since the TangleTime advances towards the present/future.
+	staleThreshold := c.timeRetrieverFunc().Add(-activeTimeThreshold)
+	if t.Before(staleThreshold) {
 		return
 	}
 
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
-	if c.activeNodes[nodeID].Before(t) {
-		c.activeNodes[nodeID] = t
+	a, exists := c.activeNodes[nodeID]
+	if !exists {
+		a = newNodeActivity()
+		c.activeNodes[nodeID] = a
 	}
+
+	a.Add(t)
 }
 
 // Weight returns the weight and total weight for the given message.
@@ -88,14 +96,19 @@ func (c *CManaWeightProvider) WeightsOfRelevantSupporters() (weights map[identit
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
-	for nodeID, t := range c.activeNodes {
-		if targetTime.Sub(t) > activeTimeThreshold {
-			delete(c.activeNodes, nodeID)
+	for nodeID, al := range c.activeNodes {
+		nodeMana := mana[nodeID]
+
+		// Skip node if it does not fulfill minimumManaThreshold.
+		if nodeMana <= minimumManaThreshold {
 			continue
 		}
 
-		nodeMana := mana[nodeID]
-		if nodeMana <= minimumManaThreshold {
+		// Determine whether node was active in time window.
+		if active, empty := al.Active(targetTime.Add(-activeTimeThreshold), targetTime); !active {
+			if empty {
+				delete(c.activeNodes, nodeID)
+			}
 			continue
 		}
 
@@ -108,7 +121,8 @@ func (c *CManaWeightProvider) WeightsOfRelevantSupporters() (weights map[identit
 // Shutdown shuts down the WeightProvider and persists its state.
 func (c *CManaWeightProvider) Shutdown() {
 	if c.store != nil {
-		_ = c.store.Set(kvstore.Key(activeNodesKey), activeNodesToBytes(c.ActiveNodes()))
+		//TODO:
+		//_ = c.store.Set(kvstore.Key(activeNodesKey), activeNodesToBytes(c.ActiveNodes()))
 	}
 }
 
@@ -119,9 +133,10 @@ func (c *CManaWeightProvider) ActiveNodes() (activeNodes map[identity.ID]time.Ti
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
-	for nodeID, t := range c.activeNodes {
-		activeNodes[nodeID] = t
-	}
+	//TODO:
+	//for nodeID, t := range c.activeNodes {
+	//	activeNodes[nodeID] = t
+	//}
 
 	return activeNodes
 }
@@ -174,6 +189,108 @@ func activeNodesToBytes(activeNodes map[identity.ID]time.Time) []byte {
 	}
 
 	return marshalUtil.Bytes()
+}
+
+// endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// region activityLog //////////////////////////////////////////////////////////////////////////////////////////////////
+
+// granularity defines the granularity in seconds with which we log node activities.
+const granularity = 60
+
+// timeToUnixGranularity converts a time t to a unix timestamp with granularity.
+func timeToUnixGranularity(t time.Time) int64 {
+	return t.Unix() / granularity
+}
+
+// activityLog is a time-based log of node activity. It stores information when a node was active and provides
+// functionality to query for certain timeframes.
+type activityLog struct {
+	setTimes set.Set
+	times    *minHeap
+}
+
+func newNodeActivity() *activityLog {
+	var mh minHeap
+
+	al := &activityLog{
+		setTimes: set.New(),
+		times:    &mh,
+	}
+	heap.Init(al.times)
+
+	return al
+}
+
+// Add adds a node activity to the log.
+func (a *activityLog) Add(t time.Time) (added bool) {
+	u := timeToUnixGranularity(t)
+	if !a.setTimes.Add(u) {
+		return false
+	}
+
+	heap.Push(a.times, u)
+	return true
+}
+
+// Active returns true if the node was active between lower and upper bound.
+// It cleans up the log on the fly, meaning that old/stale times are deleted.
+// If the log ends up empty after cleaning up, empty is set to true.
+func (a *activityLog) Active(lowerBound, upperBound time.Time) (active, empty bool) {
+	lb, ub := timeToUnixGranularity(lowerBound), timeToUnixGranularity(upperBound)
+
+	for a.times.Len() > 0 {
+		// Get the lowest element of the min-heap = the earliest time.
+		activity := (*a.times)[0]
+
+		// We clean up possible stale times < lowerBound because we don't need them anymore.
+		if activity < lb {
+			a.setTimes.Delete(activity)
+			heap.Pop(a.times)
+			continue
+		}
+
+		// Check if time is between lower and upper bound. Because of cleanup, activity >= lb is implicitly given.
+		if activity <= ub {
+			return true, false
+		}
+		// Otherwise, the node has active times in the future of upperBound.
+		return false, false
+	}
+
+	// If the heap is empty, there's no activity anymore and the object might potentially be cleaned up.
+	return false, true
+}
+
+// minHeap is a
+type minHeap []int64
+
+// Len is the number of elements in the collection.
+func (h minHeap) Len() int {
+	return len(h)
+}
+
+// Less reports whether the element with index i must sort before the element with index j.
+func (h minHeap) Less(i, j int) bool {
+	return h[i] < h[j]
+}
+
+// Swap swaps the elements with indexes i and j.
+func (h minHeap) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+}
+
+// Push pushes the element x onto the heap.
+func (h *minHeap) Push(x interface{}) {
+	*h = append(*h, x.(int64))
+}
+
+// Pop removes and returns the minimum element (according to Less) from the heap.
+func (h *minHeap) Pop() interface{} {
+	n := len(*h)
+	x := (*h)[n-1]
+	*h = (*h)[:n-1]
+	return x
 }
 
 // endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
# Description of change
This PR introduces an `activityLog` per node for the cMana weight provider. In that way we can track all node activity (with a specified `granularity`) in the relevant time (from `TT-activeTimeThreshold` until `TT`). In case there is node activity in the future from the perspective of the `TangleTime`, it is stored in the `activityLog` and once the `TT` moves forward the node can stay `active` according to information in the log.

In the previous implementation we lost this information since we only stored a single time per node and did not store any active times in the future of the current `TT`. In this way nodes joining the network later could end up with a bug where 
1. no node is seen as active anymore if the first confirmed message was created by a node without cMana
2. a single node has all active cMana (as interpreted by the weight provider) if the first confirmed message was created by a node with **any cMana**. This node would be seen as having all the active weight in this case.

Add activity log to cMana weight provider to avoid bug where node activity is not properly tracked due to only storing one timestamp per node

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [ ] My code follows the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
