### PR TITLE
 Do not hardcode parameters in Docker ENTRYPOINT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -120,7 +120,7 @@ COPY --chown=nonroot:nonroot --from=build /go/bin/goshimmer /run/goshimmer
 # We execute this stage only if debugging is disabled, i.e REMOTE_DEBUGGIN==0.
 FROM prepare-runtime as debugger-enabled-0
 
-ENTRYPOINT ["/run/goshimmer", "--config=/config.json", "--messageLayer.snapshot.file=/snapshot.bin"]
+ENTRYPOINT ["/run/goshimmer", "--config=/config.json"]
 
 # We execute this stage only if debugging is enabled, i.e REMOTE_DEBUGGIN==1.
 FROM prepare-runtime as debugger-enabled-1
@@ -128,7 +128,7 @@ EXPOSE 40000
 
 # Copy the Delve binary
 COPY --chown=nonroot:nonroot --from=build /go/bin/dlv /run/dlv
-ENTRYPOINT ["/run/dlv","--listen=:40000", "--headless=true" ,"--api-version=2", "--accept-multiclient", "exec", "--continue", "/run/goshimmer", "--", "--config=/config.json", "--messageLayer.snapshot.file=/snapshot.bin"]
+ENTRYPOINT ["/run/dlv","--listen=:40000", "--headless=true" ,"--api-version=2", "--accept-multiclient", "exec", "--continue", "/run/goshimmer", "--", "--config=/config.json"]
 
 # Execute corresponding build stage depending on the REMOTE_DEBUGGING build arg.
 FROM debugger-enabled-${REMOTE_DEBUGGING} as runtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -120,7 +120,7 @@ COPY --chown=nonroot:nonroot --from=build /go/bin/goshimmer /run/goshimmer
 # We execute this stage only if debugging is disabled, i.e REMOTE_DEBUGGIN==0.
 FROM prepare-runtime as debugger-enabled-0
 
-ENTRYPOINT ["/run/goshimmer", "--config=/config.json", "--messageLayer.snapshot.file=/snapshot.bin", "--database.directory=/tmp/mainnetdb"]
+ENTRYPOINT ["/run/goshimmer", "--config=/config.json", "--messageLayer.snapshot.file=/snapshot.bin"]
 
 # We execute this stage only if debugging is enabled, i.e REMOTE_DEBUGGIN==1.
 FROM prepare-runtime as debugger-enabled-1
@@ -128,7 +128,7 @@ EXPOSE 40000
 
 # Copy the Delve binary
 COPY --chown=nonroot:nonroot --from=build /go/bin/dlv /run/dlv
-ENTRYPOINT ["/run/dlv","--listen=:40000", "--headless=true" ,"--api-version=2", "--accept-multiclient", "exec", "--continue", "/run/goshimmer", "--", "--config=/config.json", "--messageLayer.snapshot.file=/snapshot.bin", "--database.directory=/tmp/mainnetdb"]
+ENTRYPOINT ["/run/dlv","--listen=:40000", "--headless=true" ,"--api-version=2", "--accept-multiclient", "exec", "--continue", "/run/goshimmer", "--", "--config=/config.json", "--messageLayer.snapshot.file=/snapshot.bin"]
 
 # Execute corresponding build stage depending on the REMOTE_DEBUGGING build arg.
 FROM debugger-enabled-${REMOTE_DEBUGGING} as runtime


### PR DESCRIPTION
Specifying those parameters in the ENTRYPOINT always takes precedence over the same parameters defined via environment variables: so they cannot be overridden.