### PR TITLE
enable remote debugging on test

### DIFF
--- a/tools/integration-tests/runTests.sh
+++ b/tools/integration-tests/runTests.sh
@@ -5,7 +5,7 @@ TEST_NAMES='autopeering common consensus drng value faucet mana diagnostics'
 export DOCKER_BUILDKIT=1
 export COMPOSE_DOCKER_CLI_BUILD=1
 echo "Build GoShimmer image"
-docker build --build-arg DOWNLOAD_SNAPSHOT=0 -t iotaledger/goshimmer ../../.
+docker build --build-arg REMOTE_DEBUGGING=1 --build-arg DOWNLOAD_SNAPSHOT=0 -t iotaledger/goshimmer ../../.
 
 echo "Pull additional Docker images"
 docker pull angelocapossele/drand:v1.1.4


### PR DESCRIPTION
# Description of change

Fixes #2019 by building an image that runs `dlv`, utilizing a variable that already exists in our DockerFile.

Documentation will be added only after  #2018 Will be done. Then we will use the `socat` container to forward debugging calls.

## Type of change

- Enhancement (a non-breaking change which adds functionality)