### PR TITLE
Update webAPI.md

### DIFF
--- a/documentation/docs/apis/webAPI.md
+++ b/documentation/docs/apis/webAPI.md
@@ -20,16 +20,16 @@ The default port to access the web API is set to `8080:8080/tcp` in `docker-comp
 
 The server instance of the web API is contacted via `webapi.Server()`. Next we need to register a route with a matching handler.
 
-```
+```go
 webapi.Server().ROUTE(path string, h HandlerFunc)
 ```
 where `ROUTE` will be replaced later in this documentation by `GET` or `POST`. The `HandlerFunc` defines a function to serve HTTP requests that gives access to the Context
 
-```
+```go
 func HandlerFunc(c Context) error
 ```
 We can then use the Context to send a JSON response to the node: 
-```
+```go
 JSON(statuscode int, i interface{}) error
 ```
 An implementation example is shown later for the POST method.
@@ -37,7 +37,7 @@ An implementation example is shown later for the POST method.
 ## GET and POST 
 
 Two methods are currently used. First, with `GET` we register a new GET route for a handler function. The handler is accessed via the address `path`. The handler for a GET method can set the node to perform certain actions.
-```
+```go
 webapi.Server().GET("path", HandlerFunc)
 ```	
 A command can be sent to the node software to the API, e.g. via command prompt: 
@@ -48,12 +48,12 @@ curl "http://127.0.0.1:8080/path?command"
 $$ . $$
 
 Second, with `POST` we register a new POST route for a handler function. The handler can receive a JSON body input and send specific messages to the tangle.
-```
+```go
 webapi.Server().POST("path", HandlerFunc)
 ```	
 
 For example, the following Handler `broadcastData` sends a data message to the tangle
-```
+```go
 func broadcastData(c echo.Context) error {
 	var request Request
 	if err := c.Bind(&request); err != nil {
@@ -70,9 +70,9 @@ func broadcastData(c echo.Context) error {
 }
 ```
 As an example the JSON body   
-```
+```json
 {
-	"data":"HelloWor"
+	"data":"HelloWorld"
 }
 ```
 can be sent to `http://127.0.0.1:8080/data`, which will issue a data message containing "HelloWor" (note that in this  example the data input is size limited.)


### PR DESCRIPTION
Suggestion: use \```go or \```json or ```shell for code snippets to enable syntax highlighting. This greatly enhances reading experience.
As an example I edited this page. You can do it yourself for the rest of the 1000 pages :)
Update: some (most?) pages are already using it... but at least this page didn't  :)