### PR TITLE
Use multi-arch 1.17.1 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # syntax = docker/dockerfile:1.2.1
 
 ############################
-# golang 1.17-buster amd64
-FROM golang@sha256:cefedeae41e0bbbfa20bb1c37c3a43e0001fa541be9732f7bc6a28ecc154e9e4 AS build
+# golang 1.17.1-buster multi-arch
+FROM golang@sha256:d2710b111354dd7d8a64454d80c22ffd62f90993d811e57a9fce7ff76a235b5f AS build
 
 ARG BUILD_TAGS=rocksdb,builtin_static
 # Download and include snapshot into resulting image by default.
@@ -29,7 +29,7 @@ RUN go mod verify
 # 4. Verify that goshimmer binary is statically linked
 RUN --mount=target=. \
     --mount=type=cache,target=/root/.cache/go-build \
-    GOOS=linux GOARCH=amd64 go build \
+    go build \
     -tags="$BUILD_TAGS" \
     -ldflags='-w -s' \
     -o /go/bin/goshimmer

--- a/tools/integration-tests/tester/go.mod
+++ b/tools/integration-tests/tester/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/drand/drand v1.1.1
 	github.com/iotaledger/goshimmer v0.1.3
-	github.com/iotaledger/hive.go v0.0.0-20210821074123-831d7702ae07
+	github.com/iotaledger/hive.go v0.0.0-20210913073932-c392e25de04a
 	github.com/mr-tron/base58 v1.2.0
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/stretchr/testify v1.7.0

--- a/tools/integration-tests/tester/go.sum
+++ b/tools/integration-tests/tester/go.sum
@@ -421,14 +421,8 @@ github.com/hydrogen18/memlistener v0.0.0-20141126152155-54553eb933fb/go.mod h1:q
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/iotaledger/hive.go v0.0.0-20210820150235-842611c50632 h1:U4Axt7EaP6ZQSvIsMHuNUblJn6a0jkVG3khiuOyai00=
-github.com/iotaledger/hive.go v0.0.0-20210820150235-842611c50632/go.mod h1:vZXMpgveUkATu1IueKmUJK3/OVgrYRQdH/Jh/yZ2j9Q=
-github.com/iotaledger/hive.go v0.0.0-20210820164332-f230dc40974e h1:vEtssZw8FDWrd/h+LD9SLPTLO/nyxS4p8hsArhQQ7K4=
-github.com/iotaledger/hive.go v0.0.0-20210820164332-f230dc40974e/go.mod h1:vZXMpgveUkATu1IueKmUJK3/OVgrYRQdH/Jh/yZ2j9Q=
-github.com/iotaledger/hive.go v0.0.0-20210820172323-2a396d09ff59 h1:8FSojcK4nYqIi8KvPrHkDXYj7BpzqwQydZTMznmp7I4=
-github.com/iotaledger/hive.go v0.0.0-20210820172323-2a396d09ff59/go.mod h1:vZXMpgveUkATu1IueKmUJK3/OVgrYRQdH/Jh/yZ2j9Q=
-github.com/iotaledger/hive.go v0.0.0-20210821074123-831d7702ae07 h1:iqBuH88I1MJGpCTMngxwA46SeE4rX9QUBWCsQB++dZI=
-github.com/iotaledger/hive.go v0.0.0-20210821074123-831d7702ae07/go.mod h1:vZXMpgveUkATu1IueKmUJK3/OVgrYRQdH/Jh/yZ2j9Q=
+github.com/iotaledger/hive.go v0.0.0-20210913073932-c392e25de04a h1:qwbiJo/fijt9Hl5qHsMzg4lmU2wyaYeruthaSOmvIyU=
+github.com/iotaledger/hive.go v0.0.0-20210913073932-c392e25de04a/go.mod h1:vZXMpgveUkATu1IueKmUJK3/OVgrYRQdH/Jh/yZ2j9Q=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.2/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.3/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=

--- a/tools/integration-tests/tester/go.sum
+++ b/tools/integration-tests/tester/go.sum
@@ -421,6 +421,7 @@ github.com/hydrogen18/memlistener v0.0.0-20141126152155-54553eb933fb/go.mod h1:q
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
+github.com/iotaledger/hive.go v0.0.0-20210821074123-831d7702ae07/go.mod h1:vZXMpgveUkATu1IueKmUJK3/OVgrYRQdH/Jh/yZ2j9Q=
 github.com/iotaledger/hive.go v0.0.0-20210913073932-c392e25de04a h1:qwbiJo/fijt9Hl5qHsMzg4lmU2wyaYeruthaSOmvIyU=
 github.com/iotaledger/hive.go v0.0.0-20210913073932-c392e25de04a/go.mod h1:vZXMpgveUkATu1IueKmUJK3/OVgrYRQdH/Jh/yZ2j9Q=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=


### PR DESCRIPTION
We had the 1.17-buster linux/amd64 image defined in combination with GOOS=linux/GOARCH=amd64; this however caused my Macbook Air M1 to no longer be able to compile/run the tools/docker-network as it would lead to a qemu segmentation fault. Changing our base image to the multi-arch 1.17.1-buster image and removing the explicit GOOS/GOARCH envs in the build RUN step, resolved these issues for me.

In theory there never was a need to have GOOS/GOARCH defined in the build RUN step, since it would be set correctly automatically by whatever golang image would be pulled. 