### PR TITLE
Fix docker-network

### DIFF
--- a/tools/docker-network/docker-compose.yml
+++ b/tools/docker-network/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       --prometheus.bindAddress=0.0.0.0:9311
       --prometheus.processMetrics=false
       --webAPI.exportPath=/tmp/
+      --messageLayer.startSynced=true
     secrets:
       - goshimmer.config.json
       - goshimmer.message.snapshot.bin
@@ -81,6 +82,7 @@ services:
       --messageLayer.snapshot.genesisNode=
       --node.disablePlugins=portcheck,clock
       --mana.snapshotResetTime=true
+      --messageLayer.startSynced=true
     secrets:
       - goshimmer.config.json
       - goshimmer.message.snapshot.bin
@@ -175,7 +177,7 @@ services:
       - "8000/tcp"
       - "8081/tcp"
     deploy:
-      replicas: ${DRNG_REPLICAS:-2}
+      replicas: ${DRNG_REPLICAS:-4}
     external_links:
       # Manually set the container name for the leader to what the container expects
       - drand-leader:testdrng-drand_0


### PR DESCRIPTION
# Description of change

- Makes peer_master 1 and 2 start sync
- Increases drng replicas to 4

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)