### PR TITLE
Remove booker lock

### DIFF
--- a/packages/tangle/booker.go
+++ b/packages/tangle/booker.go
@@ -30,8 +30,6 @@ type Booker struct {
 	bookerQueue chan MessageID
 	shutdown    chan struct{}
 	shutdownWG  sync.WaitGroup
-
-	sync.RWMutex
 }
 
 // NewBooker is the constructor of a Booker.
@@ -157,9 +155,6 @@ func (b *Booker) Shutdown() {
 // as booked. Following, the message branch is set, and it can continue in the dataflow to add support to the determined
 // branches and markers.
 func (b *Booker) BookMessage(messageID MessageID) (err error) {
-	b.RLock()
-	defer b.RUnlock()
-
 	b.tangle.Storage.Message(messageID).Consume(func(message *Message) {
 		b.tangle.Storage.MessageMetadata(messageID).Consume(func(messageMetadata *MessageMetadata) {
 			// TODO: we need to enforce that the dislike references contain "the other" branch with respect to the strong references

--- a/packages/tangle/messagefactory.go
+++ b/packages/tangle/messagefactory.go
@@ -76,9 +76,6 @@ func (f *MessageFactory) SetTimeout(timeout time.Duration) {
 // It also triggers the MessageConstructed event once it's done, which is for example used by the plugins to listen for
 // messages that shall be attached to the tangle.
 func (f *MessageFactory) IssuePayload(p payload.Payload, parentsCount ...int) (*Message, error) {
-	f.tangle.Booker.Lock()
-	defer f.tangle.Booker.Unlock()
-
 	payloadLen := len(p.Bytes())
 	if payloadLen > payload.MaxSize {
 		err := fmt.Errorf("maximum payload size of %d bytes exceeded", payloadLen)


### PR DESCRIPTION
# Description of change

Remove the Booker lock as it is unnecessary and blocks the node while issuing messages and performing PoW. Therefore, no message can be processed anymore and there will be backpressure within the node. 