### PR TITLE
Fix: disable REMOTE_DEBUGGING on feature network, hangs the entrynode

### DIFF
--- a/.github/workflows/feature-network-deploy.yml
+++ b/.github/workflows/feature-network-deploy.yml
@@ -45,7 +45,7 @@ jobs:
           build-args: |
             CUSTOM_SNAPSHOT_URL=${{github.event.inputs.snapshotUrl}}
             DEFAULT_SNAPSHOT_URL=https://dbfiles-goshimmer.s3.eu-central-1.amazonaws.com/snapshots/feature/snapshot.bin
-            REMOTE_DEBUGGING=1
+            REMOTE_DEBUGGING=0
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -109,6 +109,8 @@ EXPOSE 9311/tcp
 EXPOSE 8080/tcp
 # Dashboard
 EXPOSE 8081/tcp
+# DAGs Visualizer
+EXPOSE 8061/tcp
 
 # Copy configuration
 COPY --from=build /tmp/snapshot.bin /snapshot.bin

--- a/deploy/ansible/roles/goshimmer-node/templates/docker-compose-goshimmer.yml.j2
+++ b/deploy/ansible/roles/goshimmer-node/templates/docker-compose-goshimmer.yml.j2
@@ -22,6 +22,8 @@ services:
     {% if debugPorts|default(false) %}
       # Dashboard
       - "0.0.0.0:8081:8081/tcp"
+      # DAGs Visualizer
+      - "0.0.0.0:8061:8061/tcp"
       # pprof profiling
       - "0.0.0.0:6061:6061/tcp"
     {% else %}

--- a/deploy/ansible/roles/goshimmer-node/templates/docker-compose-public-node.yml.j2
+++ b/deploy/ansible/roles/goshimmer-node/templates/docker-compose-public-node.yml.j2
@@ -18,6 +18,8 @@ services:
       - "0.0.0.0:8080:8080/tcp"
       # Dashboard
       - "0.0.0.0:8081:8081/tcp"
+      # DAGs Visualizer
+      - "0.0.0.0:8061:8061/tcp"
       # pprof profiling
       - "0.0.0.0:6061:6061/tcp"
       # prometheus


### PR DESCRIPTION
This should be reverted once #2033 is resolved 