### PR TITLE
CRITICAL Fix: HandleMarker Confirmation

### DIFF
--- a/packages/consensus/finality/finality_gadget.go
+++ b/packages/consensus/finality/finality_gadget.go
@@ -242,7 +242,7 @@ func (s *SimpleFinalityGadget) HandleMarker(marker *markers.Marker, aw float64) 
 			return
 		}
 
-		if gradeOfFinality > s.opts.MessageGoFReachedLevel {
+		if gradeOfFinality >= s.opts.MessageGoFReachedLevel {
 			s.setMarkerConfirmed(marker)
 		}
 


### PR DESCRIPTION
# Description of change
Fixes a critical bug where we don't set the confirmed marker which, in turn, leads to walking the entire Sequence DAG every time AW for a message is stored (essentially for every message that is booked). 

The condition for stopping the walk down the Sequence DAG is whether a marker is confirmed.  Now, if no marker is ever marked as confirmed, this walk gets longer and longer the more markers and sequences there are. As the booker operates currently still single threaded, this operation blocked the whole node, sometimes for multiple seconds. This creates more and more backpressure and eventually prevents nodes from processing messages fast enough, and the whole network goes out of sync.
