### PR TITLE
Don't log errors on write to closed connection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/labstack/gommon v0.3.0
 	github.com/libp2p/go-libp2p v0.15.0
 	github.com/libp2p/go-libp2p-core v0.9.0
+	github.com/libp2p/go-yamux/v2 v2.2.0
 	github.com/linxGnu/grocksdb v1.6.35 // indirect
 	github.com/magiconair/properties v1.8.1
 	github.com/markbates/pkger v0.17.1

--- a/packages/gossip/manager.go
+++ b/packages/gossip/manager.go
@@ -230,7 +230,7 @@ func (m *Manager) send(packet *pb.Packet, to ...identity.ID) {
 	}
 
 	for _, nbr := range neighbors {
-		if err := nbr.ps.writePacket(packet); err != nil {
+		if err := nbr.ps.writePacket(packet); err != nil && !isAlreadyClosedError(err){
 			m.log.Warnw("send error", "peer-id", nbr.ID(), "err", err)
 			nbr.close()
 		}
@@ -352,7 +352,7 @@ func (m *Manager) processMessageRequest(packetMsgReq *pb.Packet_MessageRequest, 
 
 	// send the loaded message directly to the neighbor
 	packet := &pb.Packet{Body: &pb.Packet_Message{Message: &pb.Message{Data: msgBytes}}}
-	if err := nbr.ps.writePacket(packet); err != nil {
+	if err := nbr.ps.writePacket(packet); err != nil && !isAlreadyClosedError(err){
 		nbr.log.Warnw("Failed to send requested message back to the neighbor", "err", err)
 		nbr.close()
 	}

--- a/packages/gossip/manager.go
+++ b/packages/gossip/manager.go
@@ -230,7 +230,7 @@ func (m *Manager) send(packet *pb.Packet, to ...identity.ID) {
 	}
 
 	for _, nbr := range neighbors {
-		if err := nbr.ps.writePacket(packet); err != nil && !isAlreadyClosedError(err){
+		if err := nbr.ps.writePacket(packet); err != nil && !isAlreadyClosedError(err) {
 			m.log.Warnw("send error", "peer-id", nbr.ID(), "err", err)
 			nbr.close()
 		}
@@ -352,7 +352,7 @@ func (m *Manager) processMessageRequest(packetMsgReq *pb.Packet_MessageRequest, 
 
 	// send the loaded message directly to the neighbor
 	packet := &pb.Packet{Body: &pb.Packet_Message{Message: &pb.Message{Data: msgBytes}}}
-	if err := nbr.ps.writePacket(packet); err != nil && !isAlreadyClosedError(err){
+	if err := nbr.ps.writePacket(packet); err != nil && !isAlreadyClosedError(err) {
 		nbr.log.Warnw("Failed to send requested message back to the neighbor", "err", err)
 		nbr.close()
 	}

--- a/packages/gossip/neighbor.go
+++ b/packages/gossip/neighbor.go
@@ -11,6 +11,7 @@ import (
 	"github.com/iotaledger/hive.go/events"
 	"github.com/iotaledger/hive.go/logger"
 	"github.com/libp2p/go-libp2p-core/mux"
+	"github.com/libp2p/go-yamux/v2"
 
 	pb "github.com/iotaledger/goshimmer/packages/gossip/gossipproto"
 )
@@ -133,6 +134,6 @@ func (n *Neighbor) disconnect() (err error) {
 
 func isAlreadyClosedError(err error) bool {
 	return strings.Contains(err.Error(), "use of closed network connection") ||
-		errors.Is(err, io.ErrClosedPipe) || errors.Is(err, mux.ErrReset) ||
+		errors.Is(err, io.ErrClosedPipe) || errors.Is(err, mux.ErrReset) || errors.Is(err, yamux.ErrStreamClosed) ||
 		errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF)
 }


### PR DESCRIPTION
We have nasty warnings in the logs:
```
Dec 06 23:36:11 lunariota goshimmer[50384]: 2021-12-06T23:36:11+02:00        WARN        Gossip        gossip/manager.go:356        Failed to send requested message back to the neighbor        {"id": "aknHA4yEenx", "localAddr": "/ip4/LOCAL_IP_ADDR/tcp/14666", "remoteAddr": "/ip4/REMOTE_IP_ADDR/tcp/14666", "err": "stream closed", "errVerbose": "stream closed\n(1) attached stack trace\n  -- stack trace:\n  | github.com/iotaledger/goshimmer/packages/gossip.(packetsStream).writePacket\n  | \t/usr/src/goshimmer-0.8.3/packages/gossip/stream.go:215\n  | github.com/iotaledger/goshimmer/packages/gossip.(Manager).processMessageRequest\n  | \t/usr/src/goshimmer-0.8.3/packages/gossip/manager.go:355\n  | github.com/iotaledger/goshimmer/packages/gossip.NewManager.func2\n  | \t/usr/src/goshimmer-0.8.3/packages/gossip/manager.go:107\n  | github.com/iotaledger/hive.go/workerpool.(NonBlockingQueuedWorkerPool).workerFuncWrapper.func1\n  | \t/usr/src/goshimmer-0.8.3/goshimmer_go_dependencies/pkg/mod/github.com/iotaledger/hive.go@v0.0.0-20211124122420-c2f1493d35a5/workerpool/non_blocking_queued_workerpool.go:60\n  | github.com/iotaledger/hive.go/workerpool.(NonBlockingQueuedWorkerPool).workerFuncWrapper\n  | \t/usr/src/goshimmer-0.8.3/goshimmer_go_dependencies/pkg/mod/github.com/iotaledger/hive.go@v0.0.0-20211124122420-c2f1493d35a5/workerpool/non_blocking_queued_workerpool.go:61\n  | github.com/panjf2000/ants/v2.(*goWorkerWithFunc).run.func1\n  | \t/usr/src/goshimmer-0.8.3/goshimmer_go_dependencies/pkg/mod/github.com/panjf2000/ants/v2@v2.4.6/worker_func.go:70\n  | runtime.goexit\n  | \t/usr/lib/go/src/runtime/asm_amd64.s:1371\nWraps: (2) stream closed\nError types: (1) *withstack.withStack (2) *yamux.Error"}
```
But they are actually Okay. We just don't need to log a warning when we can't write into the connection because it's already closed.
So this PR just removes the unscary and confusing log record