### PR TITLE
Feat: Solidification Rework

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/go-resty/resty/v2 v2.6.0
 	github.com/golang/protobuf v1.5.2
 	github.com/gorilla/websocket v1.4.2
-	github.com/iotaledger/hive.go v0.0.0-20210821074123-831d7702ae07
+	github.com/iotaledger/hive.go v0.0.0-20211022130818-5eadd0c9157d
 	github.com/labstack/echo v3.3.10+incompatible
 	github.com/labstack/gommon v0.3.0
 	github.com/linxGnu/grocksdb v1.6.35 // indirect

--- a/go.sum
+++ b/go.sum
@@ -413,8 +413,8 @@ github.com/hydrogen18/memlistener v0.0.0-20141126152155-54553eb933fb/go.mod h1:q
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/iotaledger/hive.go v0.0.0-20210821074123-831d7702ae07 h1:iqBuH88I1MJGpCTMngxwA46SeE4rX9QUBWCsQB++dZI=
-github.com/iotaledger/hive.go v0.0.0-20210821074123-831d7702ae07/go.mod h1:vZXMpgveUkATu1IueKmUJK3/OVgrYRQdH/Jh/yZ2j9Q=
+github.com/iotaledger/hive.go v0.0.0-20211022130818-5eadd0c9157d h1:c1kKNh3GxF0nJg4Y06AbiF48uRCrKC3x95N4GM+fBEI=
+github.com/iotaledger/hive.go v0.0.0-20211022130818-5eadd0c9157d/go.mod h1:qfpjDWmi+h7AAOkqjZslPHTNeQ7Gf7kTCdIOzbMyjhc=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.2/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.3/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=

--- a/packages/consensus/finality/finality_gadget_test.go
+++ b/packages/consensus/finality/finality_gadget_test.go
@@ -44,6 +44,8 @@ func TestSimpleFinalityGadget(t *testing.T) {
 		}
 	}(processMsgScenario, t)
 
+	processMsgScenario.Tangle.LedgerState.Configure(ledgerstate.LazyBookingEnabled(false))
+
 	sfg := NewSimpleFinalityGadget(processMsgScenario.Tangle)
 	wireUpEvents(t, processMsgScenario.Tangle, sfg)
 

--- a/packages/consensus/otv/otv_test.go
+++ b/packages/consensus/otv/otv_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/iotaledger/goshimmer/packages/consensus"
 
-	"github.com/iotaledger/hive.go/kvstore/mapdb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -1026,11 +1025,11 @@ func TestOnTangleVoting_LikedInstead(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			branchDAG := NewBranchDAG(mapdb.NewMapDB(), database.NewCacheTimeProvider(0))
-			defer branchDAG.Shutdown()
+			ledgerstate := New(CacheTimeProvider(database.NewCacheTimeProvider(0)))
+			defer ledgerstate.Shutdown()
 
-			tt.test.Scenario.CreateBranches(t, branchDAG)
-			o := NewOnTangleVoting(branchDAG, tt.test.WeightFunc)
+			tt.test.Scenario.CreateBranches(t, ledgerstate.BranchDAG)
+			o := NewOnTangleVoting(ledgerstate.BranchDAG, tt.test.WeightFunc)
 
 			for _, e := range tt.test.executions {
 				liked, err := o.LikedInstead(tt.test.Scenario.BranchID(e.branchAlias))
@@ -1381,11 +1380,11 @@ func TestOnTangleVoting_Opinion(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			branchDAG := NewBranchDAG(mapdb.NewMapDB(), database.NewCacheTimeProvider(0))
-			defer branchDAG.Shutdown()
+			ledgerstate := New(CacheTimeProvider(database.NewCacheTimeProvider(0)))
+			defer ledgerstate.Shutdown()
 
-			tt.test.Scenario.CreateBranches(t, branchDAG)
-			o := NewOnTangleVoting(branchDAG, tt.test.WeightFunc)
+			tt.test.Scenario.CreateBranches(t, ledgerstate.BranchDAG)
+			o := NewOnTangleVoting(ledgerstate.BranchDAG, tt.test.WeightFunc)
 
 			gotLiked, gotDisliked, err := o.Opinion(tt.test.args())
 			if tt.wantErr {

--- a/packages/jsonmodels/ledgerstate.go
+++ b/packages/jsonmodels/ledgerstate.go
@@ -510,14 +510,14 @@ func NewOutputMetadata(outputMetadata *ledgerstate.OutputMetadata, confirmedCons
 // Consumer represents the JSON model of a ledgerstate.Consumer.
 type Consumer struct {
 	TransactionID string `json:"transactionID"`
-	Valid         string `json:"valid"`
+	SolidityType  string `json:"solidityType"`
 }
 
 // NewConsumer returns a Consumer from the given ledgerstate.Consumer.
 func NewConsumer(consumer *ledgerstate.Consumer) *Consumer {
 	return &Consumer{
 		TransactionID: consumer.TransactionID().Base58(),
-		Valid:         consumer.Valid().String(),
+		SolidityType:  consumer.SolidityType().String(),
 	}
 }
 
@@ -741,9 +741,8 @@ func NewUnlockBlock(unlockBlock ledgerstate.UnlockBlock) *UnlockBlock {
 type TransactionMetadata struct {
 	TransactionID       string              `json:"transactionID"`
 	BranchID            string              `json:"branchID"`
-	Solid               bool                `json:"solid"`
+	SolidityType        string              `json:"solidityType"`
 	SolidificationTime  int64               `json:"solidificationTime"`
-	LazyBooked          bool                `json:"lazyBooked"`
 	GradeOfFinality     gof.GradeOfFinality `json:"gradeOfFinality"`
 	GradeOfFinalityTime int64               `json:"gradeOfFinalityTime"`
 }
@@ -753,9 +752,8 @@ func NewTransactionMetadata(transactionMetadata *ledgerstate.TransactionMetadata
 	return &TransactionMetadata{
 		TransactionID:       transactionMetadata.ID().Base58(),
 		BranchID:            transactionMetadata.BranchID().Base58(),
-		Solid:               transactionMetadata.Solid(),
+		SolidityType:        transactionMetadata.SolidityType().String(),
 		SolidificationTime:  transactionMetadata.SolidificationTime().Unix(),
-		LazyBooked:          transactionMetadata.LazyBooked(),
 		GradeOfFinality:     transactionMetadata.GradeOfFinality(),
 		GradeOfFinalityTime: transactionMetadata.GradeOfFinalityTime().Unix(),
 	}

--- a/packages/ledgerstate/branch.go
+++ b/packages/ledgerstate/branch.go
@@ -229,24 +229,26 @@ func (b BranchIDs) Subtract(other BranchIDs) BranchIDs {
 
 // Intersect removes all BranchIDs from the collection that are not contained in the argument collection.
 // It returns the collection to enable chaining.
-func (b BranchIDs) Intersect(branchIDs BranchIDs) BranchIDs {
-	for branchID := range b {
-		if !branchIDs.Contains(branchID) {
-			delete(b, branchID)
+func (b BranchIDs) Intersect(branchIDs BranchIDs) (res BranchIDs) {
+	// Iterate over the smallest map to increase performance.
+	target, source := branchIDs, b
+	if len(source) < len(target) {
+		target, source = source, target
+	}
+
+	res = NewBranchIDs()
+	for branchID := range target {
+		if source.Contains(branchID) {
+			res.Add(branchID)
 		}
 	}
 
-	return b
+	return
 }
 
 // Contains checks if the given target BranchID is part of the BranchIDs.
 func (b BranchIDs) Contains(targetBranchID BranchID) (contains bool) {
-	for branchID := range b {
-		if contains = branchID == targetBranchID; contains {
-			return
-		}
-	}
-
+	_, contains = b[targetBranchID]
 	return
 }
 

--- a/packages/ledgerstate/branch_dag_test.go
+++ b/packages/ledgerstate/branch_dag_test.go
@@ -6,19 +6,19 @@ import (
 	"github.com/iotaledger/goshimmer/packages/database"
 
 	"github.com/iotaledger/hive.go/events"
-	"github.com/iotaledger/hive.go/kvstore/mapdb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
 func TestBranchDAG_RetrieveConflictBranch(t *testing.T) {
-	branchDAG := NewBranchDAG(mapdb.NewMapDB(), database.NewCacheTimeProvider(0))
-	err := branchDAG.Prune()
-	require.NoError(t, err)
-	defer branchDAG.Shutdown()
+	ledgerstate := New(CacheTimeProvider(database.NewCacheTimeProvider(0)))
+	defer ledgerstate.Shutdown()
 
-	cachedConflictBranch2, newBranchCreated, err := branchDAG.CreateConflictBranch(BranchID{2}, NewBranchIDs(MasterBranchID), NewConflictIDs(ConflictID{0}, ConflictID{1}))
+	err := ledgerstate.Prune()
+	require.NoError(t, err)
+
+	cachedConflictBranch2, newBranchCreated, err := ledgerstate.CreateConflictBranch(BranchID{2}, NewBranchIDs(MasterBranchID), NewConflictIDs(ConflictID{0}, ConflictID{1}))
 	require.NoError(t, err)
 	defer cachedConflictBranch2.Release()
 	conflictBranch2, err := cachedConflictBranch2.UnwrapConflictBranch()
@@ -28,7 +28,7 @@ func TestBranchDAG_RetrieveConflictBranch(t *testing.T) {
 	assert.Equal(t, ConflictBranchType, conflictBranch2.Type())
 	assert.Equal(t, NewConflictIDs(ConflictID{0}, ConflictID{1}), conflictBranch2.Conflicts())
 
-	cachedConflictBranch3, _, err := branchDAG.CreateConflictBranch(BranchID{3}, NewBranchIDs(conflictBranch2.ID()), NewConflictIDs(ConflictID{0}, ConflictID{1}, ConflictID{2}))
+	cachedConflictBranch3, _, err := ledgerstate.CreateConflictBranch(BranchID{3}, NewBranchIDs(conflictBranch2.ID()), NewConflictIDs(ConflictID{0}, ConflictID{1}, ConflictID{2}))
 	require.NoError(t, err)
 	defer cachedConflictBranch3.Release()
 	conflictBranch3, err := cachedConflictBranch3.UnwrapConflictBranch()
@@ -38,7 +38,7 @@ func TestBranchDAG_RetrieveConflictBranch(t *testing.T) {
 	assert.Equal(t, ConflictBranchType, conflictBranch3.Type())
 	assert.Equal(t, NewConflictIDs(ConflictID{0}, ConflictID{1}, ConflictID{2}), conflictBranch3.Conflicts())
 
-	cachedConflictBranch2, newBranchCreated, err = branchDAG.CreateConflictBranch(BranchID{2}, NewBranchIDs(MasterBranchID), NewConflictIDs(ConflictID{0}, ConflictID{1}, ConflictID{2}))
+	cachedConflictBranch2, newBranchCreated, err = ledgerstate.CreateConflictBranch(BranchID{2}, NewBranchIDs(MasterBranchID), NewConflictIDs(ConflictID{0}, ConflictID{1}, ConflictID{2}))
 	require.NoError(t, err)
 	defer cachedConflictBranch2.Release()
 	conflictBranch2, err = cachedConflictBranch2.UnwrapConflictBranch()
@@ -46,241 +46,242 @@ func TestBranchDAG_RetrieveConflictBranch(t *testing.T) {
 	assert.False(t, newBranchCreated)
 	assert.Equal(t, NewConflictIDs(ConflictID{0}, ConflictID{1}, ConflictID{2}), conflictBranch2.Conflicts())
 
-	_, _, err = branchDAG.CreateConflictBranch(BranchID{4}, NewBranchIDs(cachedConflictBranch2.ID(), cachedConflictBranch3.ID()), NewConflictIDs(ConflictID{3}))
+	_, _, err = ledgerstate.CreateConflictBranch(BranchID{4}, NewBranchIDs(cachedConflictBranch2.ID(), cachedConflictBranch3.ID()), NewConflictIDs(ConflictID{3}))
 	require.Error(t, err)
 }
 
 func TestBranchDAG_normalizeBranches(t *testing.T) {
-	branchDAG := NewBranchDAG(mapdb.NewMapDB(), database.NewCacheTimeProvider(0))
-	err := branchDAG.Prune()
-	require.NoError(t, err)
-	defer branchDAG.Shutdown()
+	ledgerstate := New(CacheTimeProvider(database.NewCacheTimeProvider(0)))
+	defer ledgerstate.Shutdown()
 
-	cachedBranch2, newBranchCreated, _ := branchDAG.CreateConflictBranch(BranchID{2}, NewBranchIDs(MasterBranchID), NewConflictIDs(ConflictID{0}))
+	err := ledgerstate.Prune()
+	require.NoError(t, err)
+
+	cachedBranch2, newBranchCreated, _ := ledgerstate.CreateConflictBranch(BranchID{2}, NewBranchIDs(MasterBranchID), NewConflictIDs(ConflictID{0}))
 	defer cachedBranch2.Release()
 	branch2 := cachedBranch2.Unwrap()
 	assert.True(t, newBranchCreated)
 
-	cachedBranch3, newBranchCreated, _ := branchDAG.CreateConflictBranch(BranchID{3}, NewBranchIDs(MasterBranchID), NewConflictIDs(ConflictID{0}))
+	cachedBranch3, newBranchCreated, _ := ledgerstate.CreateConflictBranch(BranchID{3}, NewBranchIDs(MasterBranchID), NewConflictIDs(ConflictID{0}))
 	defer cachedBranch3.Release()
 	branch3 := cachedBranch3.Unwrap()
 	assert.True(t, newBranchCreated)
 
 	{
-		normalizedBranches, err := branchDAG.normalizeBranches(NewBranchIDs(MasterBranchID, branch2.ID()))
+		normalizedBranches, err := ledgerstate.normalizeBranches(NewBranchIDs(MasterBranchID, branch2.ID()))
 		require.NoError(t, err)
 		assert.Equal(t, normalizedBranches, NewBranchIDs(branch2.ID()))
 
-		normalizedBranches, err = branchDAG.normalizeBranches(NewBranchIDs(MasterBranchID, branch3.ID()))
+		normalizedBranches, err = ledgerstate.normalizeBranches(NewBranchIDs(MasterBranchID, branch3.ID()))
 		require.NoError(t, err)
 		assert.Equal(t, normalizedBranches, NewBranchIDs(branch3.ID()))
 
-		_, err = branchDAG.normalizeBranches(NewBranchIDs(branch2.ID(), branch3.ID()))
+		_, err = ledgerstate.normalizeBranches(NewBranchIDs(branch2.ID(), branch3.ID()))
 		require.Error(t, err)
 	}
 
 	// spawn of branch 4 and 5 from branch 2
-	cachedBranch4, newBranchCreated, _ := branchDAG.CreateConflictBranch(BranchID{4}, NewBranchIDs(branch2.ID()), NewConflictIDs(ConflictID{1}))
+	cachedBranch4, newBranchCreated, _ := ledgerstate.CreateConflictBranch(BranchID{4}, NewBranchIDs(branch2.ID()), NewConflictIDs(ConflictID{1}))
 	defer cachedBranch4.Release()
 	branch4 := cachedBranch4.Unwrap()
 	assert.True(t, newBranchCreated)
 
-	cachedBranch5, newBranchCreated, _ := branchDAG.CreateConflictBranch(BranchID{5}, NewBranchIDs(branch2.ID()), NewConflictIDs(ConflictID{1}))
+	cachedBranch5, newBranchCreated, _ := ledgerstate.CreateConflictBranch(BranchID{5}, NewBranchIDs(branch2.ID()), NewConflictIDs(ConflictID{1}))
 	defer cachedBranch5.Release()
 	branch5 := cachedBranch5.Unwrap()
 	assert.True(t, newBranchCreated)
 
 	{
-		normalizedBranches, err := branchDAG.normalizeBranches(NewBranchIDs(MasterBranchID, branch4.ID()))
+		normalizedBranches, err := ledgerstate.normalizeBranches(NewBranchIDs(MasterBranchID, branch4.ID()))
 		require.NoError(t, err)
 		assert.Equal(t, NewBranchIDs(branch4.ID()), normalizedBranches)
 
-		_, err = branchDAG.normalizeBranches(NewBranchIDs(branch3.ID(), branch4.ID()))
+		_, err = ledgerstate.normalizeBranches(NewBranchIDs(branch3.ID(), branch4.ID()))
 		require.Error(t, err)
 
-		normalizedBranches, err = branchDAG.normalizeBranches(NewBranchIDs(MasterBranchID, branch5.ID()))
+		normalizedBranches, err = ledgerstate.normalizeBranches(NewBranchIDs(MasterBranchID, branch5.ID()))
 		require.NoError(t, err)
 		assert.Equal(t, NewBranchIDs(branch5.ID()), normalizedBranches)
 
-		_, err = branchDAG.normalizeBranches(NewBranchIDs(branch3.ID(), branch5.ID()))
+		_, err = ledgerstate.normalizeBranches(NewBranchIDs(branch3.ID(), branch5.ID()))
 		require.Error(t, err)
 
 		// since both consume the same output
-		_, err = branchDAG.normalizeBranches(NewBranchIDs(branch4.ID(), branch5.ID()))
+		_, err = ledgerstate.normalizeBranches(NewBranchIDs(branch4.ID(), branch5.ID()))
 		require.Error(t, err)
 	}
 
 	// branch 6, 7 are on the same level as 2 and 3 but are not part of that conflict set
-	cachedBranch6, newBranchCreated, _ := branchDAG.CreateConflictBranch(BranchID{6}, NewBranchIDs(MasterBranchID), NewConflictIDs(ConflictID{2}))
+	cachedBranch6, newBranchCreated, _ := ledgerstate.CreateConflictBranch(BranchID{6}, NewBranchIDs(MasterBranchID), NewConflictIDs(ConflictID{2}))
 	defer cachedBranch6.Release()
 	branch6 := cachedBranch6.Unwrap()
 	assert.True(t, newBranchCreated)
 
-	cachedBranch7, newBranchCreated, _ := branchDAG.CreateConflictBranch(BranchID{7}, NewBranchIDs(MasterBranchID), NewConflictIDs(ConflictID{2}))
+	cachedBranch7, newBranchCreated, _ := ledgerstate.CreateConflictBranch(BranchID{7}, NewBranchIDs(MasterBranchID), NewConflictIDs(ConflictID{2}))
 	defer cachedBranch7.Release()
 	branch7 := cachedBranch7.Unwrap()
 	assert.True(t, newBranchCreated)
 
 	{
-		normalizedBranches, err := branchDAG.normalizeBranches(NewBranchIDs(branch2.ID(), branch6.ID()))
+		normalizedBranches, err := ledgerstate.normalizeBranches(NewBranchIDs(branch2.ID(), branch6.ID()))
 		require.NoError(t, err)
 		assert.Equal(t, NewBranchIDs(branch2.ID(), branch6.ID()), normalizedBranches)
 
-		normalizedBranches, err = branchDAG.normalizeBranches(NewBranchIDs(branch3.ID(), branch6.ID()))
+		normalizedBranches, err = ledgerstate.normalizeBranches(NewBranchIDs(branch3.ID(), branch6.ID()))
 		require.NoError(t, err)
 		assert.Equal(t, NewBranchIDs(branch3.ID(), branch6.ID()), normalizedBranches)
 
-		normalizedBranches, err = branchDAG.normalizeBranches(NewBranchIDs(branch2.ID(), branch7.ID()))
+		normalizedBranches, err = ledgerstate.normalizeBranches(NewBranchIDs(branch2.ID(), branch7.ID()))
 		require.NoError(t, err)
 		assert.Equal(t, NewBranchIDs(branch2.ID(), branch7.ID()), normalizedBranches)
 
-		normalizedBranches, err = branchDAG.normalizeBranches(NewBranchIDs(branch3.ID(), branch7.ID()))
+		normalizedBranches, err = ledgerstate.normalizeBranches(NewBranchIDs(branch3.ID(), branch7.ID()))
 		require.NoError(t, err)
 		assert.Equal(t, NewBranchIDs(branch3.ID(), branch7.ID()), normalizedBranches)
 
-		_, err = branchDAG.normalizeBranches(NewBranchIDs(branch6.ID(), branch7.ID()))
+		_, err = ledgerstate.normalizeBranches(NewBranchIDs(branch6.ID(), branch7.ID()))
 		require.Error(t, err)
 
-		normalizedBranches, err = branchDAG.normalizeBranches(NewBranchIDs(branch4.ID(), branch6.ID()))
+		normalizedBranches, err = ledgerstate.normalizeBranches(NewBranchIDs(branch4.ID(), branch6.ID()))
 		require.NoError(t, err)
 		assert.Equal(t, NewBranchIDs(branch4.ID(), branch6.ID()), normalizedBranches)
 
-		normalizedBranches, err = branchDAG.normalizeBranches(NewBranchIDs(branch5.ID(), branch6.ID()))
+		normalizedBranches, err = ledgerstate.normalizeBranches(NewBranchIDs(branch5.ID(), branch6.ID()))
 		require.NoError(t, err)
 		assert.Equal(t, NewBranchIDs(branch5.ID(), branch6.ID()), normalizedBranches)
 
-		normalizedBranches, err = branchDAG.normalizeBranches(NewBranchIDs(branch4.ID(), branch7.ID()))
+		normalizedBranches, err = ledgerstate.normalizeBranches(NewBranchIDs(branch4.ID(), branch7.ID()))
 		require.NoError(t, err)
 		assert.Equal(t, NewBranchIDs(branch4.ID(), branch7.ID()), normalizedBranches)
 
-		normalizedBranches, err = branchDAG.normalizeBranches(NewBranchIDs(branch5.ID(), branch7.ID()))
+		normalizedBranches, err = ledgerstate.normalizeBranches(NewBranchIDs(branch5.ID(), branch7.ID()))
 		require.NoError(t, err)
 		assert.Equal(t, NewBranchIDs(branch5.ID(), branch7.ID()), normalizedBranches)
 	}
 
 	// aggregated branch out of branch 4 (child of branch 2) and branch 6
-	cachedAggrBranch8, newBranchCreated, aggrBranchErr := branchDAG.AggregateBranches(NewBranchIDs(branch4.ID(), branch6.ID()))
+	cachedAggrBranch8, newBranchCreated, aggrBranchErr := ledgerstate.AggregateBranches(NewBranchIDs(branch4.ID(), branch6.ID()))
 	require.NoError(t, aggrBranchErr)
 	defer cachedAggrBranch8.Release()
 	aggrBranch8 := cachedAggrBranch8.Unwrap()
 	assert.True(t, newBranchCreated)
 
 	{
-		normalizedBranches, err := branchDAG.normalizeBranches(NewBranchIDs(aggrBranch8.ID(), MasterBranchID))
+		normalizedBranches, err := ledgerstate.normalizeBranches(NewBranchIDs(aggrBranch8.ID(), MasterBranchID))
 		require.NoError(t, err)
 		assert.Equal(t, NewBranchIDs(branch4.ID(), branch6.ID()), normalizedBranches)
 
-		normalizedBranches, err = branchDAG.normalizeBranches(NewBranchIDs(aggrBranch8.ID(), branch2.ID()))
+		normalizedBranches, err = ledgerstate.normalizeBranches(NewBranchIDs(aggrBranch8.ID(), branch2.ID()))
 		require.NoError(t, err)
 		assert.Equal(t, NewBranchIDs(branch4.ID(), branch6.ID()), normalizedBranches)
 
 		// conflicting since branch 2 and branch 3 are
-		_, err = branchDAG.normalizeBranches(NewBranchIDs(aggrBranch8.ID(), branch3.ID()))
+		_, err = ledgerstate.normalizeBranches(NewBranchIDs(aggrBranch8.ID(), branch3.ID()))
 		require.Error(t, err)
 
 		// conflicting since branch 4 and branch 5 are
-		_, err = branchDAG.normalizeBranches(NewBranchIDs(aggrBranch8.ID(), branch5.ID()))
+		_, err = ledgerstate.normalizeBranches(NewBranchIDs(aggrBranch8.ID(), branch5.ID()))
 		require.Error(t, err)
 
 		// conflicting since branch 6 and branch 7 are
-		_, err = branchDAG.normalizeBranches(NewBranchIDs(aggrBranch8.ID(), branch7.ID()))
+		_, err = ledgerstate.normalizeBranches(NewBranchIDs(aggrBranch8.ID(), branch7.ID()))
 		require.Error(t, err)
 	}
 
 	// aggregated branch out of aggr. branch 8 and branch 7:
 	// should fail since branch 6 & 7 are conflicting
-	_, newBrachCreated, aggrBranchErr := branchDAG.AggregateBranches(NewBranchIDs(aggrBranch8.ID(), branch7.ID()))
+	_, newBrachCreated, aggrBranchErr := ledgerstate.AggregateBranches(NewBranchIDs(aggrBranch8.ID(), branch7.ID()))
 	require.Error(t, aggrBranchErr)
 	assert.False(t, newBrachCreated)
 
 	// aggregated branch out of branch 5 (child of branch 2) and branch 7
-	cachedAggrBranch9, newBranchCreated, aggrBranchErr := branchDAG.AggregateBranches(NewBranchIDs(branch5.ID(), branch7.ID()))
+	cachedAggrBranch9, newBranchCreated, aggrBranchErr := ledgerstate.AggregateBranches(NewBranchIDs(branch5.ID(), branch7.ID()))
 	require.NoError(t, aggrBranchErr)
 	defer cachedAggrBranch9.Release()
 	aggrBranch9 := cachedAggrBranch9.Unwrap()
 	assert.True(t, newBranchCreated)
 
 	{
-		normalizedBranches, err := branchDAG.normalizeBranches(NewBranchIDs(aggrBranch9.ID(), MasterBranchID))
+		normalizedBranches, err := ledgerstate.normalizeBranches(NewBranchIDs(aggrBranch9.ID(), MasterBranchID))
 		require.NoError(t, err)
 		assert.Equal(t, NewBranchIDs(branch5.ID(), branch7.ID()), normalizedBranches)
 
 		// aggr. branch 8 and 9 should be conflicting, since 4 & 5 and 6 & 7 are
-		_, err = branchDAG.normalizeBranches(NewBranchIDs(aggrBranch8.ID(), aggrBranch9.ID()))
+		_, err = ledgerstate.normalizeBranches(NewBranchIDs(aggrBranch8.ID(), aggrBranch9.ID()))
 		require.Error(t, err)
 
 		// conflicting since branch 3 & 2 are
-		_, err = branchDAG.normalizeBranches(NewBranchIDs(branch3.ID(), aggrBranch9.ID()))
+		_, err = ledgerstate.normalizeBranches(NewBranchIDs(branch3.ID(), aggrBranch9.ID()))
 		require.Error(t, err)
 	}
 
 	// aggregated branch out of branch 3 and branch 6
-	cachedAggrBranch10, newBranchCreated, aggrBranchErr := branchDAG.AggregateBranches(NewBranchIDs(branch3.ID(), branch6.ID()))
+	cachedAggrBranch10, newBranchCreated, aggrBranchErr := ledgerstate.AggregateBranches(NewBranchIDs(branch3.ID(), branch6.ID()))
 	require.NoError(t, aggrBranchErr)
 	defer cachedAggrBranch10.Release()
 	aggrBranch10 := cachedAggrBranch10.Unwrap()
 	assert.True(t, newBranchCreated)
 
 	{
-		normalizedBranches, err := branchDAG.normalizeBranches(NewBranchIDs(aggrBranch10.ID(), MasterBranchID))
+		normalizedBranches, err := ledgerstate.normalizeBranches(NewBranchIDs(aggrBranch10.ID(), MasterBranchID))
 		require.NoError(t, err)
 		assert.Equal(t, NewBranchIDs(branch3.ID(), branch6.ID()), normalizedBranches)
 
 		// aggr. branch 8 and 10 should be conflicting, since 2 & 3 are
-		_, err = branchDAG.normalizeBranches(NewBranchIDs(aggrBranch8.ID(), aggrBranch10.ID()))
+		_, err = ledgerstate.normalizeBranches(NewBranchIDs(aggrBranch8.ID(), aggrBranch10.ID()))
 		require.Error(t, err)
 
 		// aggr. branch 9 and 10 should be conflicting, since 2 & 3 and 6 & 7 are
-		_, err = branchDAG.normalizeBranches(NewBranchIDs(aggrBranch9.ID(), aggrBranch10.ID()))
+		_, err = ledgerstate.normalizeBranches(NewBranchIDs(aggrBranch9.ID(), aggrBranch10.ID()))
 		require.Error(t, err)
 	}
 
 	// branch 11, 12 are on the same level as 2 & 3 and 6 & 7 but are not part of either conflict set
-	cachedBranch11, newBranchCreated, _ := branchDAG.CreateConflictBranch(BranchID{11}, NewBranchIDs(MasterBranchID), NewConflictIDs(ConflictID{3}))
+	cachedBranch11, newBranchCreated, _ := ledgerstate.CreateConflictBranch(BranchID{11}, NewBranchIDs(MasterBranchID), NewConflictIDs(ConflictID{3}))
 	defer cachedBranch11.Release()
 	branch11 := cachedBranch11.Unwrap()
 	assert.True(t, newBranchCreated)
 
-	cachedBranch12, newBranchCreated, _ := branchDAG.CreateConflictBranch(BranchID{12}, NewBranchIDs(MasterBranchID), NewConflictIDs(ConflictID{3}))
+	cachedBranch12, newBranchCreated, _ := ledgerstate.CreateConflictBranch(BranchID{12}, NewBranchIDs(MasterBranchID), NewConflictIDs(ConflictID{3}))
 	defer cachedBranch12.Release()
 	branch12 := cachedBranch12.Unwrap()
 	assert.True(t, newBranchCreated)
 
 	{
-		normalizedBranches, err := branchDAG.normalizeBranches(NewBranchIDs(MasterBranchID, branch11.ID()))
+		normalizedBranches, err := ledgerstate.normalizeBranches(NewBranchIDs(MasterBranchID, branch11.ID()))
 		require.NoError(t, err)
 		assert.Equal(t, NewBranchIDs(branch11.ID()), normalizedBranches)
 
-		normalizedBranches, err = branchDAG.normalizeBranches(NewBranchIDs(MasterBranchID, branch12.ID()))
+		normalizedBranches, err = ledgerstate.normalizeBranches(NewBranchIDs(MasterBranchID, branch12.ID()))
 		require.NoError(t, err)
 		assert.Equal(t, NewBranchIDs(branch12.ID()), normalizedBranches)
 
-		_, err = branchDAG.normalizeBranches(NewBranchIDs(branch11.ID(), branch12.ID()))
+		_, err = ledgerstate.normalizeBranches(NewBranchIDs(branch11.ID(), branch12.ID()))
 		require.Error(t, err)
 	}
 
 	// aggr. branch 13 out of branch 6 and 11
-	cachedAggrBranch13, newBranchCreated, aggrBranchErr := branchDAG.AggregateBranches(NewBranchIDs(branch6.ID(), branch11.ID()))
+	cachedAggrBranch13, newBranchCreated, aggrBranchErr := ledgerstate.AggregateBranches(NewBranchIDs(branch6.ID(), branch11.ID()))
 	require.NoError(t, aggrBranchErr)
 	defer cachedAggrBranch13.Release()
 	aggrBranch13 := cachedAggrBranch13.Unwrap()
 	assert.True(t, newBranchCreated)
 
 	{
-		_, err := branchDAG.normalizeBranches(NewBranchIDs(aggrBranch13.ID(), aggrBranch9.ID()))
+		_, err := ledgerstate.normalizeBranches(NewBranchIDs(aggrBranch13.ID(), aggrBranch9.ID()))
 		require.Error(t, err)
 
-		normalizedBranches, err := branchDAG.normalizeBranches(NewBranchIDs(aggrBranch13.ID(), aggrBranch8.ID()))
+		normalizedBranches, err := ledgerstate.normalizeBranches(NewBranchIDs(aggrBranch13.ID(), aggrBranch8.ID()))
 		require.NoError(t, err)
 		assert.Equal(t, NewBranchIDs(branch4.ID(), branch6.ID(), branch11.ID()), normalizedBranches)
 
-		normalizedBranches, err = branchDAG.normalizeBranches(NewBranchIDs(aggrBranch13.ID(), aggrBranch10.ID()))
+		normalizedBranches, err = ledgerstate.normalizeBranches(NewBranchIDs(aggrBranch13.ID(), aggrBranch10.ID()))
 		require.NoError(t, err)
 		assert.Equal(t, NewBranchIDs(branch3.ID(), branch6.ID(), branch11.ID()), normalizedBranches)
 	}
 
 	// aggr. branch 14 out of aggr. branch 10 and 13
-	cachedAggrBranch14, newBranchCreated, aggrBranchErr := branchDAG.AggregateBranches(NewBranchIDs(aggrBranch10.ID(), aggrBranch13.ID()))
+	cachedAggrBranch14, newBranchCreated, aggrBranchErr := ledgerstate.AggregateBranches(NewBranchIDs(aggrBranch10.ID(), aggrBranch13.ID()))
 	require.NoError(t, aggrBranchErr)
 	defer cachedAggrBranch14.Release()
 	aggrBranch14 := cachedAggrBranch14.Unwrap()
@@ -288,16 +289,16 @@ func TestBranchDAG_normalizeBranches(t *testing.T) {
 
 	{
 		// aggr. branch 9 has parent branch 7 which conflicts with ancestor branch 6 of aggr. branch 14
-		_, err := branchDAG.normalizeBranches(NewBranchIDs(aggrBranch14.ID(), aggrBranch9.ID()))
+		_, err := ledgerstate.normalizeBranches(NewBranchIDs(aggrBranch14.ID(), aggrBranch9.ID()))
 		require.Error(t, err)
 
 		// aggr. branch has ancestor branch 2 which conflicts with ancestor branch 3 of aggr. branch 14
-		_, err = branchDAG.normalizeBranches(NewBranchIDs(aggrBranch14.ID(), aggrBranch8.ID()))
+		_, err = ledgerstate.normalizeBranches(NewBranchIDs(aggrBranch14.ID(), aggrBranch8.ID()))
 		require.Error(t, err)
 	}
 
 	// aggr. branch 15 out of branch 2, 7 and 12
-	cachedAggrBranch15, newBranchCreated, aggrBranchErr := branchDAG.AggregateBranches(NewBranchIDs(branch2.ID(), branch7.ID(), branch12.ID()))
+	cachedAggrBranch15, newBranchCreated, aggrBranchErr := ledgerstate.AggregateBranches(NewBranchIDs(branch2.ID(), branch7.ID(), branch12.ID()))
 	require.NoError(t, aggrBranchErr)
 	defer cachedAggrBranch15.Release()
 	aggrBranch15 := cachedAggrBranch15.Unwrap()
@@ -305,20 +306,20 @@ func TestBranchDAG_normalizeBranches(t *testing.T) {
 
 	{
 		// aggr. branch 13 has parent branches 11 & 6 which conflicts which conflicts with ancestor branches 12 & 7 of aggr. branch 15
-		_, err := branchDAG.normalizeBranches(NewBranchIDs(aggrBranch15.ID(), aggrBranch13.ID()))
+		_, err := ledgerstate.normalizeBranches(NewBranchIDs(aggrBranch15.ID(), aggrBranch13.ID()))
 		require.Error(t, err)
 
 		// aggr. branch 10 has parent branches 3 & 6 which conflicts with ancestor branches 2 & 7 of aggr. branch 15
-		_, err = branchDAG.normalizeBranches(NewBranchIDs(aggrBranch15.ID(), aggrBranch10.ID()))
+		_, err = ledgerstate.normalizeBranches(NewBranchIDs(aggrBranch15.ID(), aggrBranch10.ID()))
 		require.Error(t, err)
 
 		// aggr. branch 8 has parent branch 6 which conflicts with ancestor branch 7 of aggr. branch 15
-		_, err = branchDAG.normalizeBranches(NewBranchIDs(aggrBranch15.ID(), aggrBranch8.ID()))
+		_, err = ledgerstate.normalizeBranches(NewBranchIDs(aggrBranch15.ID(), aggrBranch8.ID()))
 		require.Error(t, err)
 	}
 
 	// aggr. branch 16 out of aggr. branches 15 and 9
-	cachedAggrBranch16, newBranchCreated, aggrBranchErr := branchDAG.AggregateBranches(NewBranchIDs(aggrBranch15.ID(), aggrBranch9.ID()))
+	cachedAggrBranch16, newBranchCreated, aggrBranchErr := ledgerstate.AggregateBranches(NewBranchIDs(aggrBranch15.ID(), aggrBranch9.ID()))
 	require.NoError(t, aggrBranchErr)
 	defer cachedAggrBranch16.Release()
 	aggrBranch16 := cachedAggrBranch16.Unwrap()
@@ -326,38 +327,39 @@ func TestBranchDAG_normalizeBranches(t *testing.T) {
 
 	{
 		// sanity check
-		normalizedBranches, err := branchDAG.normalizeBranches(NewBranchIDs(aggrBranch16.ID(), aggrBranch9.ID()))
+		normalizedBranches, err := ledgerstate.normalizeBranches(NewBranchIDs(aggrBranch16.ID(), aggrBranch9.ID()))
 		require.NoError(t, err)
 		assert.Equal(t, NewBranchIDs(branch5.ID(), branch7.ID(), branch12.ID()), normalizedBranches)
 
 		// sanity check
-		normalizedBranches, err = branchDAG.normalizeBranches(NewBranchIDs(aggrBranch16.ID(), branch7.ID()))
+		normalizedBranches, err = ledgerstate.normalizeBranches(NewBranchIDs(aggrBranch16.ID(), branch7.ID()))
 		require.NoError(t, err)
 		assert.Equal(t, NewBranchIDs(branch5.ID(), branch7.ID(), branch12.ID()), normalizedBranches)
 
-		_, err = branchDAG.normalizeBranches(NewBranchIDs(aggrBranch16.ID(), aggrBranch13.ID()))
+		_, err = ledgerstate.normalizeBranches(NewBranchIDs(aggrBranch16.ID(), aggrBranch13.ID()))
 		require.Error(t, err)
 
-		_, err = branchDAG.normalizeBranches(NewBranchIDs(aggrBranch16.ID(), aggrBranch14.ID()))
+		_, err = ledgerstate.normalizeBranches(NewBranchIDs(aggrBranch16.ID(), aggrBranch14.ID()))
 		require.Error(t, err)
 
-		_, err = branchDAG.normalizeBranches(NewBranchIDs(aggrBranch16.ID(), aggrBranch8.ID()))
+		_, err = ledgerstate.normalizeBranches(NewBranchIDs(aggrBranch16.ID(), aggrBranch8.ID()))
 		require.Error(t, err)
 	}
 }
 
 func TestBranchDAG_ConflictMembers(t *testing.T) {
-	branchDAG := NewBranchDAG(mapdb.NewMapDB(), database.NewCacheTimeProvider(0))
-	err := branchDAG.Prune()
+	ledgerstate := New(CacheTimeProvider(database.NewCacheTimeProvider(0)))
+	defer ledgerstate.Shutdown()
+
+	err := ledgerstate.Prune()
 	require.NoError(t, err)
-	defer branchDAG.Shutdown()
 
 	// create initial branches
-	cachedBranch2, newBranchCreated, _ := branchDAG.CreateConflictBranch(BranchID{2}, NewBranchIDs(MasterBranchID), NewConflictIDs(ConflictID{0}))
+	cachedBranch2, newBranchCreated, _ := ledgerstate.CreateConflictBranch(BranchID{2}, NewBranchIDs(MasterBranchID), NewConflictIDs(ConflictID{0}))
 	defer cachedBranch2.Release()
 	branch2 := cachedBranch2.Unwrap()
 	assert.True(t, newBranchCreated)
-	cachedBranch3, newBranchCreated, _ := branchDAG.CreateConflictBranch(BranchID{3}, NewBranchIDs(MasterBranchID), NewConflictIDs(ConflictID{0}))
+	cachedBranch3, newBranchCreated, _ := ledgerstate.CreateConflictBranch(BranchID{3}, NewBranchIDs(MasterBranchID), NewConflictIDs(ConflictID{0}))
 	defer cachedBranch3.Release()
 	branch3 := cachedBranch3.Unwrap()
 	assert.True(t, newBranchCreated)
@@ -367,13 +369,13 @@ func TestBranchDAG_ConflictMembers(t *testing.T) {
 		branch2.ID(): {}, branch3.ID(): {},
 	}
 	actualConflictMembers := map[BranchID]struct{}{}
-	branchDAG.ConflictMembers(ConflictID{0}).Consume(func(conflictMember *ConflictMember) {
+	ledgerstate.ConflictMembers(ConflictID{0}).Consume(func(conflictMember *ConflictMember) {
 		actualConflictMembers[conflictMember.BranchID()] = struct{}{}
 	})
 	assert.Equal(t, expectedConflictMembers, actualConflictMembers)
 
 	// add branch 4
-	cachedBranch4, newBranchCreated, _ := branchDAG.CreateConflictBranch(BranchID{4}, NewBranchIDs(MasterBranchID), NewConflictIDs(ConflictID{0}))
+	cachedBranch4, newBranchCreated, _ := ledgerstate.CreateConflictBranch(BranchID{4}, NewBranchIDs(MasterBranchID), NewConflictIDs(ConflictID{0}))
 	defer cachedBranch4.Release()
 	branch4 := cachedBranch4.Unwrap()
 	assert.True(t, newBranchCreated)
@@ -383,7 +385,7 @@ func TestBranchDAG_ConflictMembers(t *testing.T) {
 		branch2.ID(): {}, branch3.ID(): {}, branch4.ID(): {},
 	}
 	actualConflictMembers = map[BranchID]struct{}{}
-	branchDAG.ConflictMembers(ConflictID{0}).Consume(func(conflictMember *ConflictMember) {
+	ledgerstate.ConflictMembers(ConflictID{0}).Consume(func(conflictMember *ConflictMember) {
 		actualConflictMembers[conflictMember.BranchID()] = struct{}{}
 	})
 	assert.Equal(t, expectedConflictMembers, actualConflictMembers)

--- a/packages/ledgerstate/confirmationoracle.go
+++ b/packages/ledgerstate/confirmationoracle.go
@@ -1,0 +1,113 @@
+package ledgerstate
+
+import (
+	"github.com/iotaledger/hive.go/datastructure/walker"
+
+	"github.com/iotaledger/goshimmer/packages/consensus/gof"
+)
+
+// region SimpleConfirmationOracle /////////////////////////////////////////////////////////////////////////////////////
+
+// SimpleConfirmationOracle is a very simple ConfirmationOracle that retrieves the confirmation status by analyzing the
+// gradeOfFinality of the different entities.
+type SimpleConfirmationOracle struct {
+	ledgerstate *Ledgerstate
+}
+
+// NewSimpleConfirmationOracle is the constructor for the SimpleConfirmationOracle.
+func NewSimpleConfirmationOracle(ledgerstate *Ledgerstate) *SimpleConfirmationOracle {
+	return &SimpleConfirmationOracle{
+		ledgerstate: ledgerstate,
+	}
+}
+
+// IsTransactionConfirmed returns true if the transaction has been accepted to stay in the ledger.
+func (s *SimpleConfirmationOracle) IsTransactionConfirmed(transactionID TransactionID) (isConfirmed bool) {
+	s.ledgerstate.CachedTransactionMetadata(transactionID).Consume(func(transactionMetadata *TransactionMetadata) {
+		isConfirmed = transactionMetadata.GradeOfFinality() >= gof.High
+	})
+
+	return
+}
+
+// IsTransactionRejected returns true if the transaction will not stay part of the ledger permanently.
+func (s *SimpleConfirmationOracle) IsTransactionRejected(transactionID TransactionID) (isRejected bool) {
+	s.ledgerstate.CachedTransactionMetadata(transactionID).Consume(func(transactionMetadata *TransactionMetadata) {
+		isRejected = s.IsBranchRejected(transactionMetadata.BranchID())
+	})
+
+	return
+}
+
+// IsBranchConfirmed returns true if the Branch has been accepted to stay in the ledger.
+func (s *SimpleConfirmationOracle) IsBranchConfirmed(branchID BranchID) bool {
+	return s.IsTransactionConfirmed(branchID.TransactionID())
+}
+
+// IsBranchRejected returns true if the Branch will not stay part of the ledger permanently.
+func (s *SimpleConfirmationOracle) IsBranchRejected(branchID BranchID) (isRejected bool) {
+	branchWalker := walker.New(false)
+	branchWalker.Push(branchID)
+	for branchWalker.HasNext() {
+		currentBranchID := branchWalker.Next().(BranchID)
+		if isRejected = s.isConflictingBranchConfirmed(currentBranchID); isRejected {
+			return
+		}
+
+		s.queueIsBranchRejectedParents(currentBranchID, branchWalker)
+	}
+
+	return
+}
+
+func (s *SimpleConfirmationOracle) queueIsBranchRejectedParents(currentBranchID BranchID, branchWalker *walker.Walker) {
+	conflictingBranchIDs, err := s.ledgerstate.ResolveConflictBranchIDs(NewBranchIDs(currentBranchID))
+	if err != nil {
+		return
+	}
+
+	for conflictBranchID := range conflictingBranchIDs {
+		s.ledgerstate.Branch(conflictBranchID).Consume(func(branch Branch) {
+			for parentBranchID := range branch.Parents() {
+				branchWalker.Push(parentBranchID)
+			}
+		})
+	}
+}
+
+func (s *SimpleConfirmationOracle) isConflictingBranchConfirmed(currentBranchID BranchID) (isRejected bool) {
+	s.ledgerstate.ForEachConflictingBranchID(currentBranchID, func(conflictingBranchID BranchID) {
+		if isRejected {
+			return
+		}
+
+		isRejected = s.IsTransactionConfirmed(conflictingBranchID.TransactionID())
+	})
+
+	return
+}
+
+// code contract (make sure the struct implements all required methods).
+var _ ConfirmationOracle = &SimpleConfirmationOracle{}
+
+// endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// region ConfirmationOracle ///////////////////////////////////////////////////////////////////////////////////////////
+
+// ConfirmationOracle is an interface for the component that answers questions about the confirmation status of the
+// different entities of the ledger.
+type ConfirmationOracle interface {
+	// IsTransactionConfirmed returns true if the transaction has been accepted to stay in the ledger.
+	IsTransactionConfirmed(transactionID TransactionID) bool
+
+	// IsTransactionRejected returns true if the transaction will not stay part of the ledger permanently.
+	IsTransactionRejected(transactionID TransactionID) bool
+
+	// IsBranchConfirmed returns true if the Branch has been accepted to stay in the ledger.
+	IsBranchConfirmed(branchID BranchID) bool
+
+	// IsBranchRejected returns true if the Branch will not stay part of the ledger permanently.
+	IsBranchRejected(branchID BranchID) bool
+}
+
+// endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/packages/ledgerstate/ledgerstate.go
+++ b/packages/ledgerstate/ledgerstate.go
@@ -1,0 +1,91 @@
+package ledgerstate
+
+import (
+	"github.com/iotaledger/hive.go/kvstore"
+	"github.com/iotaledger/hive.go/kvstore/mapdb"
+
+	"github.com/iotaledger/goshimmer/packages/database"
+)
+
+// region Ledgerstate //////////////////////////////////////////////////////////////////////////////////////////////////
+
+// Ledgerstate is a data structure that follows the principles of the quadruple entry accounting.
+type Ledgerstate struct {
+	Options *Options
+
+	*UTXODAG
+	*BranchDAG
+	ConfirmationOracle
+}
+
+// New is the constructor for the Ledgerstate.
+func New(options ...Option) (ledgerstate *Ledgerstate) {
+	ledgerstate = &Ledgerstate{}
+	ledgerstate.Configure(options...)
+
+	ledgerstate.UTXODAG = NewUTXODAG(ledgerstate)
+	ledgerstate.BranchDAG = NewBranchDAG(ledgerstate)
+	ledgerstate.ConfirmationOracle = NewSimpleConfirmationOracle(ledgerstate)
+
+	return ledgerstate
+}
+
+// Configure modifies the configuration of the Ledgerstate.
+func (l *Ledgerstate) Configure(options ...Option) {
+	if l.Options == nil {
+		l.Options = &Options{
+			Store:              mapdb.NewMapDB(),
+			LazyBookingEnabled: true,
+		}
+	}
+
+	for _, option := range options {
+		option(l.Options)
+	}
+}
+
+// Shutdown marks the Ledgerstate as stopped, so it will not accept any new Transactions.
+func (l *Ledgerstate) Shutdown() {
+	l.BranchDAG.Shutdown()
+	l.UTXODAG.Shutdown()
+}
+
+// endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// region Options //////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// Option represents the return type of optional parameters that can be handed into the constructor of the Ledgerstate
+// to configure its behavior.
+type Option func(*Options)
+
+// Options is a container for all configurable parameters of the Ledgerstate.
+type Options struct {
+	Store              kvstore.KVStore
+	CacheTimeProvider  *database.CacheTimeProvider
+	LazyBookingEnabled bool
+}
+
+// Store is an Option for the Ledgerstate that allows to specify which storage layer is supposed to be used to persist
+// data.
+func Store(store kvstore.KVStore) Option {
+	return func(options *Options) {
+		options.Store = store
+	}
+}
+
+// CacheTimeProvider is an Option for the Tangle that allows to override hard coded cache time.
+func CacheTimeProvider(cacheTimeProvider *database.CacheTimeProvider) Option {
+	return func(options *Options) {
+		options.CacheTimeProvider = cacheTimeProvider
+	}
+}
+
+// LazyBookingEnabled is an Option for the Ledgerstate that allows to specify if the ledger state should lazy book
+// conflicts that look like they have been decided already.
+func LazyBookingEnabled(enabled bool) Option {
+	return func(options *Options) {
+		options.LazyBookingEnabled = enabled
+	}
+}
+
+// endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/packages/ledgerstate/transaction_test.go
+++ b/packages/ledgerstate/transaction_test.go
@@ -13,12 +13,12 @@ import (
 var sampleColor = Color{2}
 
 func TestTransaction_Bytes(t *testing.T) {
-	branchDAG, utxoDAG := setupDependencies(t)
-	defer branchDAG.Shutdown()
+	ledgerstate := setupDependencies(t)
+	defer ledgerstate.Shutdown()
 
 	wallets := createWallets(2)
-	input := generateOutput(utxoDAG, wallets[0].address, 0)
-	tx, _ := singleInputTransaction(utxoDAG, wallets[0], wallets[1], input)
+	input := generateOutput(ledgerstate, wallets[0].address, 0)
+	tx, _ := singleInputTransaction(ledgerstate, wallets[0], wallets[1], input)
 	bytes := tx.Bytes()
 	_tx, _, err := TransactionFromBytes(bytes)
 	assert.NoError(t, err)

--- a/packages/ledgerstate/utxo_dag_test.go
+++ b/packages/ledgerstate/utxo_dag_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/iotaledger/hive.go/events"
+
 	"github.com/iotaledger/goshimmer/packages/consensus/gof"
 	"github.com/iotaledger/goshimmer/packages/database"
-	"github.com/iotaledger/goshimmer/packages/eventsqueue"
 
 	"github.com/iotaledger/hive.go/crypto/ed25519"
 	"github.com/iotaledger/hive.go/identity"
@@ -396,7 +397,7 @@ func TestBookConflictingTransaction(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, branchesOfInputsConflicting)
 
-	eventsQueue := eventsqueue.New()
+	eventsQueue := events.NewQueue()
 	targetBranch2 := ledgerstate.bookConflictingTransaction(tx2, txMetadata2, inputsMetadata2, normalizedBranchIDs, conflictingInputs.ByID(), eventsQueue)
 	eventsQueue.Trigger()
 

--- a/packages/ledgerstate/utxo_dag_test.go
+++ b/packages/ledgerstate/utxo_dag_test.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/iotaledger/goshimmer/packages/consensus/gof"
 	"github.com/iotaledger/goshimmer/packages/database"
+	"github.com/iotaledger/goshimmer/packages/eventsqueue"
 
 	"github.com/iotaledger/hive.go/crypto/ed25519"
 	"github.com/iotaledger/hive.go/identity"
-	"github.com/iotaledger/hive.go/kvstore/mapdb"
 	"github.com/iotaledger/hive.go/objectstorage"
 	"github.com/iotaledger/hive.go/types"
 	"github.com/stretchr/testify/assert"
@@ -23,8 +23,8 @@ var (
 )
 
 func TestExampleC(t *testing.T) {
-	branchDAG, utxoDAG := setupDependencies(t)
-	defer branchDAG.Shutdown()
+	ledgerstate := setupDependencies(t)
+	defer ledgerstate.Shutdown()
 
 	outputs := make(map[string]*SigLockedSingleOutput)
 	transactions := make(map[string]*Transaction)
@@ -32,20 +32,16 @@ func TestExampleC(t *testing.T) {
 	wallets := createWallets(2)
 	// Prepare and book TX1
 	{
-		outputs["A"] = generateOutput(utxoDAG, wallets[0].address, 0)
-		transactions["TX1"] = buildTransaction(utxoDAG, wallets[0], wallets[0], []*SigLockedSingleOutput{outputs["A"]})
-		targetBranch1, err := utxoDAG.BookTransaction(transactions["TX1"])
-		require.NoError(t, err)
-		assert.Equal(t, MasterBranchID, targetBranch1)
+		outputs["A"] = generateOutput(ledgerstate, wallets[0].address, 0)
+		transactions["TX1"] = buildTransaction(ledgerstate, wallets[0], wallets[0], []*SigLockedSingleOutput{outputs["A"]})
+		assertTransactionStoredIntoBranch(t, ledgerstate, transactions["TX1"], MasterBranchID)
 	}
 
 	// Prepare and book TX2
 	{
-		outputs["B"] = generateOutput(utxoDAG, wallets[0].address, 1)
-		transactions["TX2"] = buildTransaction(utxoDAG, wallets[0], wallets[0], []*SigLockedSingleOutput{outputs["B"]})
-		targetBranch2, err := utxoDAG.BookTransaction(transactions["TX2"])
-		require.NoError(t, err)
-		assert.Equal(t, MasterBranchID, targetBranch2)
+		outputs["B"] = generateOutput(ledgerstate, wallets[0].address, 1)
+		transactions["TX2"] = buildTransaction(ledgerstate, wallets[0], wallets[0], []*SigLockedSingleOutput{outputs["B"]})
+		assertTransactionStoredIntoBranch(t, ledgerstate, transactions["TX2"], MasterBranchID)
 	}
 
 	// Prepare and book TX3
@@ -53,56 +49,50 @@ func TestExampleC(t *testing.T) {
 		outputs["C"] = transactions["TX1"].Essence().Outputs()[0].(*SigLockedSingleOutput)
 		outputs["D"] = transactions["TX2"].Essence().Outputs()[0].(*SigLockedSingleOutput)
 
-		transactions["TX3"] = buildTransaction(utxoDAG, wallets[0], wallets[0], []*SigLockedSingleOutput{outputs["C"], outputs["D"]})
-		targetBranch3, err := utxoDAG.BookTransaction(transactions["TX3"])
-		require.NoError(t, err)
-		assert.Equal(t, MasterBranchID, targetBranch3)
+		transactions["TX3"] = buildTransaction(ledgerstate, wallets[0], wallets[0], []*SigLockedSingleOutput{outputs["C"], outputs["D"]})
+		assertTransactionStoredIntoBranch(t, ledgerstate, transactions["TX3"], MasterBranchID)
 	}
 
 	// Prepare and book Tx4 (double spending B)
 	{
-		transactions["TX4"] = buildTransaction(utxoDAG, wallets[0], wallets[1], []*SigLockedSingleOutput{outputs["B"]})
-		targetBranch4, err := utxoDAG.BookTransaction(transactions["TX4"])
-		require.NoError(t, err)
-		assert.Equal(t, NewBranchID(transactions["TX4"].ID()), targetBranch4)
+		transactions["TX4"] = buildTransaction(ledgerstate, wallets[0], wallets[1], []*SigLockedSingleOutput{outputs["B"]})
+		assertTransactionStoredIntoBranch(t, ledgerstate, transactions["TX4"], NewBranchID(transactions["TX4"].ID()))
 	}
 
 	// Prepare and book TX5 (double spending A)
 	{
-		transactions["TX5"] = buildTransaction(utxoDAG, wallets[0], wallets[1], []*SigLockedSingleOutput{outputs["A"]})
-		targetBranch5, err := utxoDAG.BookTransaction(transactions["TX5"])
-		require.NoError(t, err)
-		assert.Equal(t, NewBranchID(transactions["TX5"].ID()), targetBranch5)
+		transactions["TX5"] = buildTransaction(ledgerstate, wallets[0], wallets[1], []*SigLockedSingleOutput{outputs["A"]})
+		assertTransactionStoredIntoBranch(t, ledgerstate, transactions["TX5"], NewBranchID(transactions["TX5"].ID()))
 	}
 
 	// Checking TX3
 	{
 		// Checking that the BranchID of Tx3 is correct
 		Tx3AggregatedBranch := NewAggregatedBranch(NewBranchIDs(NewBranchID(transactions["TX1"].ID()), NewBranchID(transactions["TX2"].ID())))
-		utxoDAG.CachedTransactionMetadata(transactions["TX3"].ID()).Consume(func(metadata *TransactionMetadata) {
+		ledgerstate.CachedTransactionMetadata(transactions["TX3"].ID()).Consume(func(metadata *TransactionMetadata) {
 			assert.Equal(t, Tx3AggregatedBranch.ID(), metadata.BranchID())
 		})
 
 		// Checking that the parents BranchID of TX3 are TX1 and TX2
-		utxoDAG.branchDAG.Branch(Tx3AggregatedBranch.ID()).Consume(func(branch Branch) {
+		ledgerstate.Branch(Tx3AggregatedBranch.ID()).Consume(func(branch Branch) {
 			assert.Equal(t, NewBranchIDs(NewBranchID(transactions["TX1"].ID()), NewBranchID(transactions["TX2"].ID())), branch.Parents())
 		})
 
 		time.Sleep(1 * time.Second)
 
-		utxoDAG.branchDAG.ChildBranches(NewBranchID(transactions["TX1"].ID())).Consume(func(childBranch *ChildBranch) {
+		ledgerstate.ChildBranches(NewBranchID(transactions["TX1"].ID())).Consume(func(childBranch *ChildBranch) {
 			assert.Equal(t, AggregatedBranchType, childBranch.ChildBranchType())
 		})
 
-		utxoDAG.branchDAG.ChildBranches(NewBranchID(transactions["TX2"].ID())).Consume(func(childBranch *ChildBranch) {
+		ledgerstate.ChildBranches(NewBranchID(transactions["TX2"].ID())).Consume(func(childBranch *ChildBranch) {
 			assert.Equal(t, AggregatedBranchType, childBranch.ChildBranchType())
 		})
 	}
 }
 
 func TestExampleB(t *testing.T) {
-	branchDAG, utxoDAG := setupDependencies(t)
-	defer branchDAG.Shutdown()
+	ledgerstate := setupDependencies(t)
+	defer ledgerstate.Shutdown()
 
 	outputs := make(map[string]*SigLockedSingleOutput)
 	transactions := make(map[string]*Transaction)
@@ -110,20 +100,16 @@ func TestExampleB(t *testing.T) {
 	wallets := createWallets(2)
 	// Prepare and book TX1
 	{
-		outputs["A"] = generateOutput(utxoDAG, wallets[0].address, 0)
-		transactions["TX1"] = buildTransaction(utxoDAG, wallets[0], wallets[0], []*SigLockedSingleOutput{outputs["A"]})
-		targetBranch1, err := utxoDAG.BookTransaction(transactions["TX1"])
-		require.NoError(t, err)
-		assert.Equal(t, MasterBranchID, targetBranch1)
+		outputs["A"] = generateOutput(ledgerstate, wallets[0].address, 0)
+		transactions["TX1"] = buildTransaction(ledgerstate, wallets[0], wallets[0], []*SigLockedSingleOutput{outputs["A"]})
+		assertTransactionStoredIntoBranch(t, ledgerstate, transactions["TX1"], MasterBranchID)
 	}
 
 	// Prepare and book TX2
 	{
-		outputs["B"] = generateOutput(utxoDAG, wallets[0].address, 1)
-		transactions["TX2"] = buildTransaction(utxoDAG, wallets[0], wallets[0], []*SigLockedSingleOutput{outputs["B"]})
-		targetBranch2, err := utxoDAG.BookTransaction(transactions["TX2"])
-		require.NoError(t, err)
-		assert.Equal(t, MasterBranchID, targetBranch2)
+		outputs["B"] = generateOutput(ledgerstate, wallets[0].address, 1)
+		transactions["TX2"] = buildTransaction(ledgerstate, wallets[0], wallets[0], []*SigLockedSingleOutput{outputs["B"]})
+		assertTransactionStoredIntoBranch(t, ledgerstate, transactions["TX2"], MasterBranchID)
 	}
 
 	// Prepare and book TX3
@@ -131,30 +117,26 @@ func TestExampleB(t *testing.T) {
 		outputs["C"] = transactions["TX1"].Essence().Outputs()[0].(*SigLockedSingleOutput)
 		outputs["D"] = transactions["TX2"].Essence().Outputs()[0].(*SigLockedSingleOutput)
 
-		transactions["TX3"] = buildTransaction(utxoDAG, wallets[0], wallets[0], []*SigLockedSingleOutput{outputs["C"], outputs["D"]})
-		targetBranch3, err := utxoDAG.BookTransaction(transactions["TX3"])
-		require.NoError(t, err)
-		assert.Equal(t, MasterBranchID, targetBranch3)
+		transactions["TX3"] = buildTransaction(ledgerstate, wallets[0], wallets[0], []*SigLockedSingleOutput{outputs["C"], outputs["D"]})
+		assertTransactionStoredIntoBranch(t, ledgerstate, transactions["TX3"], MasterBranchID)
 	}
 
 	// Prepare and book Tx4
 	{
-		transactions["TX4"] = buildTransaction(utxoDAG, wallets[0], wallets[1], []*SigLockedSingleOutput{outputs["D"]})
-		targetBranch4, err := utxoDAG.BookTransaction(transactions["TX4"])
-		require.NoError(t, err)
-		assert.Equal(t, NewBranchID(transactions["TX4"].ID()), targetBranch4)
+		transactions["TX4"] = buildTransaction(ledgerstate, wallets[0], wallets[1], []*SigLockedSingleOutput{outputs["D"]})
+		assertTransactionStoredIntoBranch(t, ledgerstate, transactions["TX4"], NewBranchID(transactions["TX4"].ID()))
 	}
 
 	// Checking TX3
 	{
 		// Checking that the BranchID of Tx3 is correct
 		Tx3BranchID := NewBranchID(transactions["TX3"].ID())
-		utxoDAG.CachedTransactionMetadata(transactions["TX3"].ID()).Consume(func(metadata *TransactionMetadata) {
+		ledgerstate.CachedTransactionMetadata(transactions["TX3"].ID()).Consume(func(metadata *TransactionMetadata) {
 			assert.Equal(t, Tx3BranchID, metadata.BranchID())
 		})
 
 		// Checking that the parents BranchID of Tx3 is MasterBranchID
-		utxoDAG.branchDAG.Branch(Tx3BranchID).Consume(func(branch Branch) {
+		ledgerstate.Branch(Tx3BranchID).Consume(func(branch Branch) {
 			assert.Equal(t, NewBranchIDs(MasterBranchID), branch.Parents())
 		})
 	}
@@ -163,45 +145,43 @@ func TestExampleB(t *testing.T) {
 	{
 		// Checking that the BranchID of Tx4 is correct
 		Tx4BranchID := NewBranchID(transactions["TX4"].ID())
-		utxoDAG.CachedTransactionMetadata(transactions["TX4"].ID()).Consume(func(metadata *TransactionMetadata) {
+		ledgerstate.CachedTransactionMetadata(transactions["TX4"].ID()).Consume(func(metadata *TransactionMetadata) {
 			assert.Equal(t, Tx4BranchID, metadata.BranchID())
 		})
 		// Checking that the parents BranchID of TX4 is MasterBranchID
-		utxoDAG.branchDAG.Branch(Tx4BranchID).Consume(func(branch Branch) {
+		ledgerstate.Branch(Tx4BranchID).Consume(func(branch Branch) {
 			assert.Equal(t, NewBranchIDs(MasterBranchID), branch.Parents())
 		})
 	}
 
 	// Prepare and book TX5
 	{
-		transactions["TX5"] = buildTransaction(utxoDAG, wallets[0], wallets[1], []*SigLockedSingleOutput{outputs["B"]})
-		targetBranch5, err := utxoDAG.BookTransaction(transactions["TX5"])
-		require.NoError(t, err)
-		assert.Equal(t, NewBranchID(transactions["TX5"].ID()), targetBranch5)
+		transactions["TX5"] = buildTransaction(ledgerstate, wallets[0], wallets[1], []*SigLockedSingleOutput{outputs["B"]})
+		assertTransactionStoredIntoBranch(t, ledgerstate, transactions["TX5"], NewBranchID(transactions["TX5"].ID()))
 	}
 
-	// Checking that the BranchID of TX2 is correct and it is the parent of both TX3 and TX4.
+	// Checking that the BranchID of TX2 is correct, and it is the parent of both TX3 and TX4.
 	{
 		Tx2BranchID := NewBranchID(transactions["TX2"].ID())
-		utxoDAG.CachedTransactionMetadata(transactions["TX2"].ID()).Consume(func(metadata *TransactionMetadata) {
+		ledgerstate.CachedTransactionMetadata(transactions["TX2"].ID()).Consume(func(metadata *TransactionMetadata) {
 			assert.Equal(t, Tx2BranchID, metadata.BranchID())
 		})
 
 		// Checking that the parents BranchID of Tx3 is Tx2BranchID
-		utxoDAG.branchDAG.Branch(NewBranchID(transactions["TX3"].ID())).Consume(func(branch Branch) {
+		ledgerstate.Branch(NewBranchID(transactions["TX3"].ID())).Consume(func(branch Branch) {
 			assert.Equal(t, NewBranchIDs(Tx2BranchID), branch.Parents())
 		})
 
 		// Checking that the parents BranchID of Tx4 is Tx2BranchID
-		utxoDAG.branchDAG.Branch(NewBranchID(transactions["TX4"].ID())).Consume(func(branch Branch) {
+		ledgerstate.Branch(NewBranchID(transactions["TX4"].ID())).Consume(func(branch Branch) {
 			assert.Equal(t, NewBranchIDs(Tx2BranchID), branch.Parents())
 		})
 	}
 }
 
 func TestExampleA(t *testing.T) {
-	branchDAG, utxoDAG := setupDependencies(t)
-	defer branchDAG.Shutdown()
+	ledgerstate := setupDependencies(t)
+	defer ledgerstate.Shutdown()
 
 	outputs := make(map[string]*SigLockedSingleOutput)
 	transactions := make(map[string]*Transaction)
@@ -209,20 +189,16 @@ func TestExampleA(t *testing.T) {
 	wallets := createWallets(2)
 	// Prepare and book TX1
 	{
-		outputs["A"] = generateOutput(utxoDAG, wallets[0].address, 0)
-		transactions["TX1"] = buildTransaction(utxoDAG, wallets[0], wallets[0], []*SigLockedSingleOutput{outputs["A"]})
-		targetBranch1, err := utxoDAG.BookTransaction(transactions["TX1"])
-		require.NoError(t, err)
-		assert.Equal(t, MasterBranchID, targetBranch1)
+		outputs["A"] = generateOutput(ledgerstate, wallets[0].address, 0)
+		transactions["TX1"] = buildTransaction(ledgerstate, wallets[0], wallets[0], []*SigLockedSingleOutput{outputs["A"]})
+		assertTransactionStoredIntoBranch(t, ledgerstate, transactions["TX1"], MasterBranchID)
 	}
 
 	// Prepare and book TX2
 	{
-		outputs["B"] = generateOutput(utxoDAG, wallets[0].address, 1)
-		transactions["TX2"] = buildTransaction(utxoDAG, wallets[0], wallets[0], []*SigLockedSingleOutput{outputs["B"]})
-		targetBranch2, err := utxoDAG.BookTransaction(transactions["TX2"])
-		require.NoError(t, err)
-		assert.Equal(t, MasterBranchID, targetBranch2)
+		outputs["B"] = generateOutput(ledgerstate, wallets[0].address, 1)
+		transactions["TX2"] = buildTransaction(ledgerstate, wallets[0], wallets[0], []*SigLockedSingleOutput{outputs["B"]})
+		assertTransactionStoredIntoBranch(t, ledgerstate, transactions["TX2"], MasterBranchID)
 	}
 
 	// Prepare and book TX3
@@ -230,24 +206,20 @@ func TestExampleA(t *testing.T) {
 		outputs["C"] = transactions["TX1"].Essence().Outputs()[0].(*SigLockedSingleOutput)
 		outputs["D"] = transactions["TX2"].Essence().Outputs()[0].(*SigLockedSingleOutput)
 
-		transactions["TX3"] = buildTransaction(utxoDAG, wallets[0], wallets[0], []*SigLockedSingleOutput{outputs["C"], outputs["D"]})
-		targetBranch3, err := utxoDAG.BookTransaction(transactions["TX3"])
-		require.NoError(t, err)
-		assert.Equal(t, MasterBranchID, targetBranch3)
+		transactions["TX3"] = buildTransaction(ledgerstate, wallets[0], wallets[0], []*SigLockedSingleOutput{outputs["C"], outputs["D"]})
+		assertTransactionStoredIntoBranch(t, ledgerstate, transactions["TX3"], MasterBranchID)
 	}
 
 	// Prepare and book Tx4 (double spending B)
 	{
-		transactions["TX4"] = buildTransaction(utxoDAG, wallets[0], wallets[1], []*SigLockedSingleOutput{outputs["B"]})
-		targetBranch4, err := utxoDAG.BookTransaction(transactions["TX4"])
-		require.NoError(t, err)
-		assert.Equal(t, NewBranchID(transactions["TX4"].ID()), targetBranch4)
+		transactions["TX4"] = buildTransaction(ledgerstate, wallets[0], wallets[1], []*SigLockedSingleOutput{outputs["B"]})
+		assertTransactionStoredIntoBranch(t, ledgerstate, transactions["TX4"], NewBranchID(transactions["TX4"].ID()))
 	}
 
 	// Checking TX2
 	{
 		Tx2BranchID := NewBranchID(transactions["TX2"].ID())
-		utxoDAG.CachedTransactionMetadata(transactions["TX2"].ID()).Consume(func(metadata *TransactionMetadata) {
+		ledgerstate.CachedTransactionMetadata(transactions["TX2"].ID()).Consume(func(metadata *TransactionMetadata) {
 			assert.Equal(t, Tx2BranchID, metadata.BranchID())
 		})
 	}
@@ -256,188 +228,235 @@ func TestExampleA(t *testing.T) {
 	{
 		// Checking that the BranchID of Tx3 is correct
 		Tx3BranchID := NewBranchID(transactions["TX2"].ID())
-		utxoDAG.CachedTransactionMetadata(transactions["TX3"].ID()).Consume(func(metadata *TransactionMetadata) {
+		ledgerstate.CachedTransactionMetadata(transactions["TX3"].ID()).Consume(func(metadata *TransactionMetadata) {
 			assert.Equal(t, Tx3BranchID, metadata.BranchID())
 		})
 
 		// Checking that the parents BranchID of TX3 is the MasterBranchID
-		utxoDAG.branchDAG.Branch(Tx3BranchID).Consume(func(branch Branch) {
+		ledgerstate.Branch(Tx3BranchID).Consume(func(branch Branch) {
 			assert.Equal(t, NewBranchIDs(MasterBranchID), branch.Parents())
 		})
 	}
 }
 
-func TestBookTransaction(t *testing.T) {
-	branchDAG, utxoDAG := setupDependencies(t)
-	defer branchDAG.Shutdown()
+func TestStoreTransaction(t *testing.T) {
+	ledgerstate := setupDependencies(t)
+	defer ledgerstate.Shutdown()
 
 	wallets := createWallets(1)
-	input := generateOutput(utxoDAG, wallets[0].address, 0)
+	input := generateOutput(ledgerstate, wallets[0].address, 0)
 
-	tx := buildTransaction(utxoDAG, wallets[0], wallets[0], []*SigLockedSingleOutput{input})
-	targetBranch, err := utxoDAG.BookTransaction(tx)
-	require.NoError(t, err)
-	assert.Equal(t, MasterBranchID, targetBranch)
+	tx := buildTransaction(ledgerstate, wallets[0], wallets[0], []*SigLockedSingleOutput{input})
+	assertTransactionStoredIntoBranch(t, ledgerstate, tx, MasterBranchID)
 }
 
 func TestBookInvalidTransaction(t *testing.T) {
-	branchDAG, utxoDAG := setupDependencies(t)
-	defer branchDAG.Shutdown()
+	ledgerstate := setupDependencies(t)
+	defer ledgerstate.Shutdown()
 
 	wallets := createWallets(1)
-	input := generateOutput(utxoDAG, wallets[0].address, 0)
-	tx, _ := singleInputTransaction(utxoDAG, wallets[0], wallets[0], input)
+	input := generateOutput(ledgerstate, wallets[0].address, 0)
+	tx, _ := singleInputTransaction(ledgerstate, wallets[0], wallets[0], input)
 
-	cachedTxMetadata := utxoDAG.CachedTransactionMetadata(tx.ID())
+	cachedTxMetadata := ledgerstate.CachedTransactionMetadata(tx.ID())
 	defer cachedTxMetadata.Release()
 	txMetadata := cachedTxMetadata.Unwrap()
 
 	inputsMetadata := OutputsMetadata{}
-	utxoDAG.transactionInputsMetadata(tx).Consume(func(metadata *OutputMetadata) {
+	ledgerstate.transactionInputsMetadata(tx).Consume(func(metadata *OutputMetadata) {
 		inputsMetadata = append(inputsMetadata, metadata)
 	})
 
-	utxoDAG.bookInvalidTransaction(tx, txMetadata, inputsMetadata)
+	ledgerstate.bookInvalidTransaction(tx, txMetadata)
 
 	assert.Equal(t, InvalidBranchID, txMetadata.branchID)
-	assert.True(t, txMetadata.Solid())
+	assert.Equal(t, Invalid, txMetadata.SolidityType())
 	assert.Greater(t, txMetadata.GradeOfFinality(), gof.Medium)
 
 	// check that the inputs are still marked as unspent
-	assert.True(t, utxoDAG.outputsUnspent(inputsMetadata))
+	assert.True(t, ledgerstate.outputsUnspent(inputsMetadata))
+}
+
+func TestBookRejectedTransaction(t *testing.T) {
+	ledgerstate := setupDependencies(t)
+	defer ledgerstate.Shutdown()
+
+	wallets := createWallets(1)
+	input := generateOutput(ledgerstate, wallets[0].address, 0)
+	tx, _ := singleInputTransaction(ledgerstate, wallets[0], wallets[0], input)
+	rejectedBranch := NewConflictBranch(BranchID(tx.ID()), nil, nil)
+	ledgerstate.branchStorage.Store(rejectedBranch).Release()
+	cachedTxMetadata := ledgerstate.CachedTransactionMetadata(tx.ID())
+	defer cachedTxMetadata.Release()
+	txMetadata := cachedTxMetadata.Unwrap()
+	inputsMetadata := OutputsMetadata{}
+	ledgerstate.transactionInputsMetadata(tx).Consume(func(metadata *OutputMetadata) {
+		inputsMetadata = append(inputsMetadata, metadata)
+	})
+
+	ledgerstate.bookRejectedTransaction(tx, txMetadata, rejectedBranch.ID())
+
+	assert.Equal(t, rejectedBranch.ID(), txMetadata.branchID)
+	assert.Equal(t, LazySolid, txMetadata.SolidityType())
+
+	// check that the inputs are still marked as unspent
+	assert.True(t, ledgerstate.outputsUnspent(inputsMetadata))
+}
+
+func TestBookRejectedConflictingTransaction(t *testing.T) {
+	ledgerstate := setupDependencies(t)
+	defer ledgerstate.Shutdown()
+
+	wallets := createWallets(2)
+	input := generateOutput(ledgerstate, wallets[0].address, 0)
+	singleInputTransaction(ledgerstate, wallets[0], wallets[0], input, gof.High)
+	// double spend
+	tx, _ := singleInputTransaction(ledgerstate, wallets[0], wallets[1], input)
+	cachedTxMetadata := ledgerstate.CachedTransactionMetadata(tx.ID())
+	defer cachedTxMetadata.Release()
+	txMetadata := cachedTxMetadata.Unwrap()
+
+	_, err := ledgerstate.bookRejectedConflictingTransaction(tx, txMetadata)
+	require.NoError(t, err)
+
+	ledgerstate.Branch(txMetadata.BranchID()).Consume(func(branch Branch) {
+		assert.Equal(t, LazySolid, txMetadata.SolidityType())
+	})
 }
 
 func TestBookNonConflictingTransaction(t *testing.T) {
-	branchDAG, utxoDAG := setupDependencies(t)
-	defer branchDAG.Shutdown()
+	ledgerstate := setupDependencies(t)
+	defer ledgerstate.Shutdown()
 
 	wallets := createWallets(2)
-	input := generateOutput(utxoDAG, wallets[0].address, 0)
-	tx, _ := singleInputTransaction(utxoDAG, wallets[0], wallets[0], input, gof.High)
+	input := generateOutput(ledgerstate, wallets[0].address, 0)
+	tx, _ := singleInputTransaction(ledgerstate, wallets[0], wallets[0], input, gof.High)
 
-	cachedTxMetadata := utxoDAG.CachedTransactionMetadata(tx.ID())
+	cachedTxMetadata := ledgerstate.CachedTransactionMetadata(tx.ID())
 	defer cachedTxMetadata.Release()
 	txMetadata := cachedTxMetadata.Unwrap()
 
 	inputsMetadata := OutputsMetadata{}
-	utxoDAG.transactionInputsMetadata(tx).Consume(func(metadata *OutputMetadata) {
+	ledgerstate.transactionInputsMetadata(tx).Consume(func(metadata *OutputMetadata) {
 		inputsMetadata = append(inputsMetadata, metadata)
 	})
 
-	targetBranch := utxoDAG.bookNonConflictingTransaction(tx, txMetadata, inputsMetadata, BranchIDs{MasterBranchID: types.Void})
+	targetBranch := ledgerstate.bookNonConflictingTransaction(tx, txMetadata, inputsMetadata, BranchIDs{MasterBranchID: types.Void})
 
 	assert.Equal(t, MasterBranchID, targetBranch)
 
-	utxoDAG.branchDAG.Branch(txMetadata.BranchID()).Consume(func(branch Branch) {
+	ledgerstate.Branch(txMetadata.BranchID()).Consume(func(branch Branch) {
 		assert.Equal(t, MasterBranchID, txMetadata.BranchID())
-		assert.True(t, txMetadata.Solid())
+		assert.Equal(t, Solid, txMetadata.SolidityType())
 	})
 
-	finality, err := utxoDAG.TransactionGradeOfFinality(tx.ID())
+	finality, err := ledgerstate.TransactionGradeOfFinality(tx.ID())
 	require.NoError(t, err)
 	assert.Greater(t, finality, gof.Medium)
 
 	// check that the inputs are marked as spent
-	assert.False(t, utxoDAG.outputsUnspent(inputsMetadata))
+	assert.False(t, ledgerstate.outputsUnspent(inputsMetadata))
 }
 
 func TestBookConflictingTransaction(t *testing.T) {
-	branchDAG, utxoDAG := setupDependencies(t)
-	defer branchDAG.Shutdown()
+	ledgerstate := setupDependencies(t)
+	defer ledgerstate.Shutdown()
 
 	wallets := createWallets(2)
-	input := generateOutput(utxoDAG, wallets[0].address, 0)
-	tx1, _ := singleInputTransaction(utxoDAG, wallets[0], wallets[0], input, gof.High)
+	input := generateOutput(ledgerstate, wallets[0].address, 0)
+	tx1, _ := singleInputTransaction(ledgerstate, wallets[0], wallets[0], input, gof.High)
 
-	cachedTxMetadata := utxoDAG.CachedTransactionMetadata(tx1.ID())
+	cachedTxMetadata := ledgerstate.CachedTransactionMetadata(tx1.ID())
 	defer cachedTxMetadata.Release()
 	txMetadata := cachedTxMetadata.Unwrap()
 
 	inputsMetadata := OutputsMetadata{}
-	utxoDAG.transactionInputsMetadata(tx1).Consume(func(metadata *OutputMetadata) {
+	ledgerstate.transactionInputsMetadata(tx1).Consume(func(metadata *OutputMetadata) {
 		inputsMetadata = append(inputsMetadata, metadata)
 	})
 
-	utxoDAG.bookNonConflictingTransaction(tx1, txMetadata, inputsMetadata, BranchIDs{MasterBranchID: types.Void})
+	ledgerstate.bookNonConflictingTransaction(tx1, txMetadata, inputsMetadata, BranchIDs{MasterBranchID: types.Void})
 
 	assert.Equal(t, MasterBranchID, txMetadata.BranchID())
 
 	// double spend
-	tx2, _ := singleInputTransaction(utxoDAG, wallets[0], wallets[1], input)
+	tx2, _ := singleInputTransaction(ledgerstate, wallets[0], wallets[1], input)
 
-	cachedTxMetadata2 := utxoDAG.CachedTransactionMetadata(tx2.ID())
+	cachedTxMetadata2 := ledgerstate.CachedTransactionMetadata(tx2.ID())
 	defer cachedTxMetadata2.Release()
 	txMetadata2 := cachedTxMetadata2.Unwrap()
 
 	inputsMetadata2 := OutputsMetadata{}
-	utxoDAG.transactionInputsMetadata(tx2).Consume(func(metadata *OutputMetadata) {
+	ledgerstate.transactionInputsMetadata(tx2).Consume(func(metadata *OutputMetadata) {
 		inputsMetadata2 = append(inputsMetadata2, metadata)
 	})
 
 	// determine the booking details before we book
-	branchesOfInputsConflicting, normalizedBranchIDs, conflictingInputs, err := utxoDAG.determineBookingDetails(inputsMetadata2)
+	branchesOfInputsConflicting, normalizedBranchIDs, conflictingInputs, err := ledgerstate.determineBookingDetails(inputsMetadata2)
 	require.NoError(t, err)
 	assert.False(t, branchesOfInputsConflicting)
 
-	targetBranch2 := utxoDAG.bookConflictingTransaction(tx2, txMetadata2, inputsMetadata2, normalizedBranchIDs, conflictingInputs.ByID())
+	eventsQueue := eventsqueue.New()
+	targetBranch2 := ledgerstate.bookConflictingTransaction(tx2, txMetadata2, inputsMetadata2, normalizedBranchIDs, conflictingInputs.ByID(), eventsQueue)
+	eventsQueue.Trigger()
 
-	utxoDAG.branchDAG.Branch(txMetadata2.BranchID()).Consume(func(branch Branch) {
+	ledgerstate.Branch(txMetadata2.BranchID()).Consume(func(branch Branch) {
 		assert.Equal(t, targetBranch2, txMetadata2.BranchID())
-		assert.True(t, txMetadata2.Solid())
+		assert.Equal(t, Solid, txMetadata2.SolidityType())
 	})
 
 	assert.NotEqual(t, MasterBranchID, txMetadata.BranchID())
 
-	finality, err := utxoDAG.TransactionGradeOfFinality(tx1.ID())
+	finality, err := ledgerstate.TransactionGradeOfFinality(tx1.ID())
 	require.NoError(t, err)
 	assert.Greater(t, finality, gof.Medium)
 
-	finality, err = utxoDAG.TransactionGradeOfFinality(tx2.ID())
+	finality, err = ledgerstate.TransactionGradeOfFinality(tx2.ID())
 	require.NoError(t, err)
 	assert.Less(t, finality, gof.Medium)
 
 	// check that the inputs are marked as spent
-	assert.False(t, utxoDAG.outputsUnspent(inputsMetadata))
-	assert.False(t, utxoDAG.outputsUnspent(inputsMetadata2))
+	assert.False(t, ledgerstate.outputsUnspent(inputsMetadata))
+	assert.False(t, ledgerstate.outputsUnspent(inputsMetadata2))
 }
 
 func TestConsumedBranchIDs(t *testing.T) {
-	branchDAG, utxoDAG := setupDependencies(t)
-	defer branchDAG.Shutdown()
+	ledgerstate := setupDependencies(t)
+	defer ledgerstate.Shutdown()
 
 	wallets := createWallets(1)
 	branchIDs := BranchIDs{MasterBranchID: types.Void, InvalidBranchID: types.Void}
-	inputs := generateOutputs(utxoDAG, wallets[0].address, branchIDs)
-	tx := multipleInputsTransaction(utxoDAG, wallets[0], wallets[0], inputs, gof.High)
+	inputs := generateOutputs(ledgerstate, wallets[0].address, branchIDs)
+	tx := multipleInputsTransaction(ledgerstate, wallets[0], wallets[0], inputs, gof.High)
 
-	assert.Equal(t, branchIDs, utxoDAG.consumedBranchIDs(tx.ID()))
+	assert.Equal(t, branchIDs, ledgerstate.consumedBranchIDs(tx.ID()))
 }
 
 func TestCreatedOutputIDsOfTransaction(t *testing.T) {
-	branchDAG, utxoDAG := setupDependencies(t)
-	defer branchDAG.Shutdown()
+	ledgerstate := setupDependencies(t)
+	defer ledgerstate.Shutdown()
 
 	wallets := createWallets(1)
-	input := generateOutput(utxoDAG, wallets[0].address, 0)
-	tx, output := singleInputTransaction(utxoDAG, wallets[0], wallets[0], input, gof.High)
+	input := generateOutput(ledgerstate, wallets[0].address, 0)
+	tx, output := singleInputTransaction(ledgerstate, wallets[0], wallets[0], input, gof.High)
 
-	assert.Equal(t, []OutputID{output.ID()}, utxoDAG.createdOutputIDsOfTransaction(tx.ID()))
+	assert.Equal(t, []OutputID{output.ID()}, ledgerstate.createdOutputIDsOfTransaction(tx.ID()))
 }
 
 func TestConsumedOutputIDsOfTransaction(t *testing.T) {
-	branchDAG, utxoDAG := setupDependencies(t)
-	defer branchDAG.Shutdown()
+	ledgerstate := setupDependencies(t)
+	defer ledgerstate.Shutdown()
 
 	wallets := createWallets(1)
-	input := generateOutput(utxoDAG, wallets[0].address, 0)
-	tx, _ := singleInputTransaction(utxoDAG, wallets[0], wallets[0], input, gof.High)
+	input := generateOutput(ledgerstate, wallets[0].address, 0)
+	tx, _ := singleInputTransaction(ledgerstate, wallets[0], wallets[0], input, gof.High)
 
-	assert.Equal(t, []OutputID{input.ID()}, utxoDAG.consumedOutputIDsOfTransaction(tx.ID()))
+	assert.Equal(t, []OutputID{input.ID()}, ledgerstate.consumedOutputIDsOfTransaction(tx.ID()))
 }
 
 func TestOutputsUnspent(t *testing.T) {
-	branchDAG, utxoDAG := setupDependencies(t)
-	defer branchDAG.Shutdown()
+	ledgerstate := setupDependencies(t)
+	defer ledgerstate.Shutdown()
 
 	outputsMetadata := []*OutputMetadata{
 		{
@@ -448,13 +467,13 @@ func TestOutputsUnspent(t *testing.T) {
 		},
 	}
 
-	assert.False(t, utxoDAG.outputsUnspent(outputsMetadata))
-	assert.True(t, utxoDAG.outputsUnspent(outputsMetadata[:1]))
+	assert.False(t, ledgerstate.outputsUnspent(outputsMetadata))
+	assert.True(t, ledgerstate.outputsUnspent(outputsMetadata[:1]))
 }
 
 func TestInputsInInvalidBranch(t *testing.T) {
-	branchDAG, utxoDAG := setupDependencies(t)
-	defer branchDAG.Shutdown()
+	ledgerstate := setupDependencies(t)
+	defer ledgerstate.Shutdown()
 
 	outputsMetadata := []*OutputMetadata{
 		{
@@ -465,20 +484,20 @@ func TestInputsInInvalidBranch(t *testing.T) {
 		},
 	}
 
-	assert.True(t, utxoDAG.inputsInInvalidBranch(outputsMetadata))
-	assert.False(t, utxoDAG.inputsInInvalidBranch(outputsMetadata[1:]))
+	assert.True(t, ledgerstate.inputsInInvalidBranch(outputsMetadata))
+	assert.False(t, ledgerstate.inputsInInvalidBranch(outputsMetadata[1:]))
 }
 
 func TestConsumedOutputs(t *testing.T) {
-	branchDAG, utxoDAG := setupDependencies(t)
-	defer branchDAG.Shutdown()
+	ledgerstate := setupDependencies(t)
+	defer ledgerstate.Shutdown()
 
 	wallets := createWallets(2)
-	input := generateOutput(utxoDAG, wallets[0].address, 0)
+	input := generateOutput(ledgerstate, wallets[0].address, 0)
 
 	// testing when storing the inputs
-	tx, output := singleInputTransaction(utxoDAG, wallets[0], wallets[1], input)
-	cachedInputs := utxoDAG.ConsumedOutputs(tx)
+	tx, output := singleInputTransaction(ledgerstate, wallets[0], wallets[1], input)
+	cachedInputs := ledgerstate.ConsumedOutputs(tx)
 	inputs := cachedInputs.Unwrap()
 
 	assert.Equal(t, input, inputs[0])
@@ -486,8 +505,8 @@ func TestConsumedOutputs(t *testing.T) {
 	cachedInputs.Release(true)
 
 	// testing when not storing the inputs
-	tx, _ = singleInputTransaction(utxoDAG, wallets[1], wallets[0], output)
-	cachedInputs = utxoDAG.ConsumedOutputs(tx)
+	tx, _ = singleInputTransaction(ledgerstate, wallets[1], wallets[0], output)
+	cachedInputs = ledgerstate.ConsumedOutputs(tx)
 	inputs = cachedInputs.Unwrap()
 
 	assert.Equal(t, nil, inputs[0])
@@ -496,34 +515,34 @@ func TestConsumedOutputs(t *testing.T) {
 }
 
 func TestAllOutputsExist(t *testing.T) {
-	branchDAG, utxoDAG := setupDependencies(t)
-	defer branchDAG.Shutdown()
+	ledgerstate := setupDependencies(t)
+	defer ledgerstate.Shutdown()
 
 	wallets := createWallets(2)
-	input := generateOutput(utxoDAG, wallets[0].address, 0)
+	input := generateOutput(ledgerstate, wallets[0].address, 0)
 
 	// testing when storing the inputs
-	tx, output := singleInputTransaction(utxoDAG, wallets[0], wallets[1], input)
-	cachedInputs := utxoDAG.ConsumedOutputs(tx)
+	tx, output := singleInputTransaction(ledgerstate, wallets[0], wallets[1], input)
+	cachedInputs := ledgerstate.ConsumedOutputs(tx)
 	inputs := cachedInputs.Unwrap()
 
-	assert.True(t, utxoDAG.allOutputsExist(inputs))
+	assert.True(t, ledgerstate.allOutputsExist(inputs))
 
 	cachedInputs.Release()
 
 	// testing when not storing the inputs
-	tx, _ = singleInputTransaction(utxoDAG, wallets[1], wallets[0], output)
-	cachedInputs = utxoDAG.ConsumedOutputs(tx)
+	tx, _ = singleInputTransaction(ledgerstate, wallets[1], wallets[0], output)
+	cachedInputs = ledgerstate.ConsumedOutputs(tx)
 	inputs = cachedInputs.Unwrap()
 
-	assert.False(t, utxoDAG.allOutputsExist(inputs))
+	assert.False(t, ledgerstate.allOutputsExist(inputs))
 
 	cachedInputs.Release()
 }
 
 func TestTransactionBalancesValid(t *testing.T) {
-	branchDAG, _ := setupDependencies(t)
-	defer branchDAG.Shutdown()
+	ledgerstate := setupDependencies(t)
+	defer ledgerstate.Shutdown()
 
 	wallets := createWallets(2)
 
@@ -596,42 +615,40 @@ func TestTransactionBalancesValid(t *testing.T) {
 }
 
 func TestUnlockBlocksValid(t *testing.T) {
-	branchDAG, utxoDAG := setupDependencies(t)
-	defer branchDAG.Shutdown()
+	ledgerstate := setupDependencies(t)
+	defer ledgerstate.Shutdown()
 
 	wallets := createWallets(2)
 
-	input := generateOutput(utxoDAG, wallets[0].address, 0)
+	input := generateOutput(ledgerstate, wallets[0].address, 0)
 
 	// testing valid signature
-	tx, _ := singleInputTransaction(utxoDAG, wallets[0], wallets[1], input, gof.High)
+	tx, _ := singleInputTransaction(ledgerstate, wallets[0], wallets[1], input, gof.High)
 	assert.True(t, UnlockBlocksValid(Outputs{input}, tx))
 
 	// testing invalid signature
-	tx, _ = singleInputTransaction(utxoDAG, wallets[1], wallets[0], input, gof.High)
+	tx, _ = singleInputTransaction(ledgerstate, wallets[1], wallets[0], input, gof.High)
 	assert.False(t, UnlockBlocksValid(Outputs{input}, tx))
 }
 
 func TestAddressOutputMapping(t *testing.T) {
-	branchDAG, utxoDAG := setupDependencies(t)
-	defer branchDAG.Shutdown()
-	defer utxoDAG.Shutdown()
+	ledgerstate := setupDependencies(t)
+	defer ledgerstate.Shutdown()
 
 	kp := ed25519.GenerateKeyPair()
 	w := wallet{
 		kp,
 		NewED25519Address(kp.PublicKey),
 	}
-	utxoDAG.addressOutputMappingStorage.Store(NewAddressOutputMapping(w.address, EmptyOutputID)).Release()
-	res := utxoDAG.CachedAddressOutputMapping(w.address)
+	ledgerstate.addressOutputMappingStorage.Store(NewAddressOutputMapping(w.address, EmptyOutputID)).Release()
+	res := ledgerstate.CachedAddressOutputMapping(w.address)
 	res.Release()
 	assert.Equal(t, 1, len(res))
 }
 
 func TestUTXODAG_CheckTransaction(t *testing.T) {
-	branchDAG, utxoDAG := setupDependencies(t)
-	defer branchDAG.Shutdown()
-	defer utxoDAG.Shutdown()
+	ledgerstate := setupDependencies(t)
+	defer ledgerstate.Shutdown()
 
 	w := genRandomWallet()
 	governingWallet := genRandomWallet()
@@ -653,13 +670,13 @@ func TestUTXODAG_CheckTransaction(t *testing.T) {
 		output = output.UpdateMintingColor()
 
 		// store Output
-		utxoDAG.outputStorage.Store(output).Release()
+		ledgerstate.outputStorage.Store(output).Release()
 
 		// store OutputMetadata
 		metadata := NewOutputMetadata(output.ID())
 		metadata.SetBranchID(MasterBranchID)
 		metadata.SetSolid(true)
-		utxoDAG.outputMetadataStorage.Store(metadata).Release()
+		ledgerstate.outputMetadataStorage.Store(metadata).Release()
 	}
 
 	nextAliasBalance := alias.Balances().Map()
@@ -697,7 +714,7 @@ func TestUTXODAG_CheckTransaction(t *testing.T) {
 
 		tx := NewTransaction(essence, unlocks)
 
-		bErr := utxoDAG.CheckTransaction(tx)
+		bErr := ledgerstate.CheckTransaction(tx)
 		assert.NoError(t, bErr)
 	})
 
@@ -715,7 +732,7 @@ func TestUTXODAG_CheckTransaction(t *testing.T) {
 
 		tx := NewTransaction(essence, unlocks)
 
-		bErr := utxoDAG.CheckTransaction(tx)
+		bErr := ledgerstate.CheckTransaction(tx)
 		t.Log(bErr)
 		assert.Error(t, bErr)
 	})
@@ -738,20 +755,18 @@ func TestUTXODAG_CheckTransaction(t *testing.T) {
 
 		tx := NewTransaction(essence, unlocks)
 
-		bErr := utxoDAG.CheckTransaction(tx)
+		bErr := ledgerstate.CheckTransaction(tx)
 		t.Log(bErr)
 		assert.Error(t, bErr)
 	})
 }
 
-func setupDependencies(t *testing.T) (*BranchDAG, *UTXODAG) {
-	store := mapdb.NewMapDB()
-	cacheTimeProvider := database.NewCacheTimeProvider(0)
-	branchDAG := NewBranchDAG(store, cacheTimeProvider)
-	err := branchDAG.Prune()
+func setupDependencies(t *testing.T) *Ledgerstate {
+	ledgerstate := New(CacheTimeProvider(database.NewCacheTimeProvider(0)))
+	err := ledgerstate.Prune()
 	require.NoError(t, err)
 
-	return branchDAG, NewUTXODAG(store, cacheTimeProvider, branchDAG)
+	return ledgerstate
 }
 
 type wallet struct {
@@ -792,40 +807,40 @@ func (w wallet) unlockBlocks(txEssence *TransactionEssence) []UnlockBlock {
 	return unlockBlocks
 }
 
-func generateOutput(utxoDAG *UTXODAG, address Address, index uint16) *SigLockedSingleOutput {
+func generateOutput(ledgerstate *Ledgerstate, address Address, index uint16) *SigLockedSingleOutput {
 	output := NewSigLockedSingleOutput(100, address)
 	output.SetID(NewOutputID(GenesisTransactionID, index))
-	utxoDAG.outputStorage.Store(output).Release()
+	ledgerstate.outputStorage.Store(output).Release()
 
 	// store OutputMetadata
 	metadata := NewOutputMetadata(output.ID())
 	metadata.SetBranchID(MasterBranchID)
 	metadata.SetSolid(true)
-	utxoDAG.outputMetadataStorage.Store(metadata).Release()
+	ledgerstate.outputMetadataStorage.Store(metadata).Release()
 
 	return output
 }
 
-func generateOutputs(utxoDAG *UTXODAG, address Address, branchIDs BranchIDs) (outputs []*SigLockedSingleOutput) {
+func generateOutputs(ledgerstate *Ledgerstate, address Address, branchIDs BranchIDs) (outputs []*SigLockedSingleOutput) {
 	i := 0
 	outputs = make([]*SigLockedSingleOutput, len(branchIDs))
 	for branchID := range branchIDs {
 		outputs[i] = NewSigLockedSingleOutput(100, address)
 		outputs[i].SetID(NewOutputID(GenesisTransactionID, uint16(i)))
-		utxoDAG.outputStorage.Store(outputs[i]).Release()
+		ledgerstate.outputStorage.Store(outputs[i]).Release()
 
 		// store OutputMetadata
 		metadata := NewOutputMetadata(outputs[i].ID())
 		metadata.SetBranchID(branchID)
 		metadata.SetSolid(true)
-		utxoDAG.outputMetadataStorage.Store(metadata).Release()
+		ledgerstate.outputMetadataStorage.Store(metadata).Release()
 		i++
 	}
 
 	return
 }
 
-func singleInputTransaction(utxoDAG *UTXODAG, a, b wallet, outputToSpend *SigLockedSingleOutput, optionalGradeOfFinality ...gof.GradeOfFinality) (*Transaction, *SigLockedSingleOutput) {
+func singleInputTransaction(ledgerstate *Ledgerstate, a, b wallet, outputToSpend *SigLockedSingleOutput, optionalGradeOfFinality ...gof.GradeOfFinality) (*Transaction, *SigLockedSingleOutput) {
 	input := NewUTXOInput(outputToSpend.ID())
 	output := NewSigLockedSingleOutput(100, b.address)
 
@@ -835,7 +850,6 @@ func singleInputTransaction(utxoDAG *UTXODAG, a, b wallet, outputToSpend *SigLoc
 
 	// store TransactionMetadata
 	transactionMetadata := NewTransactionMetadata(tx.ID())
-	transactionMetadata.SetSolid(true)
 	transactionMetadata.SetBranchID(MasterBranchID)
 
 	if len(optionalGradeOfFinality) >= 1 {
@@ -844,24 +858,24 @@ func singleInputTransaction(utxoDAG *UTXODAG, a, b wallet, outputToSpend *SigLoc
 		transactionMetadata.SetGradeOfFinality(gof.Low)
 	}
 
-	cachedTransactionMetadata := &CachedTransactionMetadata{CachedObject: utxoDAG.transactionMetadataStorage.ComputeIfAbsent(tx.ID().Bytes(), func(key []byte) objectstorage.StorableObject {
+	cachedTransactionMetadata := &CachedTransactionMetadata{CachedObject: ledgerstate.transactionMetadataStorage.ComputeIfAbsent(tx.ID().Bytes(), func(key []byte) objectstorage.StorableObject {
 		transactionMetadata.Persist()
 		transactionMetadata.SetModified()
 		return transactionMetadata
 	})}
 	defer cachedTransactionMetadata.Release()
 
-	utxoDAG.transactionStorage.Store(tx).Release()
+	ledgerstate.transactionStorage.Store(tx).Release()
 
 	return tx, output
 }
 
-func multipleInputsTransaction(utxoDAG *UTXODAG, a, b wallet, outputsToSpend []*SigLockedSingleOutput, optionalGradeOfFinality ...gof.GradeOfFinality) *Transaction {
+func multipleInputsTransaction(ledgerstate *Ledgerstate, a, b wallet, outputsToSpend []*SigLockedSingleOutput, optionalGradeOfFinality ...gof.GradeOfFinality) *Transaction {
 	inputs := make(Inputs, len(outputsToSpend))
 	branchIDs := make(BranchIDs, len(outputsToSpend))
 	for i, outputToSpend := range outputsToSpend {
 		inputs[i] = NewUTXOInput(outputToSpend.ID())
-		utxoDAG.CachedOutputMetadata(outputToSpend.ID()).Consume(func(outputMetadata *OutputMetadata) {
+		ledgerstate.CachedOutputMetadata(outputToSpend.ID()).Consume(func(outputMetadata *OutputMetadata) {
 			branchIDs[outputMetadata.BranchID()] = types.Void
 		})
 	}
@@ -872,9 +886,9 @@ func multipleInputsTransaction(utxoDAG *UTXODAG, a, b wallet, outputsToSpend []*
 
 	tx := NewTransaction(txEssence, a.unlockBlocks(txEssence))
 
-	// store aggreagated branch
-	normalizedBranchIDs, _ := utxoDAG.branchDAG.normalizeBranches(branchIDs)
-	cachedAggregatedBranch, _, _ := utxoDAG.branchDAG.aggregateNormalizedBranches(normalizedBranchIDs)
+	// store aggregated branch
+	normalizedBranchIDs, _ := ledgerstate.normalizeBranches(branchIDs)
+	cachedAggregatedBranch, _, _ := ledgerstate.aggregateNormalizedBranches(normalizedBranchIDs)
 	branchID := BranchID{}
 	cachedAggregatedBranch.Consume(func(branch Branch) {
 		branchID = branch.ID()
@@ -882,7 +896,6 @@ func multipleInputsTransaction(utxoDAG *UTXODAG, a, b wallet, outputsToSpend []*
 
 	// store TransactionMetadata
 	transactionMetadata := NewTransactionMetadata(tx.ID())
-	transactionMetadata.SetSolid(true)
 	transactionMetadata.SetBranchID(branchID)
 	if len(optionalGradeOfFinality) >= 1 {
 		transactionMetadata.SetGradeOfFinality(optionalGradeOfFinality[0])
@@ -890,19 +903,19 @@ func multipleInputsTransaction(utxoDAG *UTXODAG, a, b wallet, outputsToSpend []*
 		transactionMetadata.SetGradeOfFinality(gof.Low)
 	}
 
-	cachedTransactionMetadata := &CachedTransactionMetadata{CachedObject: utxoDAG.transactionMetadataStorage.ComputeIfAbsent(tx.ID().Bytes(), func(key []byte) objectstorage.StorableObject {
+	cachedTransactionMetadata := &CachedTransactionMetadata{CachedObject: ledgerstate.transactionMetadataStorage.ComputeIfAbsent(tx.ID().Bytes(), func(key []byte) objectstorage.StorableObject {
 		transactionMetadata.Persist()
 		transactionMetadata.SetModified()
 		return transactionMetadata
 	})}
 	defer cachedTransactionMetadata.Release()
 
-	utxoDAG.transactionStorage.Store(tx).Release()
+	ledgerstate.transactionStorage.Store(tx).Release()
 
 	return tx
 }
 
-func buildTransaction(_ *UTXODAG, a, b wallet, outputsToSpend []*SigLockedSingleOutput) *Transaction {
+func buildTransaction(_ *Ledgerstate, a, b wallet, outputsToSpend []*SigLockedSingleOutput) *Transaction {
 	inputs := make(Inputs, len(outputsToSpend))
 	sum := uint64(0)
 	for i, outputToSpend := range outputsToSpend {
@@ -923,4 +936,16 @@ func buildTransaction(_ *UTXODAG, a, b wallet, outputsToSpend []*SigLockedSingle
 	tx := NewTransaction(txEssence, a.unlockBlocks(txEssence))
 
 	return tx
+}
+
+// assertTransactionStoredIntoBranch stores the Transaction in the UTXODAG and then validates its Branch.
+func assertTransactionStoredIntoBranch(t *testing.T, ledgerstate *Ledgerstate, transaction *Transaction, branchID BranchID) {
+	stored, solidityType, err := ledgerstate.StoreTransaction(transaction)
+	require.NoError(t, err)
+	require.True(t, stored)
+	require.Equal(t, solidityType, Solid)
+	require.NoError(t, err)
+	require.True(t, ledgerstate.CachedTransactionMetadata(transaction.ID()).Consume(func(transactionMetadata *TransactionMetadata) {
+		assert.Equal(t, branchID, transactionMetadata.BranchID())
+	}))
 }

--- a/packages/mana/consensusbasevector.go
+++ b/packages/mana/consensusbasevector.go
@@ -206,14 +206,9 @@ func (c *ConsensusBaseManaVector) GetManaMap(optionalUpdateTime ...time.Time) (r
 	c.Lock()
 	defer c.Unlock()
 	t = time.Now()
-	res = make(map[identity.ID]float64)
-	for ID := range c.vector {
-		var mana float64
-		mana, err = c.getMana(ID)
-		if err != nil {
-			return nil, t, err
-		}
-		res[ID] = mana
+	res = make(map[identity.ID]float64, len(c.vector))
+	for ID, val := range c.vector {
+		res[ID] = val.BaseValue()
 	}
 	return
 }

--- a/packages/tangle/approvalweightmanager.go
+++ b/packages/tangle/approvalweightmanager.go
@@ -76,7 +76,7 @@ func (a *ApprovalWeightManager) ProcessMessage(messageID MessageID) {
 func (a *ApprovalWeightManager) WeightOfBranch(branchID ledgerstate.BranchID) (weight float64) {
 	conflictBranchIDs, err := a.tangle.LedgerState.BranchDAG.ResolveConflictBranchIDs(ledgerstate.NewBranchIDs(branchID))
 	if err != nil {
-		panic(err)
+		panic(errors.Errorf("failed to retrieve conflict BranchIDs: %w", err))
 	}
 
 	weight = math.MaxFloat64
@@ -168,8 +168,8 @@ func (a *ApprovalWeightManager) isRelevantSupporter(message *Message) bool {
 	return supporterWeight/totalWeight >= minSupporterWeight
 }
 
-// SupportersOfBranch returns the Supporters of the given ledgerstate.BranchID.
-func (a *ApprovalWeightManager) SupportersOfBranch(branchID ledgerstate.BranchID) (supporters *Supporters) {
+// SupportersOfAggregatedBranch returns the Supporters of the given aggregatedbranch ledgerstate.BranchID.
+func (a *ApprovalWeightManager) SupportersOfAggregatedBranch(branchID ledgerstate.BranchID) (supporters *Supporters) {
 	conflictBranchIDs, err := a.tangle.LedgerState.BranchDAG.ResolveConflictBranchIDs(ledgerstate.NewBranchIDs(branchID))
 	if err != nil {
 		panic(err)
@@ -188,6 +188,16 @@ func (a *ApprovalWeightManager) SupportersOfBranch(branchID ledgerstate.BranchID
 		}
 	}
 
+	return
+}
+
+// SupportersOfConflictBranch returns the Supporters of the given conflictbranch ledgerstate.BranchID.
+func (a *ApprovalWeightManager) SupportersOfConflictBranch(branchID ledgerstate.BranchID) (supporters *Supporters) {
+	if !a.tangle.Storage.BranchSupporters(branchID).Consume(func(branchSupporters *BranchSupporters) {
+		supporters = branchSupporters.Supporters()
+	}) {
+		supporters = NewSupporters()
+	}
 	return
 }
 
@@ -247,16 +257,19 @@ func (a *ApprovalWeightManager) addSupportToBranch(branchID ledgerstate.BranchID
 		added = branchSupporters.AddSupporter(identity.NewID(message.IssuerPublicKey()))
 	})
 
-	if added {
-		a.tangle.LedgerState.BranchDAG.ForEachConflictingBranchID(branchID, func(conflictingBranchID ledgerstate.BranchID) {
-			revokeWalker := walker.New(false)
-			revokeWalker.Push(conflictingBranchID)
-
-			for revokeWalker.HasNext() {
-				a.revokeSupportFromBranch(revokeWalker.Next().(ledgerstate.BranchID), message, revokeWalker)
-			}
-		})
+	// Abort if this node already supported this branch.
+	if !added {
+		return
 	}
+
+	a.tangle.LedgerState.BranchDAG.ForEachConflictingBranchID(branchID, func(conflictingBranchID ledgerstate.BranchID) {
+		revokeWalker := walker.New(false)
+		revokeWalker.Push(conflictingBranchID)
+
+		for revokeWalker.HasNext() {
+			a.revokeSupportFromBranch(revokeWalker.Next().(ledgerstate.BranchID), message, revokeWalker)
+		}
+	})
 
 	a.updateBranchWeight(branchID, message)
 
@@ -276,6 +289,7 @@ func (a *ApprovalWeightManager) revokeSupportFromBranch(branchID ledgerstate.Bra
 	a.tangle.Storage.BranchSupporters(branchID, NewBranchSupporters).Consume(func(branchSupporters *BranchSupporters) {
 		deleted = branchSupporters.DeleteSupporter(identity.NewID(message.IssuerPublicKey()))
 	})
+
 	// Abort if this node did not support this branch.
 	if !deleted {
 		return
@@ -356,26 +370,22 @@ func (a *ApprovalWeightManager) migrateMarkerSupportersToNewBranch(marker *marke
 		panic(err)
 	}
 
+	supportersOfOldBranch := a.SupportersOfAggregatedBranch(oldBranchID)
+	supportersOfMarker := a.supportersOfMarker(marker)
+	intersectionOfSupporters := supportersOfMarker.Intersect(supportersOfOldBranch)
+
 	for conflictBranchID := range conflictBranchIDs {
 		a.tangle.Storage.BranchSupporters(conflictBranchID, NewBranchSupporters).Consume(func(branchSupporters *BranchSupporters) {
-			supportersOfMarker := a.supportersOfMarker(marker)
-
 			if oldBranchID == ledgerstate.MasterBranchID {
-				supportersOfMarker.ForEach(func(supporter Supporter) {
-					branchSupporters.AddSupporter(supporter)
-				})
+				branchSupporters.AddSupporters(supportersOfMarker)
 				return
 			}
 
-			a.SupportersOfBranch(oldBranchID).ForEach(func(supporter Supporter) {
-				if supportersOfMarker.Has(supporter) {
-					branchSupporters.AddSupporter(supporter)
-				}
-			})
+			branchSupporters.AddSupporters(intersectionOfSupporters)
 		})
 
 		a.tangle.Storage.Message(a.tangle.Booker.MarkersManager.MessageID(marker)).Consume(func(message *Message) {
-			a.updateBranchWeight(newBranchID, message)
+			a.updateBranchWeight(conflictBranchID, message)
 		})
 	}
 }
@@ -410,39 +420,19 @@ func (a *ApprovalWeightManager) updateBranchWeight(branchID ledgerstate.BranchID
 	activeWeights, totalWeight := a.tangle.WeightProvider.WeightsOfRelevantSupporters()
 
 	var supporterWeight float64
-	a.SupportersOfBranch(branchID).ForEach(func(supporter Supporter) {
+	a.SupportersOfConflictBranch(branchID).ForEach(func(supporter Supporter) {
 		supporterWeight += activeWeights[supporter]
 	})
 
 	newBranchWeight := supporterWeight / totalWeight
 
-	conflictBranchIDs, err := a.tangle.LedgerState.BranchDAG.ResolveConflictBranchIDs(ledgerstate.NewBranchIDs(branchID))
-	if err != nil {
-		panic(err)
-	}
-
-	for conflictBranchID := range conflictBranchIDs {
-		switch isAggregatedBranch := len(conflictBranchIDs) != 1; isAggregatedBranch {
-		case false:
-			a.tangle.Storage.BranchWeight(conflictBranchID, NewBranchWeight).Consume(func(branchWeight *BranchWeight) {
-				if !branchWeight.SetWeight(newBranchWeight) {
-					return
-				}
-
-				a.Events.BranchWeightChanged.Trigger(&BranchWeightChangedEvent{conflictBranchID, newBranchWeight})
-			})
-		default:
-			a.tangle.Storage.BranchWeight(conflictBranchID, NewBranchWeight).Consume(func(branchWeight *BranchWeight) {
-				if newBranchWeight > branchWeight.Weight() {
-					if !branchWeight.SetWeight(newBranchWeight) {
-						return
-					}
-
-					a.Events.BranchWeightChanged.Trigger(&BranchWeightChangedEvent{conflictBranchID, newBranchWeight})
-				}
-			})
+	a.tangle.Storage.BranchWeight(branchID, NewBranchWeight).Consume(func(branchWeight *BranchWeight) {
+		if !branchWeight.SetWeight(newBranchWeight) {
+			return
 		}
-	}
+
+		a.Events.BranchWeightChanged.Trigger(&BranchWeightChangedEvent{branchID, newBranchWeight})
+	})
 }
 
 func (a *ApprovalWeightManager) moveMessageWeightToNewBranch(messageID MessageID, _, newBranchID ledgerstate.BranchID) {
@@ -459,7 +449,7 @@ func (a *ApprovalWeightManager) moveMarkerWeightToNewBranch(marker *markers.Mark
 	a.tangle.Storage.Message(messageID).Consume(func(message *Message) {
 		weightsOfSupporters, totalWeight := a.tangle.WeightProvider.WeightsOfRelevantSupporters()
 		branchWeight := float64(0)
-		a.SupportersOfBranch(newBranchID).ForEach(func(supporter Supporter) {
+		a.SupportersOfAggregatedBranch(newBranchID).ForEach(func(supporter Supporter) {
 			branchWeight += weightsOfSupporters[supporter]
 		})
 
@@ -1069,6 +1059,21 @@ func (b *BranchSupporters) AddSupporter(supporter Supporter) (added bool) {
 		return
 	}
 	b.SetModified()
+
+	return
+}
+
+// AddSupporters adds the supporters set to the tracked ledgerstate.BranchID.
+func (b *BranchSupporters) AddSupporters(supporters *Supporters) (added bool) {
+	supporters.ForEach(func(supporter Supporter) {
+		if b.supporters.Add(supporter) {
+			added = true
+		}
+	})
+
+	if added {
+		b.SetModified()
+	}
 
 	return
 }

--- a/packages/tangle/approvalweightmanager_test.go
+++ b/packages/tangle/approvalweightmanager_test.go
@@ -583,7 +583,7 @@ func createBranch(t *testing.T, tangle *Tangle, branchAlias string, branchIDs ma
 func validateStatementResults(t *testing.T, approvalWeightManager *ApprovalWeightManager, branchIDs map[string]ledgerstate.BranchID, supporter Supporter, expectedResults map[string]bool) {
 	for branchIDString, expectedResult := range expectedResults {
 		var actualResult bool
-		supporters := approvalWeightManager.SupportersOfBranch(branchIDs[branchIDString])
+		supporters := approvalWeightManager.SupportersOfAggregatedBranch(branchIDs[branchIDString])
 		if supporters != nil {
 			actualResult = supporters.Has(supporter)
 		}

--- a/packages/tangle/message.go
+++ b/packages/tangle/message.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"sort"
+	"strconv"
 	"sync"
 	"time"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/iotaledger/hive.go/marshalutil"
 	"github.com/iotaledger/hive.go/objectstorage"
 	"github.com/iotaledger/hive.go/stringify"
+	"github.com/iotaledger/hive.go/syncutils"
 	"github.com/iotaledger/hive.go/types"
 	"github.com/mr-tron/base58"
 	"golang.org/x/crypto/blake2b"
@@ -227,6 +229,9 @@ type Message struct {
 	payload         payload.Payload
 	nonce           uint64
 	signature       ed25519.Signature
+
+	locks      []interface{}
+	locksMutex sync.Mutex
 
 	// derived properties
 	id         *MessageID
@@ -627,6 +632,34 @@ func (m *Message) Signature() ed25519.Signature {
 	return m.signature
 }
 
+// Locks returns a list of identifiers of the entities that this Message depends on and that should be locked before
+// modifying any of its properties.
+func (m *Message) Locks() (locks []interface{}) {
+	m.locksMutex.Lock()
+	defer m.locksMutex.Unlock()
+
+	if m.locks == nil {
+		lockBuilder := (&syncutils.MultiMutexLockBuilder{}).AddLock(m.ID())
+		m.ForEachParent(func(parent Parent) {
+			if parent.ID == EmptyMessageID {
+				return
+			}
+
+			lockBuilder = lockBuilder.AddLock(parent.ID)
+		})
+
+		if transaction, typeCastOK := m.Payload().(*ledgerstate.Transaction); typeCastOK {
+			for _, lock := range transaction.Locks() {
+				lockBuilder = lockBuilder.AddLock(lock)
+			}
+		}
+
+		m.locks = lockBuilder.Build()
+	}
+
+	return m.locks
+}
+
 // calculates the message's MessageID.
 func (m *Message) calculateID() MessageID {
 	return blake2b.Sum256(m.Bytes())
@@ -782,7 +815,10 @@ type MessageMetadata struct {
 
 	messageID           MessageID
 	receivedTime        time.Time
+	source              MessageSource
+	solidificationType  SolidificationType
 	solid               bool
+	weaklySolid         bool
 	solidificationTime  time.Time
 	structureDetails    *markers.StructureDetails
 	branchID            ledgerstate.BranchID
@@ -795,6 +831,9 @@ type MessageMetadata struct {
 	gradeOfFinality     gof.GradeOfFinality
 	gradeOfFinalityTime time.Time
 
+	sourceMutex             sync.RWMutex
+	solidificationTypeMutex sync.RWMutex
+	weaklySolidMutex        sync.RWMutex
 	solidMutex              sync.RWMutex
 	solidificationTimeMutex sync.RWMutex
 	structureDetailsMutex   sync.RWMutex
@@ -841,8 +880,20 @@ func MessageMetadataFromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (resul
 		err = fmt.Errorf("failed to parse solidification time of message metadata: %w", err)
 		return
 	}
+	if result.source, err = MessageSourceFromMarshalUtil(marshalUtil); err != nil {
+		err = fmt.Errorf("failed to parse source flag of message metadata: %w", err)
+		return
+	}
+	if result.solidificationType, err = SolidificationTypeFromMarshalUtil(marshalUtil); err != nil {
+		err = fmt.Errorf("failed to parse solidification type of message metadata: %w", err)
+		return
+	}
 	if result.solid, err = marshalUtil.ReadBool(); err != nil {
 		err = fmt.Errorf("failed to parse solid flag of message metadata: %w", err)
+		return
+	}
+	if result.weaklySolid, err = marshalUtil.ReadBool(); err != nil {
+		err = fmt.Errorf("failed to parse weakly solid flag of message metadata: %w", err)
 		return
 	}
 	if result.structureDetails, err = markers.StructureDetailsFromMarshalUtil(marshalUtil); err != nil {
@@ -911,13 +962,89 @@ func (m *MessageMetadata) ReceivedTime() time.Time {
 	return m.receivedTime
 }
 
+// Source returns the MessageSource of the Message.
+func (m *MessageMetadata) Source() MessageSource {
+	m.sourceMutex.RLock()
+	defer m.sourceMutex.RUnlock()
+
+	return m.source
+}
+
+// SetSource sets the MessageSource of the Message.
+func (m *MessageMetadata) SetSource(source MessageSource) (updated bool) {
+	m.sourceMutex.Lock()
+	defer m.sourceMutex.Unlock()
+
+	if source <= m.source {
+		return false
+	}
+
+	m.source = source
+	m.SetModified()
+
+	return true
+}
+
+// SetSolidificationType sets the SolidificationType of the Message. Tt can only be "upgraded" (go from a weaker form of
+// solidification to a stronger one).
+func (m *MessageMetadata) SetSolidificationType(solidificationType SolidificationType) (updated bool) {
+	m.solidificationTypeMutex.Lock()
+	defer m.solidificationTypeMutex.Unlock()
+
+	if solidificationType <= m.solidificationType {
+		return false
+	}
+
+	m.solidificationType = solidificationType
+	m.SetModified()
+
+	return true
+}
+
+// SolidificationType returns the SolidificationType of the Message.
+func (m *MessageMetadata) SolidificationType() (solidificationType SolidificationType) {
+	m.solidificationTypeMutex.RLock()
+	defer m.solidificationTypeMutex.RUnlock()
+
+	return m.solidificationType
+}
+
+// IsWeaklySolid returns true if the message represented by this metadata is weakly solid. False otherwise.
+func (m *MessageMetadata) IsWeaklySolid() (result bool) {
+	m.weaklySolidMutex.RLock()
+	defer m.weaklySolidMutex.RUnlock()
+
+	return m.weaklySolid
+}
+
+// SetWeaklySolid sets the message associated with this metadata as weakly solid.
+// It returns true if the solid status is modified. False otherwise.
+func (m *MessageMetadata) SetWeaklySolid(weaklySolid bool) (modified bool) {
+	m.weaklySolidMutex.RLock()
+	if m.weaklySolid == weaklySolid {
+		m.weaklySolidMutex.RUnlock()
+		return
+	}
+
+	m.weaklySolidMutex.RUnlock()
+	m.weaklySolidMutex.Lock()
+	defer m.weaklySolidMutex.Unlock()
+	if m.weaklySolid == weaklySolid {
+		return
+	}
+
+	m.weaklySolid = weaklySolid
+	m.SetModified()
+
+	return true
+}
+
 // IsSolid returns true if the message represented by this metadata is solid. False otherwise.
 func (m *MessageMetadata) IsSolid() (result bool) {
 	m.solidMutex.RLock()
 	defer m.solidMutex.RUnlock()
-	result = m.solid
 
-	return
+	return m.solid
 }
 
 // SetSolid sets the message associated with this metadata as solid.
@@ -1174,7 +1301,10 @@ func (m *MessageMetadata) ObjectStorageValue() []byte {
 	return marshalutil.New().
 		WriteTime(m.ReceivedTime()).
 		WriteTime(m.SolidificationTime()).
+		Write(m.Source()).
+		Write(m.SolidificationType()).
 		WriteBool(m.IsSolid()).
+		WriteBool(m.IsWeaklySolid()).
 		Write(m.StructureDetails()).
 		Write(m.BranchID()).
 		WriteBool(m.Scheduled()).
@@ -1199,7 +1329,10 @@ func (m *MessageMetadata) String() string {
 	return stringify.Struct("MessageMetadata",
 		stringify.StructField("ID", m.messageID),
 		stringify.StructField("receivedTime", m.ReceivedTime()),
+		stringify.StructField("source", m.Source()),
+		stringify.StructField("solidificationType", m.SolidificationType()),
 		stringify.StructField("solid", m.IsSolid()),
+		stringify.StructField("weaklySolid", m.IsWeaklySolid()),
 		stringify.StructField("solidificationTime", m.SolidificationTime()),
 		stringify.StructField("structureDetails", m.StructureDetails()),
 		stringify.StructField("branchID", m.BranchID()),
@@ -1260,7 +1393,85 @@ func (c *CachedMessageMetadata) Consume(consumer func(messageMetadata *MessageMe
 
 // endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-// region Errors /////////////////////////////tangle.m//////////////////////////////////////////////////////////////////////////
+// region MessageSource ////////////////////////////////////////////////////////////////////////////////////////////////
+
+// MessageSource is a type that represents different sources for Messages in a nodes database.
+type MessageSource uint8
+
+const (
+	// UndefinedMessageSource represents the zero value of a MessageSource.
+	UndefinedMessageSource MessageSource = iota
+
+	// WeakSolidificationSource represents Messages that were requested as a missing weak parent.
+	WeakSolidificationSource
+
+	// StrongSolidificationSource represents Messages that were requested as a missing strong parent.
+	StrongSolidificationSource
+
+	// GossipSource represents Messages that were received via Gossip without previously requesting them.
+	GossipSource
+)
+
+// MessageSourceFromBytes unmarshals a MessageSource from a sequence of bytes.
+func MessageSourceFromBytes(messageSourceBytes []byte) (messageSource MessageSource, consumedBytes int, err error) {
+	marshalUtil := marshalutil.New(messageSourceBytes)
+	if messageSource, err = MessageSourceFromMarshalUtil(marshalUtil); err != nil {
+		err = errors.Errorf("failed to parse MessageSource from MarshalUtil: %w", err)
+		return
+	}
+	consumedBytes = marshalUtil.ReadOffset()
+
+	return
+}
+
+// MessageSourceFromMarshalUtil unmarshals a MessageSource using a MarshalUtil (for easier unmarshaling).
+func MessageSourceFromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (messageSource MessageSource, err error) {
+	untypedMessageSource, err := marshalUtil.ReadUint8()
+	if err != nil {
+		err = errors.Errorf("failed to parse MessageSource (%v): %w", err, cerrors.ErrParseBytesFailed)
+		return
+	}
+
+	return MessageSource(untypedMessageSource), nil
+}
+
+// SolidificationType returns the SolidificationType that is used for Messages of the given MessageSource.
+func (m MessageSource) SolidificationType() SolidificationType {
+	switch m {
+	case UndefinedMessageSource:
+		return UndefinedSolidificationType
+	case WeakSolidificationSource:
+		return WeakSolidification
+	default:
+		return StrongSolidification
+	}
+}
+
+// Bytes returns a marshaled version of the MessageSource.
+func (m MessageSource) Bytes() (marshaledMessageSource []byte) {
+	return []byte{uint8(m)}
+}
+
+// String returns a human readable version of the MessageSource.
+func (m MessageSource) String() (humanReadableMessageSource string) {
+	switch m {
+	case UndefinedMessageSource:
+		return "MessageSource(UndefinedMessageSource)"
+	case WeakSolidificationSource:
+		return "MessageSource(WeakSolidificationSource)"
+	case StrongSolidificationSource:
+		return "MessageSource(StrongSolidificationSource)"
+	case GossipSource:
+		return "MessageSource(GossipSource)"
+	default:
+		return "MessageSource(" + strconv.Itoa(int(m)) + ")"
+	}
+}
+
+// endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// region Errors ///////////////////////////////////////////////////////////////////////////////////////////////////////
+
 var (
 	ErrNoStrongParents                    = errors.New("missing strong messages in first parent block")
 	ErrBlocksNotOrderedByType             = errors.New("blocks should be ordered in ascending order according to their type")

--- a/packages/tangle/scheduler_test.go
+++ b/packages/tangle/scheduler_test.go
@@ -387,13 +387,19 @@ func BenchmarkScheduler(b *testing.B) {
 	b.StopTimer()
 }
 
+// timeOffset represents an additional offset that we are manually increasing to create different perceptions of
+// time.Now() even on platforms with a bad time precision (e.g. Windows).
+var timeOffset = time.Nanosecond
+
 func newMessage(issuerPublicKey ed25519.PublicKey) *Message {
+	timeOffset += time.Nanosecond
+
 	message, _ := NewMessage(
 		[]MessageID{EmptyMessageID},
 		[]MessageID{},
 		[]MessageID{},
 		[]MessageID{},
-		time.Now(),
+		time.Now().Add(timeOffset),
 		issuerPublicKey,
 		0,
 		payload.NewGenericDataPayload([]byte("")),

--- a/packages/tangle/solidifier.go
+++ b/packages/tangle/solidifier.go
@@ -1,11 +1,18 @@
 package tangle
 
 import (
+	"fmt"
+	"strconv"
 	"time"
 
+	"github.com/cockroachdb/errors"
+	"github.com/iotaledger/hive.go/cerrors"
 	"github.com/iotaledger/hive.go/datastructure/walker"
 	"github.com/iotaledger/hive.go/events"
+	"github.com/iotaledger/hive.go/marshalutil"
 	"github.com/iotaledger/hive.go/syncutils"
+
+	"github.com/iotaledger/goshimmer/packages/ledgerstate"
 )
 
 // maxParentsTimeDifference defines the smallest allowed time difference between a child Message and its parents.
@@ -21,16 +28,19 @@ type Solidifier struct {
 	// Events contains the Solidifier related events.
 	Events *SolidifierEvents
 
-	triggerMutex syncutils.MultiMutex
-	tangle       *Tangle
+	tangle *Tangle
+
+	syncutils.MultiMutex
 }
 
 // NewSolidifier is the constructor of the Solidifier.
 func NewSolidifier(tangle *Tangle) (solidifier *Solidifier) {
 	solidifier = &Solidifier{
 		Events: &SolidifierEvents{
-			MessageSolid:   events.NewEvent(MessageIDCaller),
-			MessageMissing: events.NewEvent(MessageIDCaller),
+			Error:              events.NewEvent(events.ErrorCaller),
+			MessageWeaklySolid: events.NewEvent(MessageIDCaller),
+			MessageSolid:       events.NewEvent(MessageIDCaller),
+			MessageMissing:     events.NewEvent(MessageIDCaller),
 		},
 
 		tangle: tangle,
@@ -42,50 +52,130 @@ func NewSolidifier(tangle *Tangle) (solidifier *Solidifier) {
 // Setup sets up the behavior of the component by making it attach to the relevant events of the other components.
 func (s *Solidifier) Setup() {
 	s.tangle.Storage.Events.MessageStored.Attach(events.NewClosure(s.Solidify))
+	s.tangle.LedgerState.UTXODAG.Events().TransactionSolid.Attach(events.NewClosure(s.TriggerTransactionSolid))
 }
 
 // Solidify solidifies the given Message.
 func (s *Solidifier) Solidify(messageID MessageID) {
-	s.tangle.Utils.WalkMessageAndMetadata(s.checkMessageSolidity, MessageIDs{messageID}, true)
+	s.tangle.Storage.MessageMetadata(messageID).Consume(func(messageMetadata *MessageMetadata) {
+		solidificationType := messageMetadata.Source().SolidificationType()
+		if solidificationType == UndefinedSolidificationType {
+			panic(errors.Errorf("unexpected %s when solidifying Message with %s", solidificationType, messageID))
+		}
+
+		s.tangle.Storage.Message(messageID).Consume(func(message *Message) {
+			s.solidify(message, messageMetadata, solidificationType)
+		})
+	})
 }
 
-// checkMessageSolidity checks if the given Message is solid and eventually queues its Approvers to also be checked.
-func (s *Solidifier) checkMessageSolidity(message *Message, messageMetadata *MessageMetadata, walker *walker.Walker) {
-	if !s.isMessageSolid(message, messageMetadata) {
+// TriggerTransactionSolid triggers the solidity checks related to a transaction payload becoming solid.
+func (s *Solidifier) TriggerTransactionSolid(transactionID ledgerstate.TransactionID) {
+	s.propagateSolidity(s.tangle.Storage.AttachmentMessageIDs(transactionID)...)
+}
+
+func (s *Solidifier) solidifyWeakly(message *Message, messageMetadata *MessageMetadata, requestMissingMessages bool) (approversToPropagate MessageIDs) {
+	approversToPropagate = make(MessageIDs, 0)
+
+	if !s.isMessageWeaklySolid(message, messageMetadata, requestMissingMessages) {
 		return
 	}
 
-	if !s.areParentMessagesValid(message) {
-		if !messageMetadata.SetInvalid(true) {
-			return
+	if s.isMessageSolid(message, messageMetadata, false) {
+		if s.triggerSolidUpdate(message, messageMetadata) {
+			approversToPropagate = append(approversToPropagate, s.tangle.Utils.ApprovingMessageIDs(messageMetadata.ID())...)
 		}
-		s.tangle.Events.MessageInvalid.Trigger(&MessageInvalidEvent{MessageID: message.ID(), Error: ErrParentsInvalid})
+
+		return approversToPropagate
+	}
+
+	if s.triggerWeaklySolidUpdate(message, messageMetadata) {
+		approversToPropagate = append(approversToPropagate, s.tangle.Utils.ApprovingMessageIDs(messageMetadata.ID())...)
+	}
+
+	return approversToPropagate
+}
+
+func (s *Solidifier) solidifyStrongly(message *Message, messageMetadata *MessageMetadata) (approversToPropagate MessageIDs) {
+	approversToPropagate = make(MessageIDs, 0)
+
+	if s.isMessageSolid(message, messageMetadata, true) {
+		if s.triggerSolidUpdate(message, messageMetadata) {
+			approversToPropagate = append(approversToPropagate, s.tangle.Utils.ApprovingMessageIDs(messageMetadata.ID())...)
+		}
+
+		return approversToPropagate
+	}
+
+	if s.isMessageWeaklySolid(message, messageMetadata, false) {
+		if s.triggerWeaklySolidUpdate(message, messageMetadata) {
+			approversToPropagate = append(approversToPropagate, s.tangle.Utils.ApprovingMessageIDs(messageMetadata.ID())...)
+		}
+	}
+
+	return approversToPropagate
+}
+
+// solidify performs the solidity checks and triggers the corresponding updates.
+func (s *Solidifier) solidify(message *Message, messageMetadata *MessageMetadata, solidificationType SolidificationType) {
+	if !messageMetadata.SetSolidificationType(solidificationType) {
 		return
 	}
 
-	lockBuilder := syncutils.MultiMutexLockBuilder{}
-	lockBuilder.AddLock(messageMetadata.ID())
-
-	message.ForEachParent(func(parent Parent) {
-		lockBuilder.AddLock(parent.ID)
-	})
-	lock := lockBuilder.Build()
-
-	s.triggerMutex.Lock(lock...)
-	defer s.triggerMutex.Unlock(lock...)
-
-	if !messageMetadata.SetSolid(true) {
-		return
+	switch solidificationType {
+	case WeakSolidification:
+		s.propagateSolidity(s.solidifyWeakly(message, messageMetadata, true)...)
+	case StrongSolidification:
+		s.propagateSolidity(s.solidifyStrongly(message, messageMetadata)...)
 	}
-	s.Events.MessageSolid.Trigger(message.ID())
+}
 
-	s.tangle.Storage.Approvers(message.ID()).Consume(func(approver *Approver) {
-		walker.Push(approver.ApproverMessageID())
+// isMessageWeaklySolid checks if the given Message is weakly solid.
+//
+// Note: A message is weakly solid if it is either not containing a transaction payload or if its weak parents are at
+//       least weakly solid (and pass the parents age check - otherwise the message is invalid).
+func (s *Solidifier) isMessageWeaklySolid(message *Message, messageMetadata *MessageMetadata, requestMissingMessages bool) (weaklySolid bool) {
+	if message == nil || message.IsDeleted() || messageMetadata == nil || messageMetadata.IsDeleted() {
+		return false
+	}
+
+	if messageMetadata.IsWeaklySolid() || messageMetadata.IsSolid() {
+		return true
+	}
+
+	if message.Payload().Type() != ledgerstate.TransactionType {
+		return true
+	}
+
+	weaklySolid = true
+	message.ForEachParentByType(WeakParentType, func(parentMessageID MessageID) {
+		if weaklySolid || requestMissingMessages {
+			weaklySolid = s.isMessageMarkedAsWeaklySolid(parentMessageID, requestMissingMessages) && weaklySolid
+		}
 	})
+	if !weaklySolid {
+		return false
+	}
+
+	if !s.parentsAgeValid(message.IssuingTime(), message.ParentsByType(WeakParentType)) {
+		if messageMetadata.SetInvalid(true) {
+			s.tangle.Events.MessageInvalid.Trigger(&MessageInvalidEvent{
+				MessageID: message.ID(),
+				Error:     errors.Errorf("parents age invalid for Message with %s: %w", message.ID(), cerrors.ErrFatal),
+			})
+		}
+
+		return false
+	}
+
+	return s.solidifyPayload(message, messageMetadata)
 }
 
 // isMessageSolid checks if the given Message is solid.
-func (s *Solidifier) isMessageSolid(message *Message, messageMetadata *MessageMetadata) (solid bool) {
+//
+// Note: A message is solid if its strong parents are solid and its weak parents are at least weakly solid. If any of
+//       the parents doesn't pass the parents age check then the Message is invalid.
+func (s *Solidifier) isMessageSolid(message *Message, messageMetadata *MessageMetadata, requestMissingMessages bool) (solid bool) {
 	if message == nil || message.IsDeleted() || messageMetadata == nil || messageMetadata.IsDeleted() {
 		return false
 	}
@@ -95,73 +185,205 @@ func (s *Solidifier) isMessageSolid(message *Message, messageMetadata *MessageMe
 	}
 
 	solid = true
-	message.ForEachParent(func(parent Parent) {
-		// as missing messages are requested in isMessageMarkedAsSolid, we need to be aware of short-circuit evaluation
-		// rules, thus we need to evaluate isMessageMarkedAsSolid !!first!!
-		solid = s.isMessageMarkedAsSolid(parent.ID) && solid
+	message.ForEachParentByType(StrongParentType, func(parentMessageID MessageID) {
+		if solid || requestMissingMessages {
+			solid = s.isMessageMarkedAsSolid(parentMessageID, requestMissingMessages) && solid
+		}
+	})
+	message.ForEachParentByType(LikeParentType, func(parentMessageID MessageID) {
+		if solid || requestMissingMessages {
+			solid = s.isMessageMarkedAsSolid(parentMessageID, requestMissingMessages) && solid
+		}
 	})
 
-	return
+	if solid && (!s.parentsAgeValid(message.IssuingTime(), message.ParentsByType(StrongParentType)) || !s.parentsAgeValid(message.IssuingTime(), message.ParentsByType(LikeParentType))) && len(message.ParentsByType(WeakParentType)) == 0 && messageMetadata.SetInvalid(true) {
+		s.tangle.Events.MessageInvalid.Trigger(&MessageInvalidEvent{
+			MessageID: message.ID(),
+			Error:     errors.Errorf("parents age invalid for Message with %s: %w", message.ID(), cerrors.ErrFatal),
+		})
+
+		return false
+	}
+
+	message.ForEachParentByType(WeakParentType, func(parentMessageID MessageID) {
+		if solid || requestMissingMessages {
+			solid = s.isMessageMarkedAsWeaklySolid(parentMessageID, requestMissingMessages) && solid
+		}
+	})
+	if !solid {
+		return false
+	}
+
+	if !s.parentsAgeValid(message.IssuingTime(), message.ParentsByType(WeakParentType)) {
+		if messageMetadata.SetInvalid(true) {
+			s.tangle.Events.MessageInvalid.Trigger(&MessageInvalidEvent{
+				MessageID: message.ID(),
+				Error:     errors.Errorf("parents age invalid for Message with %s: %w", message.ID(), cerrors.ErrFatal),
+			})
+		}
+
+		return false
+	}
+
+	return s.solidifyPayload(message, messageMetadata)
 }
 
-// isMessageMarkedAsSolid checks whether the given message is solid and marks it as missing if it isn't known.
-func (s *Solidifier) isMessageMarkedAsSolid(messageID MessageID) (solid bool) {
+// parentsAgeValid checks if the given MessageIDs belong to Messages that are within the allowed
+// maxParentsTimeDifference from the issuing time.
+func (s *Solidifier) parentsAgeValid(issuingTime time.Time, parentMessageIDs MessageIDs) (valid bool) {
+	for _, parentMessageID := range parentMessageIDs {
+		if parentMessageID == EmptyMessageID {
+			continue
+		}
+
+		if !s.tangle.Storage.Message(parentMessageID).Consume(func(parentMessage *Message) {
+			timeDifference := issuingTime.Sub(parentMessage.IssuingTime())
+
+			valid = timeDifference >= minParentsTimeDifference && timeDifference <= maxParentsTimeDifference
+		}) || !valid {
+			return false
+		}
+	}
+
+	return true
+}
+
+// isMessageMarkedAsSolid checks if the Message is already marked as solid (it requests missing messages).
+func (s *Solidifier) isMessageMarkedAsSolid(messageID MessageID, requestMissingMessages bool) (solid bool) {
 	if messageID == EmptyMessageID {
 		return true
 	}
 
 	s.tangle.Storage.MessageMetadata(messageID, func() *MessageMetadata {
-		if cachedMissingMessage, stored := s.tangle.Storage.StoreMissingMessage(NewMissingMessage(messageID)); stored {
+		if !requestMissingMessages {
+			return nil
+		}
+
+		if cachedMissingMessage, stored := s.tangle.Storage.StoreMissingMessage(NewMissingMessage(messageID, StrongSolidificationSource)); stored {
 			cachedMissingMessage.Consume(func(missingMessage *MissingMessage) {
 				s.Events.MessageMissing.Trigger(messageID)
 			})
 		}
 
-		// do not initialize the metadata here, we execute this in the optional ComputeIfAbsent callback to be secure
-		// from race conditions
 		return nil
 	}).Consume(func(messageMetadata *MessageMetadata) {
+		// if we upgraded from a WeakSolidificationSource: do a proper check with eventual requests of missing parents
+		// instead of relying on the flag in the metadata.
+		if messageMetadata.SetSource(StrongSolidificationSource) {
+			fmt.Println("upgraded source", messageMetadata.ID())
+
+			s.tangle.Storage.Message(messageMetadata.ID()).Consume(func(message *Message) {
+				s.isMessageSolid(message, messageMetadata, true)
+			})
+		}
+
 		solid = messageMetadata.IsSolid()
 	})
 
 	return
 }
 
-// areParentMessagesValid checks whether the parents of the given Message are valid.
-func (s *Solidifier) areParentMessagesValid(message *Message) (valid bool) {
-	valid = true
-	message.ForEachParent(func(parent Parent) {
-		valid = valid && s.isParentMessageValid(parent.ID, message)
+// isMessageMarkedAsSolid checks if the Message is already marked as weakly solid (it requests missing messages).
+func (s *Solidifier) isMessageMarkedAsWeaklySolid(messageID MessageID, requestMissingMessages bool) (solid bool) {
+	if messageID == EmptyMessageID {
+		return true
+	}
+
+	s.tangle.Storage.MessageMetadata(messageID, func() *MessageMetadata {
+		if !requestMissingMessages {
+			return nil
+		}
+
+		if cachedMissingMessage, stored := s.tangle.Storage.StoreMissingMessage(NewMissingMessage(messageID, WeakSolidificationSource)); stored {
+			cachedMissingMessage.Consume(func(missingMessage *MissingMessage) {
+				s.Events.MessageMissing.Trigger(messageID)
+			})
+		}
+
+		return nil
+	}).Consume(func(messageMetadata *MessageMetadata) {
+		solid = messageMetadata.IsSolid() || messageMetadata.IsWeaklySolid()
 	})
 
 	return
 }
 
-// isParentMessageValid checks whether the given parent Message is valid.
-func (s *Solidifier) isParentMessageValid(parentMessageID MessageID, childMessage *Message) (valid bool) {
-	if parentMessageID == EmptyMessageID {
-		if s.tangle.Options.GenesisNode != nil {
-			return *s.tangle.Options.GenesisNode == childMessage.IssuerPublicKey()
-		}
-
-		s.tangle.Storage.MessageMetadata(parentMessageID).Consume(func(messageMetadata *MessageMetadata) {
-			timeDifference := childMessage.IssuingTime().Sub(messageMetadata.SolidificationTime())
-			valid = timeDifference >= minParentsTimeDifference && timeDifference <= maxParentsTimeDifference
-		})
-		return
+// solidifyPayload creates the Attachment reference between the Message and its contained Transaction and then
+// solidifies the Transaction by handing it over to the UTXODAG.
+func (s *Solidifier) solidifyPayload(message *Message, messageMetadata *MessageMetadata) (solid bool) {
+	transaction, typeCastOkay := message.Payload().(*ledgerstate.Transaction)
+	if !typeCastOkay {
+		return true
 	}
 
-	s.tangle.Storage.Message(parentMessageID).Consume(func(parentMessage *Message) {
-		timeDifference := childMessage.IssuingTime().Sub(parentMessage.IssuingTime())
+	if cachedAttachment, stored := s.tangle.Storage.StoreAttachment(transaction.ID(), message.ID()); stored {
+		cachedAttachment.Release()
+	}
 
-		valid = timeDifference >= minParentsTimeDifference && timeDifference <= maxParentsTimeDifference
-	})
+	_, solidityType, err := s.tangle.LedgerState.StoreTransaction(transaction)
+	if err != nil {
+		switch {
+		case errors.Is(err, ledgerstate.ErrInvalidStateTransition):
+			messageMetadata.SetInvalid(true)
+			s.tangle.Events.MessageInvalid.Trigger(&MessageInvalidEvent{
+				MessageID: message.ID(),
+				Error:     err,
+			})
+		case errors.Is(err, ledgerstate.ErrTransactionInvalid):
+			messageMetadata.SetInvalid(true)
+			s.tangle.Events.MessageInvalid.Trigger(&MessageInvalidEvent{
+				MessageID: message.ID(),
+				Error:     err,
+			})
+		default:
+			s.Events.Error.Trigger(errors.Errorf("failed to store Transaction: %w", err))
+		}
 
-	s.tangle.Storage.MessageMetadata(parentMessageID).Consume(func(messageMetadata *MessageMetadata) {
-		valid = valid && !messageMetadata.IsInvalid()
-	})
+		return false
+	}
+	solid = solidityType == ledgerstate.Solid || solidityType == ledgerstate.LazySolid || solidityType == ledgerstate.Invalid
 
-	return
+	return solid
+}
+
+// propagateSolidity executes the solidity checks for the given MessageIDs and propagates possible updates to their
+// approvers.
+func (s *Solidifier) propagateSolidity(messageIDs ...MessageID) {
+	s.tangle.Utils.WalkMessageAndMetadata(func(message *Message, messageMetadata *MessageMetadata, walker *walker.Walker) {
+		for _, messageID := range s.solidifyWeakly(message, messageMetadata, false) {
+			walker.Push(messageID)
+		}
+	}, messageIDs, true)
+}
+
+// triggerWeaklySolidUpdate triggers the update of the MessageMetadata and the corresponding Event. It returns true if
+// the Event was fired and false if the corresponding Message was already marked as weaklySolid, before.
+func (s *Solidifier) triggerWeaklySolidUpdate(message *Message, messageMetadata *MessageMetadata) (triggered bool) {
+	s.LockEntity(message)
+	defer s.UnlockEntity(message)
+
+	if !messageMetadata.SetWeaklySolid(true) {
+		return false
+	}
+
+	s.Events.MessageWeaklySolid.Trigger(messageMetadata.ID())
+
+	return true
+}
+
+// triggerSolidUpdate triggers the update of the MessageMetadata and the corresponding Event. It returns true if
+// the Event was fired and false if the corresponding Message was already marked as solid, before.
+func (s *Solidifier) triggerSolidUpdate(message *Message, messageMetadata *MessageMetadata) (triggered bool) {
+	s.LockEntity(message)
+	defer s.UnlockEntity(message)
+
+	if !messageMetadata.SetSolid(true) {
+		return false
+	}
+
+	s.Events.MessageSolid.Trigger(messageMetadata.ID())
+
+	return true
 }
 
 // endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -170,11 +392,67 @@ func (s *Solidifier) isParentMessageValid(parentMessageID MessageID, childMessag
 
 // SolidifierEvents represents events happening in the Solidifier.
 type SolidifierEvents struct {
-	// MessageSolid is triggered when a message becomes solid, i.e. its past cone is known and solid.
+	// Error is triggered when an unexpected error occurred.
+	Error *events.Event
+
+	// MessageWeaklySolid is triggered when a message becomes weakly solid, i.e. its weak references are solid and its
+	// payload is solid.
+	MessageWeaklySolid *events.Event
+
+	// MessageSolid is triggered when a message becomes solid, i.e. all of its dependencies are known and solid.
 	MessageSolid *events.Event
 
 	// MessageMissing is triggered when a message references an unknown parent Message.
 	MessageMissing *events.Event
+}
+
+// endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// region SolidificationType ///////////////////////////////////////////////////////////////////////////////////////////
+
+// SolidificationType is a type that represents the different forms of solidification used in the Tangle.
+type SolidificationType uint8
+
+const (
+	// UndefinedSolidificationType represents the zero value of a SolidificationType.
+	UndefinedSolidificationType SolidificationType = iota
+
+	// WeakSolidification represents the type of solidification where the node requests only the weak parents of a
+	// Message.
+	WeakSolidification
+
+	// StrongSolidification represents the type of solidification where the node requests all parents of a Message.
+	StrongSolidification
+)
+
+// SolidificationTypeFromMarshalUtil unmarshals a SolidificationType using a MarshalUtil (for easier unmarshaling).
+func SolidificationTypeFromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (solidificationType SolidificationType, err error) {
+	untypedSolidificationType, err := marshalUtil.ReadUint8()
+	if err != nil {
+		err = errors.Errorf("failed to parse SolidificationType (%v): %w", err, cerrors.ErrParseBytesFailed)
+		return
+	}
+
+	return SolidificationType(untypedSolidificationType), nil
+}
+
+// Bytes returns a marshaled version of the SolidificationType.
+func (s SolidificationType) Bytes() (marshaledSolidificationType []byte) {
+	return []byte{uint8(s)}
+}
+
+// String returns a human-readable version of the SolidificationType.
+func (s SolidificationType) String() (humanReadableSolidificationType string) {
+	switch s {
+	case UndefinedSolidificationType:
+		return "SolidificationType(UndefinedSolidificationType)"
+	case StrongSolidification:
+		return "SolidificationType(StrongSolidification)"
+	case WeakSolidification:
+		return "SolidificationType(WeakSolidification)"
+	default:
+		return "SolidificationType(" + strconv.Itoa(int(s)) + ")"
+	}
 }
 
 // endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/packages/tangle/solidifier_test.go
+++ b/packages/tangle/solidifier_test.go
@@ -1,0 +1,100 @@
+package tangle
+
+import (
+	"testing"
+	"time"
+
+	"github.com/iotaledger/hive.go/events"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSolidifier(t *testing.T) {
+	sourceTangle := NewTestTangle()
+	defer sourceTangle.Shutdown()
+	sourceTangle.Setup()
+
+	sourceFramework := NewMessageTestFramework(sourceTangle)
+	sourceFramework.CreateMessage("Message1", WithStrongParents("Genesis"))
+	sourceFramework.CreateMessage("Message2", WithStrongParents("Genesis"))
+	sourceFramework.CreateMessage("Message3", WithStrongParents("Message1"))
+	sourceFramework.CreateMessage("Message4", WithStrongParents("Message2"))
+	sourceFramework.CreateMessage("Message5", WithStrongParents("Message3"), WithWeakParents("Message4"))
+	sourceFramework.CreateMessage("Message6", WithStrongParents("Message4"))
+	sourceFramework.IssueMessages("Message1", "Message2", "Message3", "Message4", "Message5", "Message6").WaitMessagesBooked()
+
+	destinationTangle := NewTestTangle()
+	defer destinationTangle.Shutdown()
+	destinationTangle.Setup()
+
+	destinationTangle.Solidifier.Events.MessageMissing.Attach(events.NewClosure(func(messageID MessageID) {
+		go func() {
+			sourceTangle.Storage.Message(messageID).Consume(func(message *Message) {
+				destinationTangle.Storage.StoreMessage(message)
+			})
+		}()
+	}))
+
+	destinationTangle.Storage.StoreMessage(sourceFramework.Message("Message5"))
+
+	assert.Eventually(t, func() bool {
+		return messagesSolid(destinationTangle, sourceFramework, "Message1", "Message3", "Message5") &&
+			messagesWeaklySolid(destinationTangle, sourceFramework, "Message1", "Message3", "Message4", "Message5") &&
+			!messagesExist(destinationTangle, sourceFramework, "Message2")
+	}, 5*time.Minute, 100*time.Millisecond)
+
+	destinationTangle.Storage.StoreMessage(sourceFramework.Message("Message6"))
+
+	assert.Eventually(t, func() bool {
+		return messagesSolid(destinationTangle, sourceFramework, "Message1", "Message2", "Message3", "Message4", "Message5", "Message6")
+	}, 5*time.Minute, 100*time.Millisecond)
+}
+
+func messagesExist(tangle *Tangle, messageTestFramework *MessageTestFramework, aliases ...string) bool {
+	for _, alias := range aliases {
+		if !messageExists(tangle, messageTestFramework.Message(alias).ID()) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func messagesSolid(tangle *Tangle, messageTestFramework *MessageTestFramework, aliases ...string) bool {
+	for _, alias := range aliases {
+		if !messageSolid(tangle, messageTestFramework.Message(alias).ID()) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func messagesWeaklySolid(tangle *Tangle, messageTestFramework *MessageTestFramework, aliases ...string) bool {
+	for _, alias := range aliases {
+		if !messageWeaklySolid(tangle, messageTestFramework.Message(alias).ID()) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func messageExists(tangle *Tangle, messageID MessageID) bool {
+	return tangle.Storage.MessageMetadata(messageID).Consume(func(messageMetadata *MessageMetadata) {})
+}
+
+func messageSolid(tangle *Tangle, messageID MessageID) (isSolid bool) {
+	tangle.Storage.MessageMetadata(messageID).Consume(func(messageMetadata *MessageMetadata) {
+		isSolid = messageMetadata.IsSolid()
+	})
+
+	return
+}
+
+func messageWeaklySolid(tangle *Tangle, messageID MessageID) (isSolid bool) {
+	tangle.Storage.MessageMetadata(messageID).Consume(func(messageMetadata *MessageMetadata) {
+		isSolid = messageMetadata.IsSolid() || messageMetadata.IsWeaklySolid()
+	})
+
+	return
+}

--- a/packages/tangle/tangle_test.go
+++ b/packages/tangle/tangle_test.go
@@ -223,12 +223,8 @@ func TestTangle_MissingMessages(t *testing.T) {
 		storeDelay   = 5 * time.Millisecond
 	)
 
-	// create rocksdb store
-	rocksdb, err := testutil.RocksDB(t)
-	require.NoError(t, err)
-
 	// create the tangle
-	tangle := NewTestTangle(Store(rocksdb))
+	tangle := NewTestTangle()
 	tangle.OTVConsensusManager = NewOTVConsensusManager(otv.NewOnTangleVoting(tangle.LedgerState.BranchDAG, tangle.ApprovalWeightManager.WeightOfBranch))
 
 	defer tangle.Shutdown()

--- a/packages/tangle/tipmanager.go
+++ b/packages/tangle/tipmanager.go
@@ -158,6 +158,14 @@ func (t *TipManager) AddTip(message *Message) {
 		panic(fmt.Errorf("failed to load MessageMetadata with %s", messageID))
 	}
 
+	messageBranchID, err := t.tangle.Booker.MessageBranchID(messageMetadata.ID())
+	if err != nil {
+		panic(errors.Errorf("failed to retrieve BranchID of Message with %s: %w", messageMetadata.ID(), err))
+	}
+	if messageBranchID == ledgerstate.InvalidBranchID {
+		return
+	}
+
 	if clock.Since(message.IssuingTime()) > tipLifeGracePeriod {
 		return
 	}

--- a/packages/tangle/tipmanager_test.go
+++ b/packages/tangle/tipmanager_test.go
@@ -189,6 +189,7 @@ func TestTipManager_TransactionTips(t *testing.T) {
 	// set up scenario (images/tipmanager-TransactionTips-test.png)
 	tangle := NewTestTangle()
 	defer tangle.Shutdown()
+	tangle.Solidifier.Setup()
 	tipManager := tangle.TipManager
 
 	wallets := make(map[string]wallet)
@@ -387,6 +388,14 @@ func TestTipManager_TransactionTips(t *testing.T) {
 
 	// Message 6
 	{
+		// with the invalidity check in the Booker, the tests would now fail as the parents are invalid
+		tangle.Storage.MessageMetadata(messages["3"].ID()).Consume(func(messageMetadata *MessageMetadata) {
+			messageMetadata.SetInvalid(false)
+		})
+		tangle.Storage.MessageMetadata(messages["5"].ID()).Consume(func(messageMetadata *MessageMetadata) {
+			messageMetadata.SetInvalid(false)
+		})
+
 		createScenarioMessageWith1Input1Output("6", "5", "3", "H", "Q", []MessageID{messages["3"].ID(), messages["5"].ID()})
 		tipManager.AddTip(messages["6"])
 		assert.Equal(t, 2, tipManager.TipCount())

--- a/plugins/dashboard/frontend/src/app/components/ExplorerOutputQueryResult.tsx
+++ b/plugins/dashboard/frontend/src/app/components/ExplorerOutputQueryResult.tsx
@@ -2,9 +2,8 @@ import * as React from 'react';
 import Container from "react-bootstrap/Container";
 import ListGroup from "react-bootstrap/ListGroup";
 import NodeStore from "app/stores/NodeStore";
-import { inject, observer } from "mobx-react";
+import {inject, observer} from "mobx-react";
 import ExplorerStore from "app/stores/ExplorerStore";
-import Badge from "react-bootstrap/Badge";
 import {displayManaUnit} from "app/utils";
 import {resolveBase58BranchID} from "app/utils/branch";
 import {outputToComponent} from "app/utils/output";
@@ -36,16 +35,6 @@ export class ExplorerOutputQueryResult extends React.Component<Props, any> {
     render() {
         let {id} = this.props.match.params;
         let { query_err, output, pendingMana, outputMetadata, outputConsumers } = this.props.explorerStore;
-
-        let renderTriBool = (val: string) => {
-            if (val === "true"){
-                return <Badge variant={"success"}>True</Badge>
-            }
-            if (val === "false"){
-                return <Badge variant={"danger"}>False</Badge>
-            }
-            return <Badge variant={"warning"}>Maybe</Badge>
-        }
 
         if (query_err) {
             return (
@@ -89,7 +78,7 @@ export class ExplorerOutputQueryResult extends React.Component<Props, any> {
                     <ListGroup>
                         {outputConsumers.consumers.map((c,i) => <ListGroup.Item key={i}>
                             <div>Transaction ID:  <a href={`/explorer/transaction/${c.transactionID}`}>{c.transactionID}</a></div>
-                            <div>Valid: {renderTriBool(c.valid)} </div>
+                            <div>SolidityType: {c.solidityType.toString()} </div>
                         </ListGroup.Item>)}
                     </ListGroup>
                 </div>}

--- a/plugins/dashboard/frontend/src/app/components/ExplorerTransactionMetadata.tsx
+++ b/plugins/dashboard/frontend/src/app/components/ExplorerTransactionMetadata.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Container from "react-bootstrap/Container";
 import NodeStore from "app/stores/NodeStore";
-import { inject, observer } from "mobx-react";
+import {inject, observer} from "mobx-react";
 import ExplorerStore from "app/stores/ExplorerStore";
 import ListGroup from "react-bootstrap/ListGroup";
 import {resolveBase58BranchID} from "app/utils/branch";
@@ -40,11 +40,10 @@ export class ExplorerTransactionMetadata extends React.Component<Props, any> {
                 <h4>Metadata</h4>
                 {txMetadata && <ListGroup>
                     <ListGroup.Item>Branch ID: <a href={`/explorer/branch/${txMetadata.branchID}`}>{resolveBase58BranchID(txMetadata.branchID)}</a></ListGroup.Item>
-                    <ListGroup.Item>Solid: {txMetadata.solid.toString()}</ListGroup.Item>
+                    <ListGroup.Item>SolidityType: {txMetadata.solidityType.toString()}</ListGroup.Item>
                     <ListGroup.Item>Solidification time: {new Date(txMetadata.solidificationTime * 1000).toLocaleString()}</ListGroup.Item>
                     <ListGroup.Item>Grade of Finality: {txMetadata.gradeOfFinality}</ListGroup.Item>
                     <ListGroup.Item>Grade of Finality Time: {new Date(txMetadata.gradeOfFinalityTime * 1000).toLocaleString()}</ListGroup.Item>
-                    <ListGroup.Item>Lazy booked: {txMetadata.lazyBooked.toString()}</ListGroup.Item>
                 </ListGroup>}
             </div>
         )

--- a/plugins/dashboard/frontend/src/app/stores/ExplorerStore.tsx
+++ b/plugins/dashboard/frontend/src/app/stores/ExplorerStore.tsx
@@ -86,7 +86,7 @@ export class OutputMetadata {
 
 class OutputConsumer {
     transactionID: string;
-    valid: string;
+    solidityType: string;
 }
 
 class OutputConsumers {

--- a/plugins/messagelayer/plugin.go
+++ b/plugins/messagelayer/plugin.go
@@ -181,14 +181,12 @@ func newTangle(deps tangledeps) *tangle.Tangle {
 		tangle.SyncTimeWindow(Parameters.TangleTimeWindow),
 		tangle.StartSynced(Parameters.StartSynced),
 		tangle.CacheTimeProvider(database.CacheTimeProvider()),
+		tangle.ConfirmationOracleFactory(finality.SimpleFinalityGadgetFactory()),
 	)
 
 	tangleInstance.Scheduler = tangle.NewScheduler(tangleInstance)
 	tangleInstance.WeightProvider = tangle.NewCManaWeightProvider(GetCMana, tangleInstance.TimeManager.Time, deps.Storage)
 	tangleInstance.OTVConsensusManager = tangle.NewOTVConsensusManager(otv.NewOnTangleVoting(tangleInstance.LedgerState.BranchDAG, tangleInstance.ApprovalWeightManager.WeightOfBranch))
-
-	finalityGadget = finality.NewSimpleFinalityGadget(tangleInstance)
-	tangleInstance.ConfirmationOracle = finalityGadget
 
 	tangleInstance.Setup()
 	return tangleInstance
@@ -309,7 +307,7 @@ func AwaitMessageToBeIssued(f func() (*tangle.Message, error), issuer ed25519.Pu
 	result := <-issueResult
 
 	if result.err != nil || result.msg == nil {
-		return nil, errors.Errorf("Failed to issue data %s: %w", result.msg.ID().Base58(), result.err)
+		return nil, errors.Errorf("Failed to issue data: %w", result.err)
 	}
 
 	ticker := time.NewTicker(maxAwait)

--- a/plugins/webapi/ledgerstate/plugin.go
+++ b/plugins/webapi/ledgerstate/plugin.go
@@ -298,7 +298,7 @@ func GetBranchSupporters(c echo.Context) (err error) {
 		return c.JSON(http.StatusBadRequest, jsonmodels.NewErrorResponse(err))
 	}
 
-	supporters := deps.Tangle.ApprovalWeightManager.SupportersOfBranch(branchID)
+	supporters := deps.Tangle.ApprovalWeightManager.SupportersOfAggregatedBranch(branchID)
 
 	return c.JSON(http.StatusOK, jsonmodels.NewGetBranchSupportersResponse(branchID, supporters))
 }

--- a/plugins/webapi/tools/message/diagnostic_branches.go
+++ b/plugins/webapi/tools/message/diagnostic_branches.go
@@ -91,7 +91,7 @@ var DiagnosticBranchesTableDescription = []string{
 	"ConflictSet",
 	"IssuanceTime",
 	"SolidTime",
-	"LazyBooked",
+	"SolidityType",
 	"GradeOfFinality",
 }
 
@@ -101,7 +101,7 @@ type DiagnosticBranchInfo struct {
 	ConflictSet       []string
 	IssuanceTimestamp time.Time
 	SolidTime         time.Time
-	LazyBooked        bool
+	SolidityType      string
 	GradeOfFinality   gof.GradeOfFinality
 }
 
@@ -127,7 +127,7 @@ func getDiagnosticConflictsInfo(branchID ledgerstate.BranchID) DiagnosticBranchI
 
 		deps.Tangle.LedgerState.TransactionMetadata(transactionID).Consume(func(transactionMetadata *ledgerstate.TransactionMetadata) {
 			conflictInfo.SolidTime = transactionMetadata.SolidificationTime()
-			conflictInfo.LazyBooked = transactionMetadata.LazyBooked()
+			conflictInfo.SolidityType = transactionMetadata.SolidityType().String()
 		})
 	})
 
@@ -140,7 +140,7 @@ func (d DiagnosticBranchInfo) toCSV() (result string) {
 		strings.Join(d.ConflictSet, ";"),
 		fmt.Sprint(d.IssuanceTimestamp.UnixNano()),
 		fmt.Sprint(d.SolidTime.UnixNano()),
-		fmt.Sprint(d.LazyBooked),
+		fmt.Sprint(d.SolidityType),
 	}
 
 	result = strings.Join(row, ",")

--- a/plugins/webapi/tools/message/diagnostic_utxoDAG.go
+++ b/plugins/webapi/tools/message/diagnostic_utxoDAG.go
@@ -63,7 +63,7 @@ var DiagnosticUTXODAGTableDescription = []string{
 	"Attachments",
 	"BranchID",
 	"Conflicting",
-	"LazyBooked",
+	"SolidityType",
 	"GradeOfFinality",
 	"GradeOfFinalityTime",
 }
@@ -83,7 +83,7 @@ type DiagnosticUTXODAGInfo struct {
 	// transaction metadata
 	BranchID            string
 	Conflicting         bool
-	LazyBooked          bool
+	SolidityType        string
 	GradeOfFinality     gof.GradeOfFinality
 	GradeOfFinalityTime time.Time
 }
@@ -110,7 +110,7 @@ func getDiagnosticUTXODAGInfo(transactionID ledgerstate.TransactionID, messageID
 		txInfo.BranchID = transactionMetadata.BranchID().String()
 
 		txInfo.Conflicting = deps.Tangle.LedgerState.TransactionConflicting(transactionID)
-		txInfo.LazyBooked = transactionMetadata.LazyBooked()
+		txInfo.SolidityType = transactionMetadata.SolidityType().String()
 		txInfo.GradeOfFinality = transactionMetadata.GradeOfFinality()
 		txInfo.GradeOfFinalityTime = transactionMetadata.GradeOfFinalityTime()
 	})
@@ -130,7 +130,7 @@ func (d DiagnosticUTXODAGInfo) toCSV() (result string) {
 		strings.Join(d.Attachments, ";"),
 		d.BranchID,
 		fmt.Sprint(d.Conflicting),
-		fmt.Sprint(d.LazyBooked),
+		fmt.Sprint(d.SolidityType),
 		fmt.Sprint(d.GradeOfFinality),
 		fmt.Sprint(d.GradeOfFinalityTime.UnixNano()),
 	}

--- a/tools/docker-network/docker-compose.yml
+++ b/tools/docker-network/docker-compose.yml
@@ -66,6 +66,10 @@ services:
     secrets:
       - goshimmer.config.json
       - goshimmer.message.snapshot.bin
+    ports:
+      - "8060:8080/tcp" # web API
+      - "8061:8081/tcp" # dashboard
+      - "6061:6061/tcp" # pprof
     networks:
       - shimmer
     depends_on:
@@ -103,6 +107,7 @@ services:
       --node.seed=base58:3YX6e7AL28hHihZewKdq6CMkEYVsTJBLgRiprUNiNq5E
       --node.overwriteStoredSeed=true
       --node.enablePlugins=bootstrap,"webAPIToolsEndpoint",faucet,activity
+      --node.seed=base58:3YX6e7AL28hHihZewKdq6CMkEYVsTJBLgRiprUNiNq5E
       --messageLayer.snapshot.file=/run/secrets/goshimmer.message.snapshot.bin
       --messageLayer.startSynced=true
       --faucet.seed=7R1itJx5hVuo9w9hjg5cwKFmek4HMSoBDgJZN8hKGxih

--- a/tools/integration-tests/tester/go.mod
+++ b/tools/integration-tests/tester/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/drand/drand v1.1.1
 	github.com/iotaledger/goshimmer v0.1.3
-	github.com/iotaledger/hive.go v0.0.0-20210821074123-831d7702ae07
+	github.com/iotaledger/hive.go v0.0.0-20211022130818-5eadd0c9157d
 	github.com/mr-tron/base58 v1.2.0
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/stretchr/testify v1.7.0

--- a/tools/integration-tests/tester/go.sum
+++ b/tools/integration-tests/tester/go.sum
@@ -421,8 +421,8 @@ github.com/hydrogen18/memlistener v0.0.0-20141126152155-54553eb933fb/go.mod h1:q
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/iotaledger/hive.go v0.0.0-20210821074123-831d7702ae07 h1:iqBuH88I1MJGpCTMngxwA46SeE4rX9QUBWCsQB++dZI=
-github.com/iotaledger/hive.go v0.0.0-20210821074123-831d7702ae07/go.mod h1:vZXMpgveUkATu1IueKmUJK3/OVgrYRQdH/Jh/yZ2j9Q=
+github.com/iotaledger/hive.go v0.0.0-20211022130818-5eadd0c9157d h1:c1kKNh3GxF0nJg4Y06AbiF48uRCrKC3x95N4GM+fBEI=
+github.com/iotaledger/hive.go v0.0.0-20211022130818-5eadd0c9157d/go.mod h1:qfpjDWmi+h7AAOkqjZslPHTNeQ7Gf7kTCdIOzbMyjhc=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.2/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.3/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=

--- a/tools/integration-tests/tester/tests/consensus/consensus_test.go
+++ b/tools/integration-tests/tester/tests/consensus/consensus_test.go
@@ -5,6 +5,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/iotaledger/hive.go/bitmask"
+	"github.com/mr-tron/base58"
+	"github.com/stretchr/testify/require"
+
 	"github.com/iotaledger/goshimmer/client/wallet"
 	"github.com/iotaledger/goshimmer/client/wallet/packages/address"
 	walletseed "github.com/iotaledger/goshimmer/client/wallet/packages/seed"
@@ -14,9 +18,6 @@ import (
 	"github.com/iotaledger/goshimmer/tools/integration-tests/tester/framework"
 	"github.com/iotaledger/goshimmer/tools/integration-tests/tester/framework/config"
 	"github.com/iotaledger/goshimmer/tools/integration-tests/tester/tests"
-	"github.com/iotaledger/hive.go/bitmask"
-	"github.com/mr-tron/base58"
-	"github.com/stretchr/testify/require"
 )
 
 // TestSimpleDoubleSpend tests whether consensus is able to resolve a simple double spend.
@@ -51,7 +52,7 @@ func TestSimpleDoubleSpend(t *testing.T) {
 
 	ctx, cancel := tests.Context(context.Background(), t)
 	defer cancel()
-	n, err := f.CreateNetwork(ctx, "test_simple_double_spend", 2, framework.CreateNetworkConfig{
+	n, err := f.CreateNetwork(ctx, t.Name(), 2, framework.CreateNetworkConfig{
 		StartSynced: true,
 		Faucet:      false,
 		Activity:    false,
@@ -107,11 +108,11 @@ func TestSimpleDoubleSpend(t *testing.T) {
 	tests.RequireGradeOfFinalityEqual(t, n.Peers(), tests.ExpectedTxsStates{
 		tx1.ID().Base58(): {
 			GradeOfFinality: tests.GoFPointer(gof.High),
-			Solid:           tests.True(),
+			SolidityType:    tests.Solid(),
 		},
 		tx2.ID().Base58(): {
 			GradeOfFinality: tests.GoFPointer(gof.None),
-			Solid:           tests.True(),
+			SolidityType:    tests.Solid(),
 		},
 	}, time.Minute, tests.Tick)
 
@@ -136,7 +137,7 @@ func sendConflictingTx(t *testing.T, wallet *wallet.Wallet, targetAddr address.A
 	tests.RequireGradeOfFinalityEqual(t, []*framework.Node{node}, tests.ExpectedTxsStates{
 		tx.ID().Base58(): {
 			GradeOfFinality: tests.GoFPointer(expectedGoF),
-			Solid:           tests.True(),
+			SolidityType:    tests.Solid(),
 		},
 	}, time.Minute, tests.Tick)
 	return tx

--- a/tools/integration-tests/tester/tests/diagnostics/diagnostics_test.go
+++ b/tools/integration-tests/tester/tests/diagnostics/diagnostics_test.go
@@ -24,12 +24,12 @@ var (
 	tipsHeader = messageHeader
 
 	branchesHeader = []string{
-		"ID", "ConflictSet", "IssuanceTime", "SolidTime", "LazyBooked", "GradeOfFinality",
+		"ID", "ConflictSet", "IssuanceTime", "SolidTime", "SolidityType", "GradeOfFinality",
 	}
 
 	utxoDagHeader = []string{
 		"ID", "IssuanceTime", "SolidTime", "AccessManaPledgeID",
-		"ConsensusManaPledgeID", "Inputs", "Outputs", "Attachments", "BranchID", "Conflicting", "LazyBooked",
+		"ConsensusManaPledgeID", "Inputs", "Outputs", "Attachments", "BranchID", "Conflicting", "SolidityType",
 		"GradeOfFinality", "GradeOfFinalityTime",
 	}
 

--- a/tools/integration-tests/tester/tests/testutil.go
+++ b/tools/integration-tests/tester/tests/testutil.go
@@ -353,7 +353,7 @@ type ExpectedState struct {
 	// The optional grade of finality state to check against.
 	GradeOfFinality *gof.GradeOfFinality
 	// The optional solid state to check against.
-	Solid *bool
+	SolidityType *string
 }
 
 // True returns a pointer to a true bool.
@@ -365,6 +365,18 @@ func True() *bool {
 // False returns a pointer to a false bool.
 func False() *bool {
 	x := false
+	return &x
+}
+
+// Solid returns a pointer to a solid SolidityType.
+func Solid() *string {
+	x := ledgerstate.Solid.String()
+	return &x
+}
+
+// LazySolid returns a pointer to a lazySolid SolidityType.
+func LazySolid() *string {
+	x := ledgerstate.LazySolid.String()
 	return &x
 }
 
@@ -457,7 +469,7 @@ func txMetadataStateEqual(t *testing.T, node *framework.Node, txID string, expIn
 	require.NoErrorf(t, err, "node=%s, txID=%, 'GetTransactionMetadata' failed")
 
 	if (expInclState.GradeOfFinality != nil && *expInclState.GradeOfFinality != metadata.GradeOfFinality) ||
-		(expInclState.Solid != nil && *expInclState.Solid != metadata.Solid) {
+		(expInclState.SolidityType != nil && *expInclState.SolidityType != metadata.SolidityType) {
 		return false
 	}
 	return true


### PR DESCRIPTION
# Description of change

This PR modifies the solidification logic to not solidify past weak parents. This allows us to use the weak parents as a way to exclude undesired messages from the tangle (e.g. as part of the congestion control).

It introduces the following changes to the definition of being solid:

1. A message is solid, if its strong parents are solid and its weak parents are at least weakly solid.
2. A message is weakly solid if it either has a data payload or if its weak parents are at least weakly solid.
3. A message is invalid if any of its weak parents doesn't pass the parents age check, or if it doesn't have weak parents and its strong parents don't pass the parents age check.

If the Solidifier requests missing weak parents, then he skips downloading their strong past cone unless another message references the same message with a strong parent.

The UTXODAG now also has a concept of Solidity and instead of booking the Transactions, we just store them and let them wait to become solid (we do not actively request transactions).

Messages only become solid after their transaction has become solid, which means that by the time we reach the Booker, the Transaction is already fully booked and associated to a branch.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
