### PR TITLE
Feat: Reworked Requester and Solidification

### DIFF
--- a/packages/gossip/neighbor.go
+++ b/packages/gossip/neighbor.go
@@ -12,10 +12,6 @@ import (
 	"github.com/iotaledger/hive.go/netutil"
 	"github.com/iotaledger/hive.go/netutil/buffconn"
 	"go.uber.org/atomic"
-	"google.golang.org/protobuf/proto"
-
-	pb "github.com/iotaledger/goshimmer/packages/gossip/proto"
-	"github.com/iotaledger/goshimmer/packages/tangle"
 )
 
 const (
@@ -122,19 +118,7 @@ func (n *Neighbor) writeLoop() {
 				continue
 			}
 
-			packet := new(pb.MessageRequest)
-			if err := proto.Unmarshal(msg[1:], packet); err != nil {
-				n.log.Debugw("invalid packet", "err", err)
-				return
-			}
-
-			msgID, _, err := tangle.MessageIDFromBytes(packet.GetId())
-			if err != nil {
-				n.log.Debugw("invalid message id:", "err", err)
-				return
-			}
-
-			n.log.Infof("popped request for %s from queue / remaining size %d", msgID, len(n.queue))
+			n.log.Infof("popped request from queue / remaining size %d: ", len(n.queue))
 
 			if _, err := n.BufferedConnection.Write(msg); err != nil {
 				n.log.Warnw("Write error", "err", err)

--- a/packages/gossip/neighbor.go
+++ b/packages/gossip/neighbor.go
@@ -117,6 +117,9 @@ func (n *Neighbor) writeLoop() {
 			if len(msg) == 0 {
 				continue
 			}
+
+			n.log.Debugf("popped request from queue / remaining size %d: ", len(n.queue))
+
 			if _, err := n.BufferedConnection.Write(msg); err != nil {
 				n.log.Warnw("Write error", "err", err)
 				_ = n.disconnect()

--- a/packages/gossip/neighbor.go
+++ b/packages/gossip/neighbor.go
@@ -12,6 +12,10 @@ import (
 	"github.com/iotaledger/hive.go/netutil"
 	"github.com/iotaledger/hive.go/netutil/buffconn"
 	"go.uber.org/atomic"
+	"google.golang.org/protobuf/proto"
+
+	pb "github.com/iotaledger/goshimmer/packages/gossip/proto"
+	"github.com/iotaledger/goshimmer/packages/tangle"
 )
 
 const (
@@ -118,7 +122,19 @@ func (n *Neighbor) writeLoop() {
 				continue
 			}
 
-			n.log.Infof("popped request from queue / remaining size %d: ", len(n.queue))
+			packet := new(pb.MessageRequest)
+			if err := proto.Unmarshal(msg[1:], packet); err != nil {
+				n.log.Debugw("invalid packet", "err", err)
+				return
+			}
+
+			msgID, _, err := tangle.MessageIDFromBytes(packet.GetId())
+			if err != nil {
+				n.log.Debugw("invalid message id:", "err", err)
+				return
+			}
+
+			n.log.Infof("popped request for %s from queue / remaining size %d", msgID, len(n.queue))
 
 			if _, err := n.BufferedConnection.Write(msg); err != nil {
 				n.log.Warnw("Write error", "err", err)

--- a/packages/gossip/neighbor.go
+++ b/packages/gossip/neighbor.go
@@ -118,7 +118,7 @@ func (n *Neighbor) writeLoop() {
 				continue
 			}
 
-			n.log.Debugf("popped request from queue / remaining size %d: ", len(n.queue))
+			n.log.Infof("popped request from queue / remaining size %d: ", len(n.queue))
 
 			if _, err := n.BufferedConnection.Write(msg); err != nil {
 				n.log.Warnw("Write error", "err", err)

--- a/packages/jsonmodels/tools.go
+++ b/packages/jsonmodels/tools.go
@@ -18,3 +18,9 @@ type MissingResponse struct {
 	IDs   []string `json:"ids,omitempty"`
 	Count int      `json:"count,omitempty"`
 }
+
+// MissingAvailableResponse is a map of messageIDs with the peers that have such message
+type MissingAvailableResponse struct {
+	Availability map[string][]string `json:"msgavailability",omitempty`
+	Count        int                 `json:"count"`
+}

--- a/packages/jsonmodels/tools.go
+++ b/packages/jsonmodels/tools.go
@@ -21,6 +21,6 @@ type MissingResponse struct {
 
 // MissingAvailableResponse is a map of messageIDs with the peers that have such message.
 type MissingAvailableResponse struct {
-	Availability map[string][]string `json:"msgavailability,omitempty""`
+	Availability map[string][]string `json:"msgavailability,omitempty"`
 	Count        int                 `json:"count"`
 }

--- a/packages/jsonmodels/tools.go
+++ b/packages/jsonmodels/tools.go
@@ -19,8 +19,8 @@ type MissingResponse struct {
 	Count int      `json:"count,omitempty"`
 }
 
-// MissingAvailableResponse is a map of messageIDs with the peers that have such message
+// MissingAvailableResponse is a map of messageIDs with the peers that have such message.
 type MissingAvailableResponse struct {
-	Availability map[string][]string `json:"msgavailability",omitempty`
+	Availability map[string][]string `json:"msgavailability,omitempty""`
 	Count        int                 `json:"count"`
 }

--- a/packages/tangle/requester.go
+++ b/packages/tangle/requester.go
@@ -145,6 +145,7 @@ func (r *Requester) reRequest(id MessageID, count int) {
 			delete(r.scheduledRequests, id)
 
 			r.Events.RequestFailed.Trigger(id)
+			r.tangle.Storage.DeleteMissingMessage(id)
 
 			return
 		}

--- a/packages/tangle/requester.go
+++ b/packages/tangle/requester.go
@@ -64,7 +64,7 @@ func NewRequester(tangle *Tangle, optionalOptions ...RequesterOption) *Requester
 		scheduledRequests: make(map[MessageID]*timedexecutor.ScheduledTask),
 		options:           newRequesterOptions(optionalOptions),
 		Events: &MessageRequesterEvents{
-			SendRequest:    events.NewEvent(sendRequestEventHandler),
+			RequestIssued:  events.NewEvent(sendRequestEventHandler),
 			RequestStarted: events.NewEvent(MessageIDCaller),
 			RequestStopped: events.NewEvent(MessageIDCaller),
 			RequestFailed:  events.NewEvent(MessageIDCaller),
@@ -128,7 +128,7 @@ func (r *Requester) StopRequest(id MessageID) {
 }
 
 func (r *Requester) reRequest(id MessageID, count int) {
-	r.Events.SendRequest.Trigger(&SendRequestEvent{ID: id})
+	r.Events.RequestIssued.Trigger(&SendRequestEvent{ID: id})
 
 	// as we schedule a request at most once per id we do not need to make the trigger and the re-schedule atomic
 	r.scheduledRequestsMutex.Lock()
@@ -170,8 +170,9 @@ func (r *Requester) createReRequest(msgID MessageID, count int) func() {
 
 // MessageRequesterEvents represents events happening on a message requester.
 type MessageRequesterEvents struct {
-	// Fired when a request for a given message should be sent.
-	SendRequest *events.Event
+	// RequestIssued is an event that is triggered when the requester wants to request the given Message from its
+	// neighbors.
+	RequestIssued *events.Event
 
 	// RequestStarted is an event that is triggered when a new request is started.
 	RequestStarted *events.Event

--- a/packages/tangle/requester.go
+++ b/packages/tangle/requester.go
@@ -60,6 +60,7 @@ type Requester struct {
 func NewRequester(tangle *Tangle, optionalOptions ...RequesterOption) *Requester {
 	requester := &Requester{
 		tangle:            tangle,
+		timedExecutor:     timedexecutor.New(1),
 		scheduledRequests: make(map[MessageID]*timedexecutor.ScheduledTask),
 		options:           newRequesterOptions(optionalOptions),
 		Events: &MessageRequesterEvents{

--- a/packages/tangle/requester.go
+++ b/packages/tangle/requester.go
@@ -16,8 +16,8 @@ type Requester struct {
 	tangle            *Tangle
 	timedExecutor     *timedexecutor.TimedExecutor
 	scheduledRequests map[MessageID]*timedexecutor.ScheduledTask
-	options           *RequesterOptions
-	Events            *RequesterEvents
+	options           RequesterOptions
+	Events            RequesterEvents
 
 	scheduledRequestsMutex sync.RWMutex
 }
@@ -29,7 +29,7 @@ func NewRequester(tangle *Tangle, optionalOptions ...RequesterOption) *Requester
 		timedExecutor:     timedexecutor.New(1),
 		scheduledRequests: make(map[MessageID]*timedexecutor.ScheduledTask),
 		options:           DefaultRequesterOptions.Apply(optionalOptions...),
-		Events: &RequesterEvents{
+		Events: RequesterEvents{
 			RequestIssued:  events.NewEvent(sendRequestEventHandler),
 			RequestStarted: events.NewEvent(MessageIDCaller),
 			RequestStopped: events.NewEvent(MessageIDCaller),
@@ -159,13 +159,13 @@ type RequesterOptions struct {
 }
 
 // Apply applies the optional Options to the RequesterOptions.
-func (r *RequesterOptions) Apply(optionalOptions ...RequesterOption) (options *RequesterOptions) {
-	*options = *r
+func (r RequesterOptions) Apply(optionalOptions ...RequesterOption) (updatedOptions RequesterOptions) {
+	updatedOptions = r
 	for _, optionalOption := range optionalOptions {
-		optionalOption(options)
+		optionalOption(&updatedOptions)
 	}
 
-	return options
+	return updatedOptions
 }
 
 // RequesterOption is a function which inits an option.

--- a/packages/tangle/requester.go
+++ b/packages/tangle/requester.go
@@ -95,6 +95,7 @@ func (r *Requester) Shutdown() {
 
 // StartRequest initiates a regular triggering of the StartRequest event until it has been stopped using StopRequest.
 func (r *Requester) StartRequest(id MessageID) {
+
 	r.scheduledRequestsMutex.Lock()
 
 	// ignore already scheduled requests

--- a/packages/tangle/requester.go
+++ b/packages/tangle/requester.go
@@ -154,7 +154,7 @@ type RequesterOptions struct {
 	RetryJitter int
 
 	// MaxRequestThreshold represents an option which defines how often the Requester should try to request messages
-	// before cancelling the request
+	// before canceling the request
 	MaxRequestThreshold int
 }
 
@@ -186,7 +186,7 @@ func RetryJitter(jitter int) RequesterOption {
 }
 
 // MaxRequestThreshold creates an option which defines how often the Requester should try to request messages before
-// cancelling the request.
+// canceling the request.
 func MaxRequestThreshold(maxRequestThreshold int) RequesterOption {
 	return func(args *RequesterOptions) {
 		args.MaxRequestThreshold = maxRequestThreshold

--- a/packages/tangle/requester.go
+++ b/packages/tangle/requester.go
@@ -95,7 +95,6 @@ func (r *Requester) Shutdown() {
 
 // StartRequest initiates a regular triggering of the StartRequest event until it has been stopped using StopRequest.
 func (r *Requester) StartRequest(id MessageID) {
-
 	r.scheduledRequestsMutex.Lock()
 
 	// ignore already scheduled requests

--- a/packages/tangle/requester.go
+++ b/packages/tangle/requester.go
@@ -108,6 +108,7 @@ func (r *Requester) StartRequest(id MessageID) {
 	r.scheduledRequestsMutex.Unlock()
 
 	r.Events.RequestStarted.Trigger(id)
+	r.Events.RequestIssued.Trigger(&SendRequestEvent{ID: id})
 }
 
 // StopRequest stops requests for the given message to further happen.

--- a/packages/tangle/solidifier.go
+++ b/packages/tangle/solidifier.go
@@ -1,6 +1,7 @@
 package tangle
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/iotaledger/hive.go/datastructure/walker"
@@ -111,8 +112,14 @@ func (s *Solidifier) isMessageMarkedAsSolid(messageID MessageID) (solid bool) {
 	}
 
 	s.tangle.Storage.MessageMetadata(messageID, func() *MessageMetadata {
+		fmt.Printf("tried to check solidity of missing Message with %s\n", messageID)
+
 		if cachedMissingMessage, stored := s.tangle.Storage.StoreMissingMessage(NewMissingMessage(messageID)); stored {
+			fmt.Printf("created  MissingMessage for Message with %s\n", messageID)
+
 			cachedMissingMessage.Consume(func(missingMessage *MissingMessage) {
+				fmt.Printf("triggering MessageMissing for Message with %s\n", messageID)
+
 				s.Events.MessageMissing.Trigger(messageID)
 			})
 		}

--- a/packages/tangle/solidifier.go
+++ b/packages/tangle/solidifier.go
@@ -2,6 +2,7 @@ package tangle
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/iotaledger/hive.go/datastructure/walker"
@@ -112,13 +113,13 @@ func (s *Solidifier) isMessageMarkedAsSolid(messageID MessageID) (solid bool) {
 	}
 
 	s.tangle.Storage.MessageMetadata(messageID, func() *MessageMetadata {
-		fmt.Printf("tried to check solidity of missing Message with %s\n", messageID)
+		fmt.Fprintf(os.Stderr, "tried to check solidity of missing Message with %s\n", messageID)
 
 		if cachedMissingMessage, stored := s.tangle.Storage.StoreMissingMessage(NewMissingMessage(messageID)); stored {
-			fmt.Printf("created MissingMessage for Message with %s\n", messageID)
+			fmt.Fprintf(os.Stderr, "created MissingMessage for Message with %s\n", messageID)
 
 			cachedMissingMessage.Consume(func(missingMessage *MissingMessage) {
-				fmt.Printf("triggering MessageMissing for Message with %s\n", messageID)
+				fmt.Fprintf(os.Stderr, "triggering MessageMissing for Message with %s\n", messageID)
 
 				s.Events.MessageMissing.Trigger(messageID)
 			})

--- a/packages/tangle/solidifier.go
+++ b/packages/tangle/solidifier.go
@@ -115,7 +115,7 @@ func (s *Solidifier) isMessageMarkedAsSolid(messageID MessageID) (solid bool) {
 		fmt.Printf("tried to check solidity of missing Message with %s\n", messageID)
 
 		if cachedMissingMessage, stored := s.tangle.Storage.StoreMissingMessage(NewMissingMessage(messageID)); stored {
-			fmt.Printf("created  MissingMessage for Message with %s\n", messageID)
+			fmt.Printf("created MissingMessage for Message with %s\n", messageID)
 
 			cachedMissingMessage.Consume(func(missingMessage *MissingMessage) {
 				fmt.Printf("triggering MessageMissing for Message with %s\n", messageID)

--- a/packages/tangle/solidifier.go
+++ b/packages/tangle/solidifier.go
@@ -51,6 +51,25 @@ func (s *Solidifier) Solidify(messageID MessageID) {
 	s.tangle.Utils.WalkMessageAndMetadata(s.checkMessageSolidity, MessageIDs{messageID}, true)
 }
 
+// RetrieveMissingMessage checks if the message is missing and triggers the corresponding events to request it. It returns true if the message has been missing.
+func (s *Solidifier) RetrieveMissingMessage(messageID MessageID) (messageWasMissing bool) {
+	s.tangle.Storage.MessageMetadata(messageID, func() *MessageMetadata {
+		fmt.Fprintf(os.Stderr, "tried to check if Message with %s is missing\n", messageID)
+
+		if cachedMissingMessage, stored := s.tangle.Storage.StoreMissingMessage(NewMissingMessage(messageID)); stored {
+			cachedMissingMessage.Release()
+			fmt.Fprintf(os.Stderr, "created MissingMessage for Message with %s\n", messageID)
+
+			messageWasMissing = true
+			s.Events.MessageMissing.Trigger(messageID)
+		}
+
+		return nil
+	}).Release()
+
+	return messageWasMissing
+}
+
 // checkMessageSolidity checks if the given Message is solid and eventually queues its Approvers to also be checked.
 func (s *Solidifier) checkMessageSolidity(message *Message, messageMetadata *MessageMetadata, walker *walker.Walker) {
 	if !s.isMessageSolid(message, messageMetadata) {
@@ -112,23 +131,11 @@ func (s *Solidifier) isMessageMarkedAsSolid(messageID MessageID) (solid bool) {
 		return true
 	}
 
-	s.tangle.Storage.MessageMetadata(messageID, func() *MessageMetadata {
-		fmt.Fprintf(os.Stderr, "tried to check solidity of missing Message with %s\n", messageID)
+	if s.RetrieveMissingMessage(messageID) {
+		return false
+	}
 
-		if cachedMissingMessage, stored := s.tangle.Storage.StoreMissingMessage(NewMissingMessage(messageID)); stored {
-			fmt.Fprintf(os.Stderr, "created MissingMessage for Message with %s\n", messageID)
-
-			cachedMissingMessage.Consume(func(missingMessage *MissingMessage) {
-				fmt.Fprintf(os.Stderr, "triggering MessageMissing for Message with %s\n", messageID)
-
-				s.Events.MessageMissing.Trigger(messageID)
-			})
-		}
-
-		// do not initialize the metadata here, we execute this in the optional ComputeIfAbsent callback to be secure
-		// from race conditions
-		return nil
-	}).Consume(func(messageMetadata *MessageMetadata) {
+	s.tangle.Storage.MessageMetadata(messageID).Consume(func(messageMetadata *MessageMetadata) {
 		solid = messageMetadata.IsSolid()
 	})
 

--- a/packages/tangle/storage.go
+++ b/packages/tangle/storage.go
@@ -208,6 +208,7 @@ func (s *Storage) Approvers(messageID MessageID, optionalApproverType ...Approve
 
 // StoreMissingMessage stores a new MissingMessage entry in the object storage.
 func (s *Storage) StoreMissingMessage(missingMessage *MissingMessage) (cachedMissingMessage *CachedMissingMessage, stored bool) {
+	fmt.Println(">> Storing missing message", missingMessage.messageID)
 	cachedObject, stored := s.missingMessageStorage.StoreIfAbsent(missingMessage)
 	cachedMissingMessage = &CachedMissingMessage{CachedObject: cachedObject}
 

--- a/packages/tangle/storage.go
+++ b/packages/tangle/storage.go
@@ -10,7 +10,6 @@ import (
 	"github.com/iotaledger/hive.go/byteutils"
 	"github.com/iotaledger/hive.go/cerrors"
 	"github.com/iotaledger/hive.go/events"
-	"github.com/iotaledger/hive.go/kvstore/debug"
 	"github.com/iotaledger/hive.go/marshalutil"
 	"github.com/iotaledger/hive.go/objectstorage"
 	"github.com/iotaledger/hive.go/stringify"
@@ -101,7 +100,7 @@ func NewStorage(tangle *Tangle) (storage *Storage) {
 		messageStorage:                    osFactory.New(PrefixMessage, MessageFromObjectStorage, cacheProvider.CacheTime(cacheTime), objectstorage.LeakDetectionEnabled(false), objectstorage.StoreOnCreation(true)),
 		messageMetadataStorage:            osFactory.New(PrefixMessageMetadata, MessageMetadataFromObjectStorage, cacheProvider.CacheTime(cacheTime), objectstorage.LeakDetectionEnabled(false)),
 		approverStorage:                   osFactory.New(PrefixApprovers, ApproverFromObjectStorage, cacheProvider.CacheTime(cacheTime), objectstorage.PartitionKey(MessageIDLength, ApproverTypeLength, MessageIDLength), objectstorage.LeakDetectionEnabled(false), objectstorage.StoreOnCreation(true)),
-		missingMessageStorage:             osFactory.New(PrefixMissingMessage, MissingMessageFromObjectStorage, cacheProvider.CacheTime(cacheTime), objectstorage.LeakDetectionEnabled(false), objectstorage.StoreOnCreation(true), objectstorage.LogAccess("missingMessages.txt", debug.AllCommands)),
+		missingMessageStorage:             osFactory.New(PrefixMissingMessage, MissingMessageFromObjectStorage, cacheProvider.CacheTime(cacheTime), objectstorage.LeakDetectionEnabled(false), objectstorage.StoreOnCreation(true)),
 		attachmentStorage:                 osFactory.New(PrefixAttachments, AttachmentFromObjectStorage, cacheProvider.CacheTime(cacheTime), objectstorage.PartitionKey(ledgerstate.TransactionIDLength, MessageIDLength), objectstorage.LeakDetectionEnabled(false), objectstorage.StoreOnCreation(true)),
 		markerIndexBranchIDMappingStorage: osFactory.New(PrefixMarkerBranchIDMapping, MarkerIndexBranchIDMappingFromObjectStorage, cacheProvider.CacheTime(cacheTime), objectstorage.LeakDetectionEnabled(false)),
 		individuallyMappedMessageStorage:  osFactory.New(PrefixIndividuallyMappedMessage, IndividuallyMappedMessageFromObjectStorage, cacheProvider.CacheTime(cacheTime), IndividuallyMappedMessagePartitionKeys, objectstorage.LeakDetectionEnabled(false), objectstorage.StoreOnCreation(true)),

--- a/packages/tangle/storage.go
+++ b/packages/tangle/storage.go
@@ -9,6 +9,7 @@ import (
 	"github.com/iotaledger/hive.go/byteutils"
 	"github.com/iotaledger/hive.go/cerrors"
 	"github.com/iotaledger/hive.go/events"
+	"github.com/iotaledger/hive.go/kvstore/debug"
 	"github.com/iotaledger/hive.go/marshalutil"
 	"github.com/iotaledger/hive.go/objectstorage"
 	"github.com/iotaledger/hive.go/stringify"
@@ -99,7 +100,7 @@ func NewStorage(tangle *Tangle) (storage *Storage) {
 		messageStorage:                    osFactory.New(PrefixMessage, MessageFromObjectStorage, cacheProvider.CacheTime(cacheTime), objectstorage.LeakDetectionEnabled(false), objectstorage.StoreOnCreation(true)),
 		messageMetadataStorage:            osFactory.New(PrefixMessageMetadata, MessageMetadataFromObjectStorage, cacheProvider.CacheTime(cacheTime), objectstorage.LeakDetectionEnabled(false)),
 		approverStorage:                   osFactory.New(PrefixApprovers, ApproverFromObjectStorage, cacheProvider.CacheTime(cacheTime), objectstorage.PartitionKey(MessageIDLength, ApproverTypeLength, MessageIDLength), objectstorage.LeakDetectionEnabled(false), objectstorage.StoreOnCreation(true)),
-		missingMessageStorage:             osFactory.New(PrefixMissingMessage, MissingMessageFromObjectStorage, cacheProvider.CacheTime(cacheTime), objectstorage.LeakDetectionEnabled(false), objectstorage.StoreOnCreation(true)),
+		missingMessageStorage:             osFactory.New(PrefixMissingMessage, MissingMessageFromObjectStorage, cacheProvider.CacheTime(cacheTime), objectstorage.LeakDetectionEnabled(false), objectstorage.StoreOnCreation(true), objectstorage.LogAccess("missingMessages.txt", debug.AllCommands)),
 		attachmentStorage:                 osFactory.New(PrefixAttachments, AttachmentFromObjectStorage, cacheProvider.CacheTime(cacheTime), objectstorage.PartitionKey(ledgerstate.TransactionIDLength, MessageIDLength), objectstorage.LeakDetectionEnabled(false), objectstorage.StoreOnCreation(true)),
 		markerIndexBranchIDMappingStorage: osFactory.New(PrefixMarkerBranchIDMapping, MarkerIndexBranchIDMappingFromObjectStorage, cacheProvider.CacheTime(cacheTime), objectstorage.LeakDetectionEnabled(false)),
 		individuallyMappedMessageStorage:  osFactory.New(PrefixIndividuallyMappedMessage, IndividuallyMappedMessageFromObjectStorage, cacheProvider.CacheTime(cacheTime), IndividuallyMappedMessagePartitionKeys, objectstorage.LeakDetectionEnabled(false), objectstorage.StoreOnCreation(true)),

--- a/packages/tangle/storage.go
+++ b/packages/tangle/storage.go
@@ -2,6 +2,7 @@ package tangle
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 	"time"
 
@@ -208,7 +209,7 @@ func (s *Storage) Approvers(messageID MessageID, optionalApproverType ...Approve
 
 // StoreMissingMessage stores a new MissingMessage entry in the object storage.
 func (s *Storage) StoreMissingMessage(missingMessage *MissingMessage) (cachedMissingMessage *CachedMissingMessage, stored bool) {
-	fmt.Println(">> Storing missing message", missingMessage.messageID)
+	fmt.Fprintln(os.Stderr, ">> Storing missing message", missingMessage.messageID)
 	cachedObject, stored := s.missingMessageStorage.StoreIfAbsent(missingMessage)
 	cachedMissingMessage = &CachedMissingMessage{CachedObject: cachedObject}
 

--- a/packages/tangle/tangle.go
+++ b/packages/tangle/tangle.go
@@ -169,6 +169,7 @@ func (t *Tangle) Prune() (err error) {
 
 // Shutdown marks the tangle as stopped, so it will not accept any new messages (waits for all backgroundTasks to finish).
 func (t *Tangle) Shutdown() {
+	t.Requester.Shutdown()
 	t.Parser.Shutdown()
 	t.MessageFactory.Shutdown()
 	t.Scheduler.Shutdown()

--- a/plugins/gossip/gossip.go
+++ b/plugins/gossip/gossip.go
@@ -39,7 +39,7 @@ func createManager(lPeer *peer.Local, t *tangle.Tangle) *gossip.Manager {
 		cachedMessage := t.Storage.Message(msgID)
 		defer cachedMessage.Release()
 		if !cachedMessage.Exists() {
-			if false && crypto.Randomness.Float64() < Parameters.MissingMessageRequestRelayProbability {
+			if crypto.Randomness.Float64() < Parameters.MissingMessageRequestRelayProbability {
 				t.Solidifier.RetrieveMissingMessage(msgID)
 			}
 

--- a/plugins/gossip/gossip.go
+++ b/plugins/gossip/gossip.go
@@ -39,7 +39,7 @@ func createManager(lPeer *peer.Local, t *tangle.Tangle) *gossip.Manager {
 		cachedMessage := t.Storage.Message(msgID)
 		defer cachedMessage.Release()
 		if !cachedMessage.Exists() {
-			if crypto.Randomness.Float64() < Parameters.MissingMessageRequestRelayProbability {
+			if false && crypto.Randomness.Float64() < Parameters.MissingMessageRequestRelayProbability {
 				t.Solidifier.RetrieveMissingMessage(msgID)
 			}
 

--- a/plugins/gossip/gossip.go
+++ b/plugins/gossip/gossip.go
@@ -35,8 +35,7 @@ func createManager(lPeer *peer.Local, t *tangle.Tangle) *gossip.Manager {
 		Plugin.LogFatalf("could not update services: %s", err)
 	}
 
-	var gossipManager *gossip.Manager
-	gossipManager = gossip.NewManager(lPeer, func(msgID tangle.MessageID) ([]byte, error) {
+	return gossip.NewManager(lPeer, func(msgID tangle.MessageID) ([]byte, error) {
 		cachedMessage := t.Storage.Message(msgID)
 		defer cachedMessage.Release()
 		if !cachedMessage.Exists() {
@@ -49,8 +48,6 @@ func createManager(lPeer *peer.Local, t *tangle.Tangle) *gossip.Manager {
 		msg := cachedMessage.Unwrap()
 		return msg.Bytes(), nil
 	}, Plugin.Logger())
-
-	return gossipManager
 }
 
 func start(ctx context.Context) {

--- a/plugins/gossip/parameters.go
+++ b/plugins/gossip/parameters.go
@@ -8,6 +8,9 @@ import (
 type ParametersDefinition struct {
 	// BindAddress defines on which address the gossip service should listen.
 	BindAddress string `default:"0.0.0.0:14666" usage:"the bind address for the gossip"`
+
+	// MissingMessageRequestRelayProbability defines the probability of missing message requests being relayed to other neighbors.
+	MissingMessageRequestRelayProbability float64 `default:"0.1" usage:"the probability of missing message requests being relayed to other neighbors"`
 }
 
 // Parameters contains the configuration parameters of the gossip plugin.

--- a/plugins/gossip/plugin.go
+++ b/plugins/gossip/plugin.go
@@ -65,13 +65,13 @@ func configureLogging() {
 		Plugin.LogInfof("Neighbor removed: %s / %s", gossip.GetAddress(n.Peer), n.ID())
 	}))
 	deps.Tangle.Requester.Events.RequestStarted.Attach(events.NewClosure(func(messageID tangle.MessageID) {
-		Plugin.LogDebugf("started to request missing Message with %s", messageID)
+		Plugin.LogInfof("started to request missing Message with %s", messageID)
 	}))
 	deps.Tangle.Requester.Events.RequestStopped.Attach(events.NewClosure(func(messageID tangle.MessageID) {
-		Plugin.LogDebugf("stopped to request missing Message with %s", messageID)
+		Plugin.LogInfof("stopped to request missing Message with %s", messageID)
 	}))
 	deps.Tangle.Requester.Events.RequestFailed.Attach(events.NewClosure(func(messageID tangle.MessageID) {
-		Plugin.LogWarnf("failed to request missing Message with %s", messageID)
+		Plugin.LogInfof("failed to request missing Message with %s", messageID)
 	}))
 }
 
@@ -90,6 +90,8 @@ func configureMessageLayer() {
 
 	// request missing messages
 	deps.Tangle.Requester.Events.RequestIssued.Attach(events.NewClosure(func(sendRequest *tangle.SendRequestEvent) {
+		Plugin.LogInfof("requesting missing Message with %s", sendRequest.ID)
+
 		deps.GossipMgr.RequestMessage(sendRequest.ID[:])
 	}))
 }

--- a/plugins/gossip/plugin.go
+++ b/plugins/gossip/plugin.go
@@ -65,10 +65,10 @@ func configureLogging() {
 		Plugin.LogInfof("Neighbor removed: %s / %s", gossip.GetAddress(n.Peer), n.ID())
 	}))
 	deps.Tangle.Requester.Events.RequestStarted.Attach(events.NewClosure(func(messageID tangle.MessageID) {
-		Plugin.LogInfof("started to request missing Message with %s", messageID)
+		Plugin.LogDebugf("started to request missing Message with %s", messageID)
 	}))
 	deps.Tangle.Requester.Events.RequestStopped.Attach(events.NewClosure(func(messageID tangle.MessageID) {
-		Plugin.LogInfof("stopped to request missing Message with %s", messageID)
+		Plugin.LogDebugf("stopped to request missing Message with %s", messageID)
 	}))
 	deps.Tangle.Requester.Events.RequestFailed.Attach(events.NewClosure(func(messageID tangle.MessageID) {
 		Plugin.LogWarnf("failed to request missing Message with %s", messageID)

--- a/plugins/gossip/plugin.go
+++ b/plugins/gossip/plugin.go
@@ -64,6 +64,15 @@ func configureLogging() {
 	deps.GossipMgr.NeighborsEvents(gossip.NeighborsGroupAuto).NeighborRemoved.Attach(events.NewClosure(func(n *gossip.Neighbor) {
 		Plugin.LogInfof("Neighbor removed: %s / %s", gossip.GetAddress(n.Peer), n.ID())
 	}))
+	deps.Tangle.Requester.Events.RequestStarted.Attach(events.NewClosure(func(messageID tangle.MessageID) {
+		Plugin.LogInfof("started to request missing Message with %s", messageID)
+	}))
+	deps.Tangle.Requester.Events.RequestStopped.Attach(events.NewClosure(func(messageID tangle.MessageID) {
+		Plugin.LogInfof("stopped to request missing Message with %s", messageID)
+	}))
+	deps.Tangle.Requester.Events.RequestFailed.Attach(events.NewClosure(func(messageID tangle.MessageID) {
+		Plugin.LogWarnf("failed to request missing Message with %s", messageID)
+	}))
 }
 
 func configureMessageLayer() {

--- a/plugins/gossip/plugin.go
+++ b/plugins/gossip/plugin.go
@@ -80,7 +80,7 @@ func configureMessageLayer() {
 	}))
 
 	// request missing messages
-	deps.Tangle.Requester.Events.SendRequest.Attach(events.NewClosure(func(sendRequest *tangle.SendRequestEvent) {
+	deps.Tangle.Requester.Events.RequestIssued.Attach(events.NewClosure(func(sendRequest *tangle.SendRequestEvent) {
 		deps.GossipMgr.RequestMessage(sendRequest.ID[:])
 	}))
 }

--- a/plugins/messagelayer/plugin.go
+++ b/plugins/messagelayer/plugin.go
@@ -99,7 +99,12 @@ func configure(plugin *node.Plugin) {
 	}))
 
 	deps.Tangle.Parser.Events.BytesRejected.Attach(events.NewClosure(func(ev *tangle.BytesRejectedEvent, err error) {
-		plugin.LogDebugf("bytes rejected from peer %s: %v", ev.Peer.ID(), err)
+		if errors.Is(err, tangle.ErrReceivedDuplicateBytes) {
+			plugin.LogDebugf("bytes rejected from peer %s: %v", ev.Peer.ID(), err)
+			return
+		}
+
+		plugin.LogWarnf("bytes rejected from peer %s: %v", ev.Peer.ID(), err)
 	}))
 
 	deps.Tangle.Scheduler.Events.MessageDiscarded.Attach(events.NewClosure(func(messageID tangle.MessageID) {

--- a/plugins/webapi/tools/message/plugin.go
+++ b/plugins/webapi/tools/message/plugin.go
@@ -8,6 +8,7 @@ import (
 	"github.com/iotaledger/hive.go/autopeering/peer"
 	"github.com/iotaledger/hive.go/configuration"
 
+	"github.com/iotaledger/goshimmer/packages/gossip"
 	"github.com/iotaledger/goshimmer/packages/tangle"
 )
 
@@ -23,10 +24,11 @@ var (
 type dependencies struct {
 	dig.In
 
-	Tangle *tangle.Tangle
-	Local  *peer.Local
-	Config *configuration.Configuration
-	Server *echo.Echo
+	Tangle    *tangle.Tangle
+	Local     *peer.Local
+	Config    *configuration.Configuration
+	Server    *echo.Echo
+	GossipMgr *gossip.Manager `optional:"true"`
 }
 
 const (
@@ -56,6 +58,7 @@ const (
 func configure(_ *node.Plugin) {
 	deps.Server.GET("tools/message/pastcone", PastconeHandler)
 	deps.Server.GET("tools/message/missing", MissingHandler)
+	deps.Server.GET("tools/message/missingavailable", MissingAvailableHandler)
 	deps.Server.GET("tools/message/approval", ApprovalHandler)
 	deps.Server.GET("tools/message/orphanage", OrphanageHandler)
 	deps.Server.GET(RouteDiagnosticMessages, DiagnosticMessagesHandler)


### PR DESCRIPTION
# Description of change

This PR modifies the Requester to show some debug messages and to use the timedExecutor instead of goroutines spawned by time.AfterFunc().

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
