### PR TITLE
/healthz to reflect Synced status

### DIFF
--- a/plugins/webapi/healthz/plugin.go
+++ b/plugins/webapi/healthz/plugin.go
@@ -6,11 +6,11 @@ import (
 
 	"github.com/iotaledger/hive.go/daemon"
 	"github.com/iotaledger/hive.go/node"
-	"github.com/iotaledger/hive.go/typeutils"
 	"github.com/labstack/echo"
 	"go.uber.org/dig"
 
 	"github.com/iotaledger/goshimmer/packages/shutdown"
+	"github.com/iotaledger/goshimmer/packages/tangle"
 )
 
 // PluginName is the name of the web API healthz endpoint plugin.
@@ -20,14 +20,13 @@ type dependencies struct {
 	dig.In
 
 	Server *echo.Echo
+	Tangle *tangle.Tangle
 }
 
 var (
 	// Plugin is the plugin instance of the web API info endpoint plugin.
 	Plugin *node.Plugin
 	deps   = new(dependencies)
-
-	healthy typeutils.AtomicBool
 )
 
 func init() {
@@ -45,16 +44,12 @@ func run(plugin *node.Plugin) {
 }
 
 func worker(ctx context.Context) {
-	// set healthy to false as soon as worker exits
-	defer healthy.SetTo(false)
-
-	healthy.SetTo(true)
 	Plugin.LogInfo("All plugins started successfully")
 	<-ctx.Done()
 }
 
 func getHealthz(c echo.Context) error {
-	if !healthy.IsSet() {
+	if !deps.Tangle.TimeManager.Synced() {
 		return c.NoContent(http.StatusServiceUnavailable)
 	}
 	return c.NoContent(http.StatusOK)

--- a/plugins/webapi/healthz/plugin.go
+++ b/plugins/webapi/healthz/plugin.go
@@ -20,7 +20,7 @@ type dependencies struct {
 	dig.In
 
 	Server *echo.Echo
-	Tangle *tangle.Tangle
+	Tangle *tangle.Tangle `optional:"true"`
 }
 
 var (
@@ -49,7 +49,7 @@ func worker(ctx context.Context) {
 }
 
 func getHealthz(c echo.Context) error {
-	if !deps.Tangle.TimeManager.Synced() {
+	if deps.Tangle != nil && !deps.Tangle.TimeManager.Synced() {
 		return c.NoContent(http.StatusServiceUnavailable)
 	}
 	return c.NoContent(http.StatusOK)


### PR DESCRIPTION
# Description of change

Currently we never update the `/healthz` endpoint to reflect the status of the node!

An alternative would have been to attach to `SyncChanged` event, but that wouldn't reflect the health of the node right after start.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)