### PR TITLE
Skip snapshot download when rebuilding images of old goshimmer version

### DIFF
--- a/.github/workflows/rebuild-docker-image.yml
+++ b/.github/workflows/rebuild-docker-image.yml
@@ -26,4 +26,4 @@ jobs:
           username: '${{ secrets.IOTALEDGER_HUB_DOCKER_LOGIN }}'
           password: '${{ secrets.IOTALEDGER_HUB_DOCKER_PASSWORD }}'
           tags: latest,${{github.event.inputs.tagName}}
-          tag_with_ref: true
+          build-args: DOWNLOAD_SNAPSHOT=0

--- a/.github/workflows/rebuild-docker-image.yml
+++ b/.github/workflows/rebuild-docker-image.yml
@@ -25,5 +25,5 @@ jobs:
           repository: iotaledger/goshimmer
           username: '${{ secrets.IOTALEDGER_HUB_DOCKER_LOGIN }}'
           password: '${{ secrets.IOTALEDGER_HUB_DOCKER_PASSWORD }}'
-          tags: latest,${{github.event.inputs.tagName}}
+          tags: ${{github.event.inputs.tagName}}
           build-args: DOWNLOAD_SNAPSHOT=0


### PR DESCRIPTION
# Description of change

We don't have the valid snapshot for old versions anymore, so downloading the latest one is incorrect. 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [ ] My code follows the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
