### PR TITLE
DAGsVisualizer: Scale visualizers' windows

### DIFF
--- a/plugins/dagsvisualizer/frontend/src/styles/style.css
+++ b/plugins/dagsvisualizer/frontend/src/styles/style.css
@@ -2,27 +2,28 @@ html, body, #root {
     height: 100%;
 }
 
+.container {
+    max-width: 80vw;
+}
+
 .graphFrame {
-    height: 300px;
     position: relative;
+    background: #ededed;
 }
 
 #tangleVisualizer {
     width: 100%;
-    height: 300px;
-    background: #ededed;
+    height: 60vh;
 }
 
-#utxoVisualizer {    
+#utxoVisualizer {
     width: 100%;
-    height: 100%;
-    background: #ededed;
+    height: 60vh;
 }
 
 #branchVisualizer {
     width: 100%;
-    height: 300px;
-    background: #ededed;
+    height: 60vh;
     overflow-x: scroll;
 }
 
@@ -34,4 +35,8 @@ html, body, #root {
     right: 20px;
     z-index: 1;
     overflow: scroll;
+}
+
+.form-control {
+    max-width: 500px;
 }


### PR DESCRIPTION
Part of #1880 
Change in styles for DAGs visualize window to take 80% of view width and 60% of view height
