### PR TITLE
Fix prometheus scrape ports

### DIFF
--- a/deploy/ansible/roles/goshimmer-node/templates/docker-compose-analysis-server.yml.j2
+++ b/deploy/ansible/roles/goshimmer-node/templates/docker-compose-analysis-server.yml.j2
@@ -13,7 +13,7 @@ services:
       - 6063:6063
       - 21888:21888
       - 28080:28080
-      - 9312:9312
+      - 9311:9311
     environment:
       - DATABASE_DIRECTORY=/db/mainnetdb
       - PROFILING_BINDADDRESS=0.0.0.0:6063

--- a/deploy/ansible/roles/goshimmer-node/templates/docker-compose-analysis-server.yml.j2
+++ b/deploy/ansible/roles/goshimmer-node/templates/docker-compose-analysis-server.yml.j2
@@ -21,7 +21,7 @@ services:
       --analysis.server.bindAddress=0.0.0.0:21888
       --analysis.dashboard.bindAddress=0.0.0.0:28080
       --analysis.dashboard.manaDashboardAddress="http://{{ manaDashboardHost }}:8081"
-      --prometheus.bindAddress=0.0.0.0:9312
+      --prometheus.bindAddress=0.0.0.0:9311
       --metrics.local=false
       --metrics.global=true
       --node.enablePlugins=analysisServer,analysisDashboard,prometheus

--- a/deploy/ansible/roles/goshimmer-node/templates/docker-compose-goshimmer.yml.j2
+++ b/deploy/ansible/roles/goshimmer-node/templates/docker-compose-goshimmer.yml.j2
@@ -30,6 +30,8 @@ services:
       # pprof profiling
       - "127.0.0.1:6061:6061/tcp"
     {% endif %}
+      # prometheus
+      - "0.0.0.0:9311:9311/tcp"
     environment:
       - NODE_SEED={{ seed }}
       - DATABASE_DIRECTORY=/db/mainnetdb
@@ -48,7 +50,7 @@ services:
       {% endif %}
       --node.disablePlugins=portcheck
       --node.enablePlugins=dashboard,remotelog,networkdelay,prometheus{% if faucet|default(false) %},faucet{% endif %},activity,snapshot,WebAPIToolsDRNGEndpoint,WebAPIToolsMessageEndpoint,"WebAPI tools Endpoint"
-      --prometheus.bindAddress=0.0.0.0:9312
+      --prometheus.bindAddress=0.0.0.0:9311
       --messageLayer.snapshot.file=/snapshot.bin
      {% if faucet|default(false) %}
       --faucet.seed={{ faucetSeed }}

--- a/deploy/ansible/roles/goshimmer-node/templates/docker-compose-public-node.yml.j2
+++ b/deploy/ansible/roles/goshimmer-node/templates/docker-compose-public-node.yml.j2
@@ -20,6 +20,8 @@ services:
       - "0.0.0.0:8081:8081/tcp"
       # pprof profiling
       - "0.0.0.0:6061:6061/tcp"
+      # prometheus
+      - "0.0.0.0:9311:9311/tcp"
     environment:
       - DATABASE_DIRECTORY=/db/mainnetdb
       - NODE_PEERDBDIRECTORY=/db/peerdb
@@ -37,7 +39,7 @@ services:
       {% endif %}
       --node.disablePlugins=portcheck
       --node.enablePlugins=dashboard,remotelog,networkdelay,prometheus{% if faucet|default(false) %},faucet{% endif %}
-      --prometheus.bindAddress=0.0.0.0:9312
+      --prometheus.bindAddress=0.0.0.0:9311
       {% if faucet|default(false) %}
       --faucet.seed={{ faucetSeed }}
       --faucet.tokensPerRequest=1000000

--- a/deploy/ansible/roles/metrics/files/grafana/provisioning/datasources/prometheus.yml
+++ b/deploy/ansible/roles/metrics/files/grafana/provisioning/datasources/prometheus.yml
@@ -1,11 +1,6 @@
 # config file version
 apiVersion: 1
 
-# list of datasources that should be deleted from the database
-deleteDatasources:
-  - name: Prometheus
-    orgId: 1
-
 # list of datasources to insert/update depending
 # whats available in the database
 datasources:

--- a/deploy/ansible/roles/metrics/templates/prometheus.yml.j2
+++ b/deploy/ansible/roles/metrics/templates/prometheus.yml.j2
@@ -4,5 +4,5 @@ scrape_configs:
       static_configs:
       - targets:
       {% for host in groups['supports'] + groups['goshimmers']%}
-        - {{ host }}:9312
+        - {{ host }}:9311
       {% endfor %}


### PR DESCRIPTION
Change prometheus scrape port to 9311 for consistency. Publish that port to the host network on Goshimmer nodes.

Fixes: https://github.com/iotaledger/goshimmer/issues/1927