### PR TITLE
Versions bumps for release v0.8.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # v0.8.6 - 2022-02-11
 
+> This release introduces several small bug fixes and improvements.
+
+The snapshot has been taken at 2022-02-21 17:30 CET.
+- /healthz to reflect Synced status (#2075)
+- clean test cache (#2045)
+- expose port ES to outside (#2052)
+- Build(deps): bump url-parse from 1.5.3 to 1.5.7 in dashboards and DAGs visualizer (#2059)
+- DAGs Vis: Add legend (#2056)
+- Check vertex data before accessing it in graphs (#2054)
+- Build(deps): bump follow-redirects from 1.14.7 to 1.14.8 in /plugins/analysis/dashboard/frontend (#2041)
+- Build(deps): bump follow-redirects from 1.14.7 to 1.14.8 in /plugins/dashboard/frontend (#2040)
+- DAGs Vis: color dags on confirmation and hide aggr branches (#2037)
+- Fix output link to dashboard (#2044)
+
+# v0.8.6 - 2022-02-11
+
 > This release introduces the "Merge to Master" functionality to avoid propagation of Confirmed branches to the future cone and introduces an amazing new DAGs Visualizer tool! The new visualizer is exposed on port 8061 by default, check it out!
 
 The snapshot has been taken at 2022-02-11 10:30 CET.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v0.8.6 - 2022-02-11
+# v0.8.7 - 2022-02-24
 
 > This release introduces several small bug fixes and improvements.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 > This release introduces several small bug fixes and improvements.
 
 The snapshot has been taken at 2022-02-21 17:30 CET.
+- Try to adjust rate limit better (#2053)
 - /healthz to reflect Synced status (#2075)
 - clean test cache (#2045)
 - expose port ES to outside (#2052)

--- a/plugins/autopeering/discovery/parameters.go
+++ b/plugins/autopeering/discovery/parameters.go
@@ -5,7 +5,7 @@ import "github.com/iotaledger/hive.go/configuration"
 // ParametersDefinitionDiscovery contains the definition of configuration parameters used by the autopeering peer discovery.
 type ParametersDefinitionDiscovery struct {
 	// NetworkVersion defines the config flag of the network version.
-	NetworkVersion uint32 `default:"47" usage:"autopeering network version"`
+	NetworkVersion uint32 `default:"48" usage:"autopeering network version"`
 
 	// EntryNodes defines the config flag of the entry nodes.
 	EntryNodes []string `default:"2PV5487xMw5rasGBXXWeqSi4hLz7r19YBt8Y1TGAsQbj@analysisentry-01.devnet.shimmer.iota.cafe:15626,5EDH4uY78EA6wrBkHHAVBWBMDt7EcksRq6pjzipoW15B@entry-0.devnet.tanglebay.com:14646,CAB87iQZR6BjBrCgEBupQJ4gpEBgvGKKv3uuGVRBKb4n@entry-1.devnet.tanglebay.com:14646" usage:"list of trusted entry nodes for auto peering"`

--- a/plugins/banner/plugin.go
+++ b/plugins/banner/plugin.go
@@ -15,7 +15,7 @@ var (
 	Plugin = node.NewPlugin(PluginName, nil, node.Enabled, configure, run)
 
 	// AppVersion version number
-	AppVersion = "v0.8.6"
+	AppVersion = "v0.8.7"
 	// SimplifiedAppVersion is the version number without commit hash
 	SimplifiedAppVersion = simplifiedVersion(AppVersion)
 )

--- a/plugins/database/versioning.go
+++ b/plugins/database/versioning.go
@@ -11,7 +11,7 @@ import (
 const (
 	// DBVersion defines the version of the database schema this version of GoShimmer supports.
 	// Every time there's a breaking change regarding the stored data, this version flag should be adjusted.
-	DBVersion = 49
+	DBVersion = 50
 )
 
 var (


### PR DESCRIPTION
# v0.8.7 - 2022-02-24

> This release introduces several small bug fixes and improvements.

The snapshot has been taken at 2022-02-21 17:30 CET.
- Try to adjust rate limit better (#2053)
- /healthz to reflect Synced status (#2075)
- clean test cache (#2045)
- expose port ES to outside (#2052)
- Build(deps): bump url-parse from 1.5.3 to 1.5.7 in dashboards and DAGs visualizer (#2059)
- DAGs Vis: Add legend (#2056)
- Check vertex data before accessing it in graphs (#2054)
- Build(deps): bump follow-redirects from 1.14.7 to 1.14.8 in /plugins/analysis/dashboard/frontend (#2041)
- Build(deps): bump follow-redirects from 1.14.7 to 1.14.8 in /plugins/dashboard/frontend (#2040)
- DAGs Vis: color dags on confirmation and hide aggr branches (#2037)
- Fix output link to dashboard (#2044)
