### PR TITLE
In Windows you must close the file before you delete it

### DIFF
--- a/tools/cli-wallet/main.go
+++ b/tools/cli-wallet/main.go
@@ -31,7 +31,10 @@ func main() {
 		panic(err)
 	}
 	defer func() {
-		if err := os.Remove(file.Name()); err != nil {
+		if err = file.Close(); err != nil {
+			panic(err)
+		}
+		if err = os.Remove(file.Name()); err != nil {
 			panic(err)
 		}
 	}()


### PR DESCRIPTION
# Description of change

Unlike Linux, Windows forces you to close the file before you delete it.
fixes #1719 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Compiled with `env GOOS=windows go build .` and copied to a Windows machine

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
