### PR TITLE
analysis-server -> bootstrap correct port

### DIFF
--- a/deploy/ansible/roles/goshimmer-node/templates/docker-compose-analysis-server.yml.j2
+++ b/deploy/ansible/roles/goshimmer-node/templates/docker-compose-analysis-server.yml.j2
@@ -21,7 +21,7 @@ services:
       --analysis.client.serverAddress=
       --analysis.server.bindAddress=0.0.0.0:21888
       --analysis.dashboard.bindAddress=0.0.0.0:28080
-      --analysis.dashboard.manaDashboardAddress="http://{{ manaDashboardHost }}:9001"
+      --analysis.dashboard.manaDashboardAddress="http://{{ manaDashboardHost }}:8081"
       --prometheus.bindAddress=0.0.0.0:9312
       --metrics.local=false
       --metrics.global=true

--- a/deploy/ansible/roles/goshimmer-node/templates/docker-compose-goshimmer.yml.j2
+++ b/deploy/ansible/roles/goshimmer-node/templates/docker-compose-goshimmer.yml.j2
@@ -28,7 +28,11 @@ services:
       # HTTP API
       - "127.0.0.1:8080:8080/tcp"
       # Dashboard
+      {% if bootstrap|default(false) %}
+      - "0.0.0.0:8081:8081/tcp"
+      {% else %}
       - "127.0.0.1:8081:8081/tcp"
+      {% endif %}
       # pprof profiling
       - "127.0.0.1:6061:6061/tcp"
     {% endif %}


### PR DESCRIPTION
# Description of change

Ports for goshimmer nodes have been remapped, but the analysis-server link to the bootstrap node to obtain metrics was not.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)