### PR TITLE
Fix browser not popping up the basic auth login modal

### DIFF
--- a/plugins/dashboard/routes.go
+++ b/plugins/dashboard/routes.go
@@ -98,7 +98,7 @@ func setupRoutes(e *echo.Echo) {
 		var statusCode int
 		var message string
 
-		switch errors.Unwrap(err) {
+		switch errors.UnwrapAll(err) {
 		case echo.ErrNotFound:
 			c.Redirect(http.StatusSeeOther, "/")
 			return


### PR DESCRIPTION
# Description of change

When dashboard basic auth is enabled and the user is not authenticated, the echo server returns an HTTP 500 response.
![image](https://user-images.githubusercontent.com/662535/150852964-984735cd-cabd-4592-a734-17897763874c.png)

Not returning the proper http response (HTTP 401), browser does not pop up the login prompt to fill the username and password. That makes accessing the dashboard hard.

The root cause was that in the error handling, the error was already leaf error, but it get unwrapped to nil and that get handled as internal server error.

Use the unwrapAll() which returns the leaf node always, and error gets handled properly.

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested
1. Run latest goshimmer version with flag `--dashboard.basicAuth.enabled=true`
2. Try to access the dashboard http://localhost:8081
2. Run `wget --tries=1 --spider -S http://localhost:8081 2>&1` to verify invalid HTTP 500 code
3. Apply this fix and run the goshimmer again with basic-auth enabled
1. Go to the http://localhost:8081 and browser pop ups the login modal

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [X] My code follows the contribution guidelines for this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
