### PR TITLE
Name NetworkDelay clock plugin dependency

### DIFF
--- a/plugins/networkdelay/plugin.go
+++ b/plugins/networkdelay/plugin.go
@@ -44,7 +44,7 @@ type dependencies struct {
 	Local        *peer.Local
 	RemoteLogger *remotelog.RemoteLoggerConn `optional:"true"`
 	Server       *echo.Echo
-	ClockPlugin  *node.Plugin
+	ClockPlugin  *node.Plugin `name:"clock"`
 }
 
 // App gets the plugin instance.


### PR DESCRIPTION
Didn't have a name and hence couldn't be resolved during dependency population.