### PR TITLE
Do not increase the scheduling rate when node is out of sync.

### DIFF
--- a/plugins/messagelayer/plugin.go
+++ b/plugins/messagelayer/plugin.go
@@ -115,18 +115,6 @@ func configure(plugin *node.Plugin) {
 
 	deps.Tangle.TimeManager.Events.SyncChanged.Attach(events.NewClosure(func(ev *tangle.SyncChangedEvent) {
 		plugin.LogInfo("Sync changed: ", ev.Synced)
-		if ev.Synced {
-			// make sure that we are using the configured rate when synced
-			rate := deps.Tangle.Options.SchedulerParams.Rate
-			deps.Tangle.Scheduler.SetRate(rate)
-			plugin.LogInfof("Scheduler rate: %v", rate)
-		} else {
-			// increase scheduler rate
-			rate := deps.Tangle.Options.SchedulerParams.Rate
-			rate -= rate / 2 // 50% increase
-			deps.Tangle.Scheduler.SetRate(rate)
-			plugin.LogInfof("Scheduler rate: %v", rate)
-		}
 	}))
 
 	// read snapshot file


### PR DESCRIPTION
# Description of change

With the new congestion control implemented, node does not need to increate the scheduling rate to schedule messages that piled in the buffer, as only unconfirmed messages need to be scheduled. Any old messages that would pile in the buffer will most likely be confirmed and there is no need to schedule them. 

Fixes #1933

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
