### PR TITLE
Fix output link to dashboard

### DIFF
--- a/plugins/dagsvisualizer/frontend/src/components/TransactionInfo.tsx
+++ b/plugins/dagsvisualizer/frontend/src/components/TransactionInfo.tsx
@@ -57,7 +57,7 @@ export class TransactionInfo extends React.Component<Props, any> {
                                         {selectedTx.outputs.map((p, i) => (
                                             <ListGroup.Item key={i}>
                                                 <LinkToDashboard
-                                                    route={`/explorer/output/${p}`}
+                                                    route={`explorer/output/${p}`}
                                                     title={p}
                                                 />
                                             </ListGroup.Item>


### PR DESCRIPTION
# Description of change

Fix broken link to output on DAGs visualizer.
Fixes #2038  