### PR TITLE
Improve gossip connections handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/go-resty/resty/v2 v2.6.0
 	github.com/gorilla/websocket v1.4.2
-	github.com/iotaledger/hive.go v0.0.0-20211029111324-6d3d2fca5b4d
+	github.com/iotaledger/hive.go v0.0.0-20211124122420-c2f1493d35a5
 	github.com/labstack/echo v3.3.10+incompatible
 	github.com/labstack/gommon v0.3.0
 	github.com/libp2p/go-libp2p v0.15.0

--- a/go.sum
+++ b/go.sum
@@ -504,8 +504,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/iotaledger/hive.go v0.0.0-20211029111324-6d3d2fca5b4d h1:wTexxkZWqeKmO4VzBBZRPUq95Dx70i/6sKfh/sxiC1k=
-github.com/iotaledger/hive.go v0.0.0-20211029111324-6d3d2fca5b4d/go.mod h1:qfpjDWmi+h7AAOkqjZslPHTNeQ7Gf7kTCdIOzbMyjhc=
+github.com/iotaledger/hive.go v0.0.0-20211124122420-c2f1493d35a5 h1:2CSr68Ow3Sz4y4MSMqsHfHTdPfJWQ3zMrjGc7iqZqSQ=
+github.com/iotaledger/hive.go v0.0.0-20211124122420-c2f1493d35a5/go.mod h1:qfpjDWmi+h7AAOkqjZslPHTNeQ7Gf7kTCdIOzbMyjhc=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.2/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.3/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=

--- a/packages/gossip/neighbor.go
+++ b/packages/gossip/neighbor.go
@@ -112,10 +112,14 @@ func (n *Neighbor) readLoop() {
 			packet := &pb.Packet{}
 			err := n.read(packet)
 			if err != nil {
-				if isAlreadyClosedError(err) || errors.Is(err, io.EOF) {
+				if !isAlreadyClosedError(err) && !errors.Is(err, io.EOF) {
 					n.log.Warnw("Permanent error", "err", errors.CombineErrors(err, n.disconnect()))
 				}
 				return
+			}
+			// ignore other errors.
+			if err != nil {
+				continue
 			}
 			n.packetReceived.Trigger(packet)
 		}

--- a/packages/gossip/neighbor.go
+++ b/packages/gossip/neighbor.go
@@ -122,7 +122,6 @@ func (n *Neighbor) readLoop() {
 					return
 				}
 				continue
-
 			}
 			if err != nil {
 				if !isAlreadyClosedError(err) && !errors.Is(err, io.EOF) {

--- a/packages/gossip/neighbor.go
+++ b/packages/gossip/neighbor.go
@@ -113,8 +113,7 @@ func (n *Neighbor) readLoop() {
 			err := n.read(packet)
 			if err != nil {
 				if isAlreadyClosedError(err) || errors.Is(err, io.EOF) {
-					errors.CombineErrors(err, n.disconnect())
-					n.log.Warnw("Permanent error", "err", err)
+					n.log.Warnw("Permanent error", "err", errors.CombineErrors(err, n.disconnect()))
 				}
 				return
 			}

--- a/tools/integration-tests/tester/go.mod
+++ b/tools/integration-tests/tester/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/drand/drand v1.1.1
 	github.com/iotaledger/goshimmer v0.1.3
-	github.com/iotaledger/hive.go v0.0.0-20211029111324-6d3d2fca5b4d
+	github.com/iotaledger/hive.go v0.0.0-20211124122420-c2f1493d35a5
 	github.com/mr-tron/base58 v1.2.0
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/stretchr/testify v1.7.0

--- a/tools/integration-tests/tester/go.sum
+++ b/tools/integration-tests/tester/go.sum
@@ -512,10 +512,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/iotaledger/hive.go v0.0.0-20211029111324-6d3d2fca5b4d h1:wTexxkZWqeKmO4VzBBZRPUq95Dx70i/6sKfh/sxiC1k=
-github.com/iotaledger/hive.go v0.0.0-20211029111324-6d3d2fca5b4d/go.mod h1:qfpjDWmi+h7AAOkqjZslPHTNeQ7Gf7kTCdIOzbMyjhc=
-github.com/iotaledger/hive.go v0.0.0-20210821074123-831d7702ae07 h1:iqBuH88I1MJGpCTMngxwA46SeE4rX9QUBWCsQB++dZI=
-github.com/iotaledger/hive.go v0.0.0-20210821074123-831d7702ae07/go.mod h1:vZXMpgveUkATu1IueKmUJK3/OVgrYRQdH/Jh/yZ2j9Q=
+github.com/iotaledger/hive.go v0.0.0-20211124122420-c2f1493d35a5 h1:2CSr68Ow3Sz4y4MSMqsHfHTdPfJWQ3zMrjGc7iqZqSQ=
+github.com/iotaledger/hive.go v0.0.0-20211124122420-c2f1493d35a5/go.mod h1:qfpjDWmi+h7AAOkqjZslPHTNeQ7Gf7kTCdIOzbMyjhc=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.2/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.3/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=


### PR DESCRIPTION
# Description of change

- [x] Disconnect from a neighbour only upon Already Closed Error OR io.EOF 
- [x] Update to new hive.go with the reset rejectionFilter in the auto peering
