### PR TITLE
Update aMana update formula to fix NaN problem

### DIFF
--- a/packages/mana/accessbase.go
+++ b/packages/mana/accessbase.go
@@ -47,11 +47,10 @@ func (a *AccessBaseMana) updateEBM2(n time.Duration) {
 		a.EffectiveBaseMana2 = 0
 		return
 	}
-
 	if emaCoeff2 != Decay {
 		a.EffectiveBaseMana2 = math.Pow(math.E, -emaCoeff2*n.Seconds())*a.EffectiveBaseMana2 +
-			(math.Pow(math.E, -Decay*n.Seconds())-math.Pow(math.E, -emaCoeff2*n.Seconds()))/
-				(emaCoeff2-Decay)*emaCoeff2/math.Pow(math.E, -Decay*n.Seconds())*a.BaseMana2
+			(1-math.Pow(math.E, -(emaCoeff2-Decay)*n.Seconds()))/
+				(emaCoeff2-Decay)*emaCoeff2*a.BaseMana2
 	} else {
 		a.EffectiveBaseMana2 = math.Pow(math.E, -Decay*n.Seconds())*a.EffectiveBaseMana2 +
 			Decay*n.Seconds()*a.BaseMana2

--- a/packages/mana/accessbase_test.go
+++ b/packages/mana/accessbase_test.go
@@ -75,6 +75,67 @@ func TestUpdateEBM2CoeffEqual(t *testing.T) {
 		// compare results of the two calculations
 		assert.Equal(t, true, math.Abs(bmBatch.EffectiveBaseMana2-bmInc.EffectiveBaseMana2) < delta)
 	})
+
+	t.Run("CASE: Large durations BM2", func(t *testing.T) {
+		bmBatch := AccessBaseMana{}
+
+		// first, let's calculate once on a 6 hour span
+		// pledge BM2 at t = o
+		bmBatch.BaseMana2 = 1.0
+		// updateEBM2 relies on an update baseMana2 value
+		minTime := time.Unix(-2208988800, 0) // Jan 1, 1900
+		maxTime := minTime.Add(1<<63 - 1)
+
+		bmBatch.updateBM2(maxTime.Sub(minTime))
+
+		assert.False(t, math.IsNaN(bmBatch.BaseMana2))
+		assert.False(t, math.IsInf(bmBatch.BaseMana2, 0))
+		assert.Equal(t, 0.0, bmBatch.BaseMana2)
+	})
+
+	t.Run("CASE: Large durations EBM2 Decay==emaCoeff2", func(t *testing.T) {
+		bmBatch := AccessBaseMana{}
+		// pledge BM2 at t = o
+		bmBatch.BaseMana2 = 1.0
+		bmBatch.EffectiveBaseMana2 = 1.0
+
+		// updateEBM2 relies on an update baseMana2 value
+		minTime := time.Unix(-2208988800, 0) // Jan 1, 1900
+		maxTime := minTime.Add(1<<63 - 1)
+
+		bmBatch.updateBM2(maxTime.Sub(minTime))
+		bmBatch.updateEBM2(maxTime.Sub(minTime))
+		assert.False(t, math.IsNaN(bmBatch.BaseMana2))
+		assert.False(t, math.IsNaN(bmBatch.EffectiveBaseMana2))
+		assert.False(t, math.IsInf(bmBatch.BaseMana2, 0))
+		assert.False(t, math.IsInf(bmBatch.EffectiveBaseMana2, 0))
+		assert.Equal(t, 0.0, bmBatch.BaseMana2)
+		assert.Equal(t, 0.0, bmBatch.EffectiveBaseMana2)
+	})
+	t.Run("CASE: Large durations EBM2 Decay!=emaCoeff2", func(t *testing.T) {
+		bmBatch := AccessBaseMana{}
+		SetCoefficients(0.00003209, 0.0057762265, 0.00003209)
+		// pledge BM2 at t = o
+		bmBatch.BaseMana2 = 1.0
+		bmBatch.EffectiveBaseMana2 = 1.0
+
+		// updateEBM2 relies on an update baseMana2 value
+		minTime := time.Unix(-2208988800, 0) // Jan 1, 1900
+		maxTime := minTime.Add(1<<63 - 1)
+
+		bmBatch.updateBM2(maxTime.Sub(minTime))
+		bmBatch.updateEBM2(maxTime.Sub(minTime))
+
+		assert.False(t, math.IsNaN(bmBatch.BaseMana2))
+		assert.False(t, math.IsNaN(bmBatch.EffectiveBaseMana2))
+		assert.False(t, math.IsInf(bmBatch.BaseMana2, 0))
+		assert.False(t, math.IsInf(bmBatch.EffectiveBaseMana2, 0))
+		assert.Equal(t, 0.0, bmBatch.BaseMana2)
+		assert.Equal(t, 0.0, bmBatch.EffectiveBaseMana2)
+		// re-set the default values so that other tests pass
+		SetCoefficients(0.00003209, 0.00003209, 0.00003209)
+
+	})
 }
 
 func TestUpdateTimeInPast_Access(t *testing.T) {
@@ -243,7 +304,6 @@ func TestPledgePastOldFunds_Access(t *testing.T) {
 	// pledged at t=0, half of input amount is added to bm2
 	assert.InDelta(t, 5.0, bm2Pledged, delta)
 	// half of the original BM2 degraded away in 6 hours
-	assert.InDelta(t, 5.0, bm.BaseMana2, delta)
 	// valid EBM2 at t=6 hours, after pledging 10 BM2 at t=0
 	assert.InDelta(t, 3.465731, bm.EffectiveBaseMana2, delta)
 }

--- a/packages/mana/accessbase_test.go
+++ b/packages/mana/accessbase_test.go
@@ -134,7 +134,6 @@ func TestUpdateEBM2CoeffEqual(t *testing.T) {
 		assert.Equal(t, 0.0, bmBatch.EffectiveBaseMana2)
 		// re-set the default values so that other tests pass
 		SetCoefficients(0.00003209, 0.00003209, 0.00003209)
-
 	})
 }
 


### PR DESCRIPTION
# Description of change

Update the mana update formula to avoid division by zero, caused by rounding error. Rounding error occurs when we calculate `e^-x` and `x` is large. 

Resolves #1926 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Unit tests. 

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [ ] My code follows the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
