### PR TITLE
Fix wiki deploy

### DIFF
--- a/documentation/docs/protocol_specification/components/tangle.md
+++ b/documentation/docs/protocol_specification/components/tangle.md
@@ -179,7 +179,6 @@ BLAKE2b-256 hash of the byte contents of the message. It should be used by the n
                         </td>
                     </tr>
                     <tr>
-                    <tr>
                         <td>Reference <code>between(1,8)</code></td>
                         <td>ByteArray[32]</td>
                         <td>Reference to a Message ID.</td>
@@ -218,6 +217,8 @@ BLAKE2b-256 hash of the byte contents of the message. It should be used by the n
                     </tr>
                 </table>
             </details>
+        </td>
+    </tr>
     <tr>
         <td>Issuer public key (Ed25519)</td>
         <td>ByteArray[32]</td>
@@ -268,7 +269,7 @@ BLAKE2b-256 hash of the byte contents of the message. It should be used by the n
                     </tr>
                 </table>
             </details>
-            </td>
+        </td>
     </tr>
     <tr>
         <td>Nonce</td>


### PR DESCRIPTION
# Description of change

This PR adds missing HTML tags and fixes the wiki deploy action. 
https://github.com/iota-community/iota-wiki/runs/4099830394?check_suite_focus=true

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Documentation Fix

## How the change has been tested

Tested locally

