### PR TITLE
Set DEBUG=1 to debug the integration tester

### DIFF
--- a/documentation/docs/tooling/integration_tests.md
+++ b/documentation/docs/tooling/integration_tests.md
@@ -48,6 +48,28 @@ n := f.CreateNetwork("testnetwork", 6, 3)
 defer n.Shutdown() 
 ```
 
+## Debugging tests
+
+Tests can be run defining a `DEBUG=1` (e.g. `DEBUG=1 ./runTests.sh`) environment variable. The main container driving the tests will be run under a Delve Go debugger listening
+on `localhost:50000`.
+The following launch configuration can be used from the VSCode IDE to attach to the debugger and step through the code:
+
+```
+{
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "Connect to Integration tester",
+			"type": "go",
+			"request": "attach",
+			"mode": "remote",
+			"port": 50000,
+			"host": "127.0.0.1"
+		}
+	]
+}
+```
+
 ## Other Tips
 
 Useful for development is to only execute the test you're currently building. For that matter, simply modify the `docker-compose.yml` file as follows:

--- a/tools/integration-tests/assets/entrypoint.sh
+++ b/tools/integration-tests/assets/entrypoint.sh
@@ -5,5 +5,12 @@ cp -rp /tmp/assets/* /assets
 chmod 777 /assets/*
 echo "assets:"
 ls /assets
-echo "running tests..."
-go test ./tests/"${TEST_NAME}" -v -timeout 30m -count=1
+if [ "x$DEBUG" = "x1" ]; then
+  echo "install debugging tools..."
+  go install github.com/go-delve/delve/cmd/dlv@master
+  echo "debugging tests..."
+  dlv test --headless --listen ':40000' --accept-multiclient --api-version 2 ./tests/${TEST_NAME}
+else
+  echo "running tests..."
+  go test ./tests/"${TEST_NAME}" -v -timeout 30m -count=1
+fi

--- a/tools/integration-tests/tester/docker-compose.yml
+++ b/tools/integration-tests/tester/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - DEBUG=${DEBUG}
       - TEST_NAME=${TEST_NAME}
     ports:
-      - 127.0.0.1:40000:40000
+      - "127.0.0.1:50000:40000"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ../../..:/tmp/goshimmer:rw

--- a/tools/integration-tests/tester/docker-compose.yml
+++ b/tools/integration-tests/tester/docker-compose.yml
@@ -3,11 +3,14 @@ version: "3.5"
 services:
   tester:
     container_name: tester
-    image: golang:1.16.2
+    image: golang:1.16
     working_dir: /tmp/goshimmer/tools/integration-tests/tester
     command: /tmp/assets/entrypoint.sh
     environment:
+      - DEBUG=${DEBUG}
       - TEST_NAME=${TEST_NAME}
+    ports:
+      - 127.0.0.1:40000:40000
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ../../..:/tmp/goshimmer:rw


### PR DESCRIPTION
# Description of change

When running integration tests, if the `DEBUG` is set to 1, the `go test` is ran under a headless `dlv` listening on localhost on port `40000`.
It is possible to connect to the debugger via the IDE using the following VSCode launch.json:

```
{
	"version": "0.2.0",
	"configurations": [
		{
			"name": "Connect to server",
			"type": "go",
			"request": "attach",
			"mode": "remote",
			"port": 50000,
			"host": "127.0.0.1"
		}
	]
}
```