### PR TITLE
clean test cache

### DIFF
--- a/tools/integration-tests/assets/entrypoint.sh
+++ b/tools/integration-tests/assets/entrypoint.sh
@@ -6,4 +6,5 @@ chmod 777 /assets/*
 echo "assets:"
 ls /assets
 echo "running tests..."
+go clean -testcache
 go test ./tests/"${TEST_NAME}" -v -timeout 30m -count=1


### PR DESCRIPTION
# Description of change

Sometimes when you don't run the tests using the bash scripts, clearing the cache is helpful.
When the tests run automatically, the command doesn't add any time overhead so I see no reason why not to include this.

## Type of change

- Enhancement (a non-breaking change which adds functionality)