### PR TITLE
Try to adjust rate limit better

### DIFF
--- a/packages/firewall/firewall.go
+++ b/packages/firewall/firewall.go
@@ -45,12 +45,12 @@ func (fd *FaultinessDetails) toKVList() []interface{} {
 
 // HandleFaultyPeer handles a faulty peer and takes appropriate actions.
 func (f *Firewall) HandleFaultyPeer(peerID identity.ID, details *FaultinessDetails) {
-	f.log.Info("Peer is faulty, executing firewall logic to handle the peer",
-		"peerId", peerID, details.toKVList())
+	logKVList := append([]interface{}{"peerId", peerID}, details.toKVList()...)
+	f.log.Infow("Peer is faulty, executing firewall logic to handle the peer", logKVList...)
 	f.incrPeerFaultinessCount(peerID)
 	nbr, err := f.gossipMgr.GetNeighbor(peerID)
 	if err != nil {
-		f.log.Errorw("Can't get neighbor info from the gossip manager", "peerId", peerID)
+		f.log.Errorw("Can't get neighbor info from the gossip manager", "peerId", peerID, "err", err)
 		return
 	}
 	if nbr.Group == gossip.NeighborsGroupAuto {
@@ -63,7 +63,7 @@ func (f *Firewall) HandleFaultyPeer(peerID identity.ID, details *FaultinessDetai
 		}
 	} else if nbr.Group == gossip.NeighborsGroupManual {
 		f.log.Warnw("To the node operator. One of neighbors connected via manual peering acts faulty, no automatic actions taken. Consider removing it from the known peers list.",
-			"neighborId", peerID, details.toKVList())
+			logKVList...)
 	}
 }
 

--- a/packages/gossip/manager.go
+++ b/packages/gossip/manager.go
@@ -236,7 +236,8 @@ func (m *Manager) RequestMessage(messageID []byte, to ...identity.ID) {
 	recipients := m.send(packet, to...)
 	if m.messagesRateLimiter != nil {
 		for _, nbr := range recipients {
-			m.messagesRateLimiter.ExtendLimit(nbr.Peer)
+			// Increase the limit by 2 for every message request to make rate limiter more forgiving during node sync.
+			m.messagesRateLimiter.ExtendLimit(nbr.Peer, 2)
 		}
 	}
 }

--- a/packages/ratelimiter/rate_limiter.go
+++ b/packages/ratelimiter/rate_limiter.go
@@ -73,8 +73,8 @@ func (prl *PeerRateLimiter) Count(p *peer.Peer) {
 }
 
 // ExtendLimit extends the activity limit of the peer.
-func (prl *PeerRateLimiter) ExtendLimit(p *peer.Peer) {
-	if err := prl.doExtendLimit(p); err != nil {
+func (prl *PeerRateLimiter) ExtendLimit(p *peer.Peer, val int) {
+	if err := prl.doExtendLimit(p, val); err != nil {
 		prl.log.Warnw("Rate limiter failed to extend peer activity limit",
 			"peerId", p.ID())
 	}
@@ -116,12 +116,12 @@ func (prl *PeerRateLimiter) doCount(p *peer.Peer) error {
 	return nil
 }
 
-func (prl *PeerRateLimiter) doExtendLimit(p *peer.Peer) error {
+func (prl *PeerRateLimiter) doExtendLimit(p *peer.Peer, val int) error {
 	peerRecord, err := prl.getPeerRecord(p)
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	peerRecord.limitExtensionCounter.Incr(1)
+	peerRecord.limitExtensionCounter.Incr(int64(val))
 	return nil
 }
 

--- a/packages/ratelimiter/rate_limiter_test.go
+++ b/packages/ratelimiter/rate_limiter_test.go
@@ -45,7 +45,7 @@ func TestPeerRateLimiter_ExtendLimit(t *testing.T) {
 	testPeer := newTestPeer()
 	limitExtensionCount := 3
 	for i := 0; i < limitExtensionCount; i++ {
-		prl.ExtendLimit(testPeer)
+		prl.ExtendLimit(testPeer, 1)
 	}
 	testCount(t, prl, testPeer, defaultTestLimit+limitExtensionCount)
 }

--- a/plugins/gossip/parameters.go
+++ b/plugins/gossip/parameters.go
@@ -19,13 +19,13 @@ type ParametersDefinition struct {
 }
 
 type messagesLimitParameters struct {
-	Interval time.Duration `default:"1s" usage:"the time interval for which we count the messages rate"`
-	Limit    int           `default:"200" usage:"the base limit of messages per interval"`
+	Interval time.Duration `default:"10s" usage:"the time interval for which we count the messages rate"`
+	Limit    int           `default:"3000" usage:"the base limit of messages per interval"`
 }
 
 type messageRequestsLimitParameters struct {
-	Interval time.Duration `default:"1s" usage:"the time interval for which we count the message requests rate"`
-	Limit    int           `default:"5000" usage:"the base limit of message requests per interval"`
+	Interval time.Duration `default:"10s" usage:"the time interval for which we count the message requests rate"`
+	Limit    int           `default:"50000" usage:"the base limit of message requests per interval"`
 }
 
 // Parameters contains the configuration parameters of the gossip plugin.


### PR DESCRIPTION
@piotrm50 noticed that node triggers rate limit during sync. 
It means that our logic about how we extend the rate limit is wrong. 
I try to extend the limit twice more hoping it could solve the problem and make rate limit more forgiving during sync.