### PR TITLE
Feat: Cleanup code and use new(Entity).From... instead of (&Entity{}).From...

### DIFF
--- a/client/wallet/wallet.go
+++ b/client/wallet/wallet.go
@@ -144,8 +144,8 @@ func (wallet *Wallet) SendFunds(options ...sendoptions.SendFundsOption) (tx *led
 
 	tx = ledgerstate.NewTransaction(txEssence, unlockBlocks)
 
-	// check syntactical validity by marshaling an unmarshaling
-	tx, err = (&ledgerstate.Transaction{}).FromBytes(tx.Bytes())
+	// check syntactical validity by marshaling an unmarshalling
+	tx, err = new(ledgerstate.Transaction).FromBytes(tx.Bytes())
 	if err != nil {
 		return nil, err
 	}
@@ -226,7 +226,7 @@ func (wallet *Wallet) ConsolidateFunds(options ...consolidateoptions.Consolidate
 		tx := ledgerstate.NewTransaction(txEssence, unlockBlocks)
 
 		// check syntactical validity by marshaling an unmarshaling
-		tx, err = (&ledgerstate.Transaction{}).FromBytes(tx.Bytes())
+		tx, err = new(ledgerstate.Transaction).FromBytes(tx.Bytes())
 		if err != nil {
 			return nil, err
 		}
@@ -303,7 +303,7 @@ func (wallet *Wallet) ClaimConditionalFunds(options ...claimconditionaloptions.C
 	tx = ledgerstate.NewTransaction(txEssence, unlockBlocks)
 
 	// check syntactical validity by marshaling an unmarshaling
-	tx, err = (&ledgerstate.Transaction{}).FromBytes(tx.Bytes())
+	tx, err = new(ledgerstate.Transaction).FromBytes(tx.Bytes())
 	if err != nil {
 		return nil, err
 	}
@@ -472,7 +472,7 @@ func (wallet *Wallet) DelegateFunds(options ...delegateoptions.DelegateFundsOpti
 	tx = ledgerstate.NewTransaction(txEssence, unlockBlocks)
 
 	// check syntactical validity by marshaling an unmarshaling
-	tx, err = (&ledgerstate.Transaction{}).FromBytes(tx.Bytes())
+	tx, err = new(ledgerstate.Transaction).FromBytes(tx.Bytes())
 	if err != nil {
 		return
 	}
@@ -599,7 +599,7 @@ func (wallet *Wallet) CreateNFT(options ...createnftoptions.CreateNFTOption) (tx
 	tx = ledgerstate.NewTransaction(txEssence, unlockBlocks)
 
 	// check syntactical validity by marshaling an unmarshaling
-	tx, err = (&ledgerstate.Transaction{}).FromBytes(tx.Bytes())
+	tx, err = new(ledgerstate.Transaction).FromBytes(tx.Bytes())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -720,7 +720,7 @@ func (wallet *Wallet) TransferNFT(options ...transfernftoptions.TransferNFTOptio
 	})
 
 	// check syntactical validity by marshaling an unmarshaling
-	tx, err = (&ledgerstate.Transaction{}).FromBytes(tx.Bytes())
+	tx, err = new(ledgerstate.Transaction).FromBytes(tx.Bytes())
 	if err != nil {
 		return nil, err
 	}
@@ -816,7 +816,7 @@ func (wallet *Wallet) DestroyNFT(options ...destroynftoptions.DestroyNFTOption) 
 	})
 
 	// check syntactical validity by marshaling an unmarshaling
-	tx, err = (&ledgerstate.Transaction{}).FromBytes(tx.Bytes())
+	tx, err = new(ledgerstate.Transaction).FromBytes(tx.Bytes())
 	if err != nil {
 		return nil, err
 	}
@@ -928,7 +928,7 @@ func (wallet *Wallet) WithdrawFundsFromNFT(options ...withdrawfromnftoptions.Wit
 	})
 
 	// check syntactical validity by marshaling an unmarshaling
-	tx, err = (&ledgerstate.Transaction{}).FromBytes(tx.Bytes())
+	tx, err = new(ledgerstate.Transaction).FromBytes(tx.Bytes())
 	if err != nil {
 		return nil, err
 	}
@@ -1043,7 +1043,7 @@ func (wallet *Wallet) DepositFundsToNFT(options ...deposittonftoptions.DepositFu
 	tx = ledgerstate.NewTransaction(txEssence, unlockBlocks)
 
 	// check syntactical validity by marshaling an unmarshaling
-	tx, err = (&ledgerstate.Transaction{}).FromBytes(tx.Bytes())
+	tx, err = new(ledgerstate.Transaction).FromBytes(tx.Bytes())
 	if err != nil {
 		return nil, err
 	}
@@ -1182,7 +1182,7 @@ func (wallet Wallet) SweepNFTOwnedFunds(options ...sweepnftownedoptions.SweepNFT
 	tx = ledgerstate.NewTransaction(essence, unlockBlocks)
 
 	// check syntactical validity by marshaling an unmarshaling
-	tx, err = (&ledgerstate.Transaction{}).FromBytes(tx.Bytes())
+	tx, err = new(ledgerstate.Transaction).FromBytes(tx.Bytes())
 	if err != nil {
 		return nil, err
 	}

--- a/packages/consensus/finality/finality_gadget.go
+++ b/packages/consensus/finality/finality_gadget.go
@@ -295,11 +295,10 @@ func (s *SimpleFinalityGadget) propagateGoFToMessagePastCone(messageID tangle.Me
 	}
 
 	weakParentsSet.ForEach(func(weakParent tangle.MessageID) {
-		weakParentMessageID := weakParent
-		if strongParentWalker.Pushed(weakParentMessageID) {
+		if strongParentWalker.Pushed(weakParent) {
 			return
 		}
-		s.tangle.Storage.MessageMetadata(weakParentMessageID).Consume(func(messageMetadata *tangle.MessageMetadata) {
+		s.tangle.Storage.MessageMetadata(weakParent).Consume(func(messageMetadata *tangle.MessageMetadata) {
 			if messageMetadata.GradeOfFinality() >= gradeOfFinality {
 				return
 			}

--- a/packages/ledgerstate/branch.go
+++ b/packages/ledgerstate/branch.go
@@ -383,12 +383,12 @@ func BranchFromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (branch Branch,
 
 	switch BranchType(branchType) {
 	case ConflictBranchType:
-		if branch, err = (&ConflictBranch{}).FromMarshalUtil(marshalUtil); err != nil {
+		if branch, err = new(ConflictBranch).FromMarshalUtil(marshalUtil); err != nil {
 			err = errors.Errorf("failed to parse ConflictBranch: %w", err)
 			return
 		}
 	case AggregatedBranchType:
-		if branch, err = (&AggregatedBranch{}).FromMarshalUtil(marshalUtil); err != nil {
+		if branch, err = new(AggregatedBranch).FromMarshalUtil(marshalUtil); err != nil {
 			err = errors.Errorf("failed to parse AggregatedBranch: %w", err)
 			return
 		}
@@ -449,7 +449,7 @@ func (c *ConflictBranch) FromObjectStorage(_, bytes []byte) (conflictBranch obje
 }
 
 // FromBytes unmarshals an ConflictBranch from a sequence of bytes.
-func (c *ConflictBranch) FromBytes(bytes []byte) (conflictBranch objectstorage.StorableObject, err error) {
+func (c *ConflictBranch) FromBytes(bytes []byte) (conflictBranch *ConflictBranch, err error) {
 	marshalUtil := marshalutil.New(bytes)
 	if conflictBranch, err = c.FromMarshalUtil(marshalUtil); err != nil {
 		err = errors.Errorf("failed to parse ConflictBranch from MarshalUtil: %w", err)
@@ -461,9 +461,8 @@ func (c *ConflictBranch) FromBytes(bytes []byte) (conflictBranch objectstorage.S
 
 // FromMarshalUtil unmarshals an ConflictBranch using a MarshalUtil (for easier unmarshaling).
 func (c *ConflictBranch) FromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (conflictBranch *ConflictBranch, err error) {
-	conflictBranch = c
-	if c == nil {
-		conflictBranch = &ConflictBranch{}
+	if conflictBranch = c; c == nil {
+		conflictBranch = new(ConflictBranch)
 	}
 
 	branchType, err := marshalUtil.ReadByte()
@@ -609,7 +608,7 @@ func (c *ConflictBranch) ObjectStorageValue() []byte {
 }
 
 // code contract (make sure the struct implements all required methods)
-var _ Branch = &ConflictBranch{}
+var _ Branch = new(ConflictBranch)
 
 // endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -668,9 +667,8 @@ func (a *AggregatedBranch) FromBytes(bytes []byte) (aggregatedBranch objectstora
 
 // FromMarshalUtil unmarshals an AggregatedBranch using a MarshalUtil (for easier unmarshaling).
 func (a *AggregatedBranch) FromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (aggregatedBranch *AggregatedBranch, err error) {
-	aggregatedBranch = a
-	if a == nil {
-		aggregatedBranch = &AggregatedBranch{}
+	if aggregatedBranch = a; a == nil {
+		aggregatedBranch = new(AggregatedBranch)
 	}
 
 	branchType, err := marshalUtil.ReadByte()
@@ -795,9 +793,8 @@ func (c *ChildBranch) FromBytes(bytes []byte) (childBranch objectstorage.Storabl
 
 // FromMarshalUtil unmarshals an ChildBranch using a MarshalUtil (for easier unmarshaling).
 func (c *ChildBranch) FromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (childBranch *ChildBranch, err error) {
-	childBranch = c
-	if c == nil {
-		childBranch = &ChildBranch{}
+	if childBranch = c; c == nil {
+		childBranch = new(ChildBranch)
 	}
 
 	if childBranch.parentBranchID, err = BranchIDFromMarshalUtil(marshalUtil); err != nil {
@@ -861,7 +858,7 @@ func (c *ChildBranch) ObjectStorageValue() (objectStorageValue []byte) {
 }
 
 // code contract (make sure the struct implements all required methods)
-var _ objectstorage.StorableObject = &ChildBranch{}
+var _ objectstorage.StorableObject = new(ChildBranch)
 
 // endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/packages/ledgerstate/branch.go
+++ b/packages/ledgerstate/branch.go
@@ -461,7 +461,7 @@ func (c *ConflictBranch) FromBytes(bytes []byte) (conflictBranch *ConflictBranch
 
 // FromMarshalUtil unmarshals an ConflictBranch using a MarshalUtil (for easier unmarshaling).
 func (c *ConflictBranch) FromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (conflictBranch *ConflictBranch, err error) {
-	if conflictBranch = c; c == nil {
+	if conflictBranch = c; conflictBranch == nil {
 		conflictBranch = new(ConflictBranch)
 	}
 
@@ -667,7 +667,7 @@ func (a *AggregatedBranch) FromBytes(bytes []byte) (aggregatedBranch objectstora
 
 // FromMarshalUtil unmarshals an AggregatedBranch using a MarshalUtil (for easier unmarshaling).
 func (a *AggregatedBranch) FromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (aggregatedBranch *AggregatedBranch, err error) {
-	if aggregatedBranch = a; a == nil {
+	if aggregatedBranch = a; aggregatedBranch == nil {
 		aggregatedBranch = new(AggregatedBranch)
 	}
 
@@ -793,7 +793,7 @@ func (c *ChildBranch) FromBytes(bytes []byte) (childBranch objectstorage.Storabl
 
 // FromMarshalUtil unmarshals an ChildBranch using a MarshalUtil (for easier unmarshaling).
 func (c *ChildBranch) FromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (childBranch *ChildBranch, err error) {
-	if childBranch = c; c == nil {
+	if childBranch = c; childBranch == nil {
 		childBranch = new(ChildBranch)
 	}
 

--- a/packages/ledgerstate/color.go
+++ b/packages/ledgerstate/color.go
@@ -54,7 +54,7 @@ func ColorFromBase58EncodedString(base58String string) (color Color, err error) 
 	return
 }
 
-// ColorFromMarshalUtil unmarshals a Color using a MarshalUtil (for easier unmarshaling).
+// ColorFromMarshalUtil unmarshals a Color using a MarshalUtil (for easier unmarshalling).
 func ColorFromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (color Color, err error) {
 	colorBytes, err := marshalUtil.ReadBytes(ColorLength)
 	if err != nil {
@@ -139,7 +139,7 @@ func ColoredBalancesFromBytes(bytes []byte) (coloredBalances *ColoredBalances, c
 	return
 }
 
-// ColoredBalancesFromMarshalUtil unmarshals ColoredBalances using a MarshalUtil (for easier unmarshaling).
+// ColoredBalancesFromMarshalUtil unmarshals ColoredBalances using a MarshalUtil (for easier unmarshalling).
 func ColoredBalancesFromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (coloredBalances *ColoredBalances, err error) {
 	balancesCount, err := marshalUtil.ReadUint32()
 	if err != nil {
@@ -191,9 +191,7 @@ func (c *ColoredBalances) Get(color Color) (uint64, bool) {
 
 // ForEach calls the consumer for each element in the collection and aborts the iteration if the consumer returns false.
 func (c *ColoredBalances) ForEach(consumer func(color Color, balance uint64) bool) {
-	c.balances.ForEach(func(key Color, value uint64) bool {
-		return consumer(key, value)
-	})
+	c.balances.ForEach(consumer)
 }
 
 // Size returns the amount of individual balances in the ColoredBalances.

--- a/packages/ledgerstate/conflict.go
+++ b/packages/ledgerstate/conflict.go
@@ -196,7 +196,7 @@ func (c *Conflict) FromObjectStorage(key, bytes []byte) (conflict objectstorage.
 }
 
 // FromBytes unmarshals a Conflict from a sequence of bytes.
-func (c *Conflict) FromBytes(bytes []byte) (conflict objectstorage.StorableObject, err error) {
+func (c *Conflict) FromBytes(bytes []byte) (conflict *Conflict, err error) {
 	marshalUtil := marshalutil.New(bytes)
 	if conflict, err = c.FromMarshalUtil(marshalUtil); err != nil {
 		err = errors.Errorf("failed to parse Conflict from MarshalUtil: %w", err)
@@ -208,8 +208,7 @@ func (c *Conflict) FromBytes(bytes []byte) (conflict objectstorage.StorableObjec
 
 // FromMarshalUtil unmarshals a Conflict using a MarshalUtil (for easier unmarshaling).
 func (c *Conflict) FromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (conflict *Conflict, err error) {
-	conflict = c
-	if c == nil {
+	if conflict = c; conflict == nil {
 		conflict = &Conflict{}
 	}
 	if conflict.id, err = ConflictIDFromMarshalUtil(marshalUtil); err != nil {
@@ -338,7 +337,7 @@ func (c *ConflictMember) FromObjectStorage(key, bytes []byte) (conflictMember ob
 }
 
 // FromBytes unmarshals a ConflictMember from a sequence of bytes.
-func (c *ConflictMember) FromBytes(bytes []byte) (conflictMember objectstorage.StorableObject, err error) {
+func (c *ConflictMember) FromBytes(bytes []byte) (conflictMember *ConflictMember, err error) {
 	marshalUtil := marshalutil.New(bytes)
 	if conflictMember, err = c.FromMarshalUtil(marshalUtil); err != nil {
 		err = errors.Errorf("failed to parse ConflictMember from MarshalUtil: %w", err)
@@ -350,8 +349,7 @@ func (c *ConflictMember) FromBytes(bytes []byte) (conflictMember objectstorage.S
 
 // FromMarshalUtil unmarshals an ConflictMember using a MarshalUtil (for easier unmarshaling).
 func (c *ConflictMember) FromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (conflictMember *ConflictMember, err error) {
-	conflictMember = c
-	if c == nil {
+	if conflictMember = c; conflictMember == nil {
 		conflictMember = &ConflictMember{}
 	}
 	if conflictMember.conflictID, err = ConflictIDFromMarshalUtil(marshalUtil); err != nil {

--- a/packages/ledgerstate/output.go
+++ b/packages/ledgerstate/output.go
@@ -262,22 +262,22 @@ func OutputFromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (output Output,
 
 	switch OutputType(outputType) {
 	case SigLockedSingleOutputType:
-		if output, err = (&SigLockedSingleOutput{}).FromMarshalUtil(marshalUtil); err != nil {
+		if output, err = new(SigLockedSingleOutput).FromMarshalUtil(marshalUtil); err != nil {
 			err = errors.Errorf("failed to parse SigLockedSingleOutput: %w", err)
 			return
 		}
 	case SigLockedColoredOutputType:
-		if output, err = (&SigLockedColoredOutput{}).FromMarshalUtil(marshalUtil); err != nil {
+		if output, err = new(SigLockedColoredOutput).FromMarshalUtil(marshalUtil); err != nil {
 			err = errors.Errorf("failed to parse SigLockedColoredOutput: %w", err)
 			return
 		}
 	case AliasOutputType:
-		if output, err = (&AliasOutput{}).FromMarshalUtil(marshalUtil); err != nil {
+		if output, err = new(AliasOutput).FromMarshalUtil(marshalUtil); err != nil {
 			err = errors.Errorf("failed to parse AliasOutput: %w", err)
 			return
 		}
 	case ExtendedLockedOutputType:
-		if output, err = (&ExtendedLockedOutput{}).FromMarshalUtil(marshalUtil); err != nil {
+		if output, err = new(ExtendedLockedOutput).FromMarshalUtil(marshalUtil); err != nil {
 			err = errors.Errorf("failed to parse ExtendedOutput: %w", err)
 			return
 		}
@@ -554,7 +554,7 @@ func (s *SigLockedSingleOutput) FromObjectStorage(key, bytes []byte) (objectstor
 }
 
 // FromBytes unmarshals a SigLockedSingleOutput from a sequence of bytes.
-func (s *SigLockedSingleOutput) FromBytes(bytes []byte) (output objectstorage.StorableObject, err error) {
+func (s *SigLockedSingleOutput) FromBytes(bytes []byte) (output *SigLockedSingleOutput, err error) {
 	marshalUtil := marshalutil.New(bytes)
 	if output, err = s.FromMarshalUtil(marshalUtil); err != nil {
 		err = errors.Errorf("failed to parse SigLockedSingleOutput from MarshalUtil: %w", err)
@@ -565,9 +565,8 @@ func (s *SigLockedSingleOutput) FromBytes(bytes []byte) (output objectstorage.St
 
 // FromMarshalUtil unmarshals a SigLockedSingleOutput using a MarshalUtil (for easier unmarshaling).
 func (s *SigLockedSingleOutput) FromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (output *SigLockedSingleOutput, err error) {
-	output = s
-	if s == nil {
-		output = &SigLockedSingleOutput{}
+	if output = s; output == nil {
+		output = new(SigLockedSingleOutput)
 	}
 
 	outputType, err := marshalUtil.ReadByte()
@@ -731,7 +730,7 @@ func (s *SigLockedSingleOutput) String() string {
 }
 
 // code contract (make sure the type implements all required methods)
-var _ Output = &SigLockedSingleOutput{}
+var _ Output = new(SigLockedSingleOutput)
 
 // endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -762,7 +761,7 @@ func (s *SigLockedColoredOutput) FromObjectStorage(key, bytes []byte) (objectsto
 }
 
 // FromBytes unmarshals a SigLockedColoredOutput from a sequence of bytes.
-func (s *SigLockedColoredOutput) FromBytes(bytes []byte) (output objectstorage.StorableObject, err error) {
+func (s *SigLockedColoredOutput) FromBytes(bytes []byte) (output *SigLockedColoredOutput, err error) {
 	marshalUtil := marshalutil.New(bytes)
 	if output, err = s.FromMarshalUtil(marshalUtil); err != nil {
 		err = errors.Errorf("failed to parse SigLockedColoredOutput from MarshalUtil: %w", err)
@@ -774,9 +773,8 @@ func (s *SigLockedColoredOutput) FromBytes(bytes []byte) (output objectstorage.S
 
 // FromMarshalUtil unmarshals a SigLockedColoredOutput using a MarshalUtil (for easier unmarshaling).
 func (s *SigLockedColoredOutput) FromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (output *SigLockedColoredOutput, err error) {
-	output = s
-	if s == nil {
-		output = &SigLockedColoredOutput{}
+	if output = s; output == nil {
+		output = new(SigLockedColoredOutput)
 	}
 
 	outputType, err := marshalUtil.ReadByte()
@@ -936,7 +934,7 @@ func (s *SigLockedColoredOutput) String() string {
 }
 
 // code contract (make sure the type implements all required methods)
-var _ Output = &SigLockedColoredOutput{}
+var _ Output = new(SigLockedColoredOutput)
 
 // endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -1058,7 +1056,7 @@ func (a *AliasOutput) FromObjectStorage(key, bytes []byte) (objectstorage.Storab
 }
 
 // FromBytes unmarshals a ExtendedLockedOutput from a sequence of bytes.
-func (a *AliasOutput) FromBytes(data []byte) (output objectstorage.StorableObject, err error) {
+func (a *AliasOutput) FromBytes(data []byte) (output *AliasOutput, err error) {
 	marshalUtil := marshalutil.New(data)
 	if output, err = a.FromMarshalUtil(marshalUtil); err != nil {
 		err = errors.Errorf("failed to parse AliasOutput from MarshalUtil: %w", err)
@@ -1069,10 +1067,9 @@ func (a *AliasOutput) FromBytes(data []byte) (output objectstorage.StorableObjec
 }
 
 // FromMarshalUtil unmarshals a AliasOutput using a MarshalUtil (for easier unmarshaling).
-func (a *AliasOutput) FromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (*AliasOutput, error) {
-	ret := a
-	if a == nil {
-		ret = &AliasOutput{}
+func (a *AliasOutput) FromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (output *AliasOutput, err error) {
+	if output = a; output == nil {
+		output = new(AliasOutput)
 	}
 
 	outputType, err := marshalUtil.ReadByte()
@@ -1087,25 +1084,25 @@ func (a *AliasOutput) FromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (*Al
 		return nil, errors.Errorf("aliasOutput: failed to parse AliasOutput flags (%v): %w", err1, cerrors.ErrParseBytesFailed)
 	}
 	flags := bitmask.BitMask(flagsByte)
-	ret.isOrigin = flags.HasBit(flagAliasOutputIsOrigin)
-	ret.isGovernanceUpdate = flags.HasBit(flagAliasOutputGovernanceUpdate)
-	ret.isDelegated = flags.HasBit(flagAliasOutputDelegationConstraint)
+	output.isOrigin = flags.HasBit(flagAliasOutputIsOrigin)
+	output.isGovernanceUpdate = flags.HasBit(flagAliasOutputGovernanceUpdate)
+	output.isDelegated = flags.HasBit(flagAliasOutputDelegationConstraint)
 
 	addr, err2 := AliasAddressFromMarshalUtil(marshalUtil)
 	if err2 != nil {
 		return nil, errors.Errorf("aliasOutput: failed to parse alias address (%v): %w", err2, cerrors.ErrParseBytesFailed)
 	}
-	ret.aliasAddress = *addr
+	output.aliasAddress = *addr
 	cb, err3 := ColoredBalancesFromMarshalUtil(marshalUtil)
 	if err3 != nil {
 		return nil, errors.Errorf("AliasOutput: failed to parse colored balances: %w", err3)
 	}
-	ret.balances = cb
-	ret.stateAddress, err = AddressFromMarshalUtil(marshalUtil)
+	output.balances = cb
+	output.stateAddress, err = AddressFromMarshalUtil(marshalUtil)
 	if err != nil {
 		return nil, errors.Errorf("aliasOutput: failed to parse state address (%v): %w", err, cerrors.ErrParseBytesFailed)
 	}
-	ret.stateIndex, err = marshalUtil.ReadUint32()
+	output.stateIndex, err = marshalUtil.ReadUint32()
 	if err != nil {
 		return nil, errors.Errorf("aliasOutput: failed to parse state address (%v): %w", err, cerrors.ErrParseBytesFailed)
 	}
@@ -1114,7 +1111,7 @@ func (a *AliasOutput) FromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (*Al
 		if err4 != nil {
 			return nil, errors.Errorf("aliasOutput: failed to parse state data size: %w", err4)
 		}
-		ret.stateData, err = marshalUtil.ReadBytes(int(size))
+		output.stateData, err = marshalUtil.ReadBytes(int(size))
 		if err != nil {
 			return nil, errors.Errorf("aliasOutput: failed to parse state data: %w", err)
 		}
@@ -1124,7 +1121,7 @@ func (a *AliasOutput) FromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (*Al
 		if err5 != nil {
 			return nil, errors.Errorf("aliasOutput: failed to parse governance metadata size: %w", err5)
 		}
-		ret.governanceMetadata, err = marshalUtil.ReadBytes(int(size))
+		output.governanceMetadata, err = marshalUtil.ReadBytes(int(size))
 		if err != nil {
 			return nil, errors.Errorf("aliasOutput: failed to parse governance metadata data: %w", err)
 		}
@@ -1134,27 +1131,27 @@ func (a *AliasOutput) FromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (*Al
 		if err6 != nil {
 			return nil, errors.Errorf("aliasOutput: failed to parse immutable data size: %w", err6)
 		}
-		ret.immutableData, err = marshalUtil.ReadBytes(int(size))
+		output.immutableData, err = marshalUtil.ReadBytes(int(size))
 		if err != nil {
 			return nil, errors.Errorf("aliasOutput: failed to parse immutable data: %w", err)
 		}
 	}
 	if flags.HasBit(flagAliasOutputGovernanceSet) {
-		ret.governingAddress, err = AddressFromMarshalUtil(marshalUtil)
+		output.governingAddress, err = AddressFromMarshalUtil(marshalUtil)
 		if err != nil {
 			return nil, errors.Errorf("aliasOutput: failed to parse governing address (%v): %w", err, cerrors.ErrParseBytesFailed)
 		}
 	}
 	if flags.HasBit(flagAliasOutputDelegationTimelockPresent) {
-		ret.delegationTimelock, err = marshalUtil.ReadTime()
+		output.delegationTimelock, err = marshalUtil.ReadTime()
 		if err != nil {
 			return nil, errors.Errorf("aliasOutput: failed to parse delegation timelock (%v): %w", err, cerrors.ErrParseBytesFailed)
 		}
 	}
-	if err7 := ret.checkBasicValidity(); err7 != nil {
+	if err7 := output.checkBasicValidity(); err7 != nil {
 		return nil, err7
 	}
-	return ret, nil
+	return output, nil
 }
 
 // SetBalances sets colored balances of the output.
@@ -1843,7 +1840,7 @@ func (a *AliasOutput) hasToBeUnlockedForGovernanceUpdate(tx *Transaction) bool {
 }
 
 // code contract (make sure the type implements all required methods).
-var _ Output = &AliasOutput{}
+var _ Output = new(AliasOutput)
 
 // endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -1923,7 +1920,7 @@ func (o *ExtendedLockedOutput) FromObjectStorage(key, bytes []byte) (objectstora
 }
 
 // FromBytes unmarshals a ExtendedLockedOutput from a sequence of bytes.
-func (o *ExtendedLockedOutput) FromBytes(data []byte) (output objectstorage.StorableObject, err error) {
+func (o *ExtendedLockedOutput) FromBytes(data []byte) (output *ExtendedLockedOutput, err error) {
 	marshalUtil := marshalutil.New(data)
 	if output, err = o.FromMarshalUtil(marshalUtil); err != nil {
 		err = errors.Errorf("failed to parse ExtendedLockedOutput from MarshalUtil: %w", err)
@@ -1933,11 +1930,10 @@ func (o *ExtendedLockedOutput) FromBytes(data []byte) (output objectstorage.Stor
 	return
 }
 
-// FromMarshalUtil unmarshals a ExtendedLockedOutput using a MarshalUtil (for easier unmarshaling).
+// FromMarshalUtil unmarshals a ExtendedLockedOutput using a MarshalUtil (for easier unmarshalling).
 func (o *ExtendedLockedOutput) FromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (output *ExtendedLockedOutput, err error) {
-	output = o
-	if o == nil {
-		output = &ExtendedLockedOutput{}
+	if output = o; output == nil {
+		output = new(ExtendedLockedOutput)
 	}
 
 	outputType, err := marshalUtil.ReadByte()
@@ -2224,7 +2220,7 @@ func (o *ExtendedLockedOutput) UnlockAddressNow(nowis time.Time) Address {
 }
 
 // code contract (make sure the type implements all required methods).
-var _ Output = &ExtendedLockedOutput{}
+var _ Output = new(ExtendedLockedOutput)
 
 // endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -2265,7 +2261,7 @@ func (o *OutputMetadata) FromObjectStorage(key, bytes []byte) (objectstorage.Sto
 }
 
 // FromBytes unmarshals an OutputMetadata object from a sequence of bytes.
-func (o *OutputMetadata) FromBytes(bytes []byte) (outputMetadata objectstorage.StorableObject, err error) {
+func (o *OutputMetadata) FromBytes(bytes []byte) (outputMetadata *OutputMetadata, err error) {
 	marshalUtil := marshalutil.New(bytes)
 	if outputMetadata, err = o.FromMarshalUtil(marshalUtil); err != nil {
 		err = errors.Errorf("failed to parse OutputMetadata from MarshalUtil: %w", err)
@@ -2275,11 +2271,10 @@ func (o *OutputMetadata) FromBytes(bytes []byte) (outputMetadata objectstorage.S
 	return
 }
 
-// FromMarshalUtil unmarshals an OutputMetadata object using a MarshalUtil (for easier unmarshaling).
+// FromMarshalUtil unmarshals an OutputMetadata object using a MarshalUtil (for easier unmarshalling).
 func (o *OutputMetadata) FromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (outputMetadata *OutputMetadata, err error) {
-	outputMetadata = o
-	if o == nil {
-		outputMetadata = &OutputMetadata{}
+	if outputMetadata = o; outputMetadata == nil {
+		outputMetadata = new(OutputMetadata)
 	}
 
 	if outputMetadata.id, err = OutputIDFromMarshalUtil(marshalUtil); err != nil {
@@ -2473,7 +2468,7 @@ func (o *OutputMetadata) ObjectStorageValue() []byte {
 }
 
 // code contract (make sure the type implements all required methods)
-var _ objectstorage.StorableObject = &OutputMetadata{}
+var _ objectstorage.StorableObject = new(OutputMetadata)
 
 // endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/packages/ledgerstate/output_test.go
+++ b/packages/ledgerstate/output_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/iotaledger/hive.go/byteutils"
 	"github.com/iotaledger/hive.go/crypto/ed25519"
-	"github.com/iotaledger/hive.go/generics/objectstorage"
 	"github.com/iotaledger/hive.go/identity"
 	"github.com/iotaledger/hive.go/marshalutil"
 	"github.com/stretchr/testify/assert"
@@ -84,7 +83,7 @@ func TestAliasOutput_NewAliasOutputNext(t *testing.T) {
 		assert.True(t, originAlias.GetAliasAddress().Equals(nextAlias.GetAliasAddress()))
 		assert.True(t, originAlias.GetStateAddress().Equals(nextAlias.GetStateAddress()))
 		assert.True(t, originAlias.GetGoverningAddress().Equals(nextAlias.GetGoverningAddress()))
-		// outputid is actually irrelevant here
+		// OutputID is actually irrelevant here
 		assert.True(t, bytes.Equal(nextAlias.ID().Bytes(), originAlias.ID().Bytes()))
 		assert.Equal(t, originAlias.Balances().Bytes(), nextAlias.Balances().Bytes())
 		assert.Equal(t, originAlias.GetStateIndex()+1, nextAlias.GetStateIndex())
@@ -99,7 +98,7 @@ func TestAliasOutput_NewAliasOutputNext(t *testing.T) {
 		assert.True(t, originAlias.GetAliasAddress().Equals(nextAlias.GetAliasAddress()))
 		assert.True(t, originAlias.GetStateAddress().Equals(nextAlias.GetStateAddress()))
 		assert.True(t, originAlias.GetGoverningAddress().Equals(nextAlias.GetGoverningAddress()))
-		// outputid is actually irrelevant here
+		// OutputID is actually irrelevant here
 		assert.True(t, bytes.Equal(nextAlias.ID().Bytes(), originAlias.ID().Bytes()))
 		assert.Equal(t, originAlias.Balances().Bytes(), nextAlias.Balances().Bytes())
 		assert.Equal(t, originAlias.GetStateIndex(), nextAlias.GetStateIndex())
@@ -119,7 +118,7 @@ func TestAliasOutput_NewAliasOutputNext(t *testing.T) {
 		assert.True(t, originAlias.GetAliasAddress().Equals(nextAlias.GetAliasAddress()))
 		assert.True(t, originAlias.GetStateAddress().Equals(nextAlias.GetStateAddress()))
 		assert.True(t, originAlias.GetGoverningAddress().Equals(nextAlias.GetGoverningAddress()))
-		// outputid is actually irrelevant here
+		// OutputID is actually irrelevant here
 		assert.True(t, bytes.Equal(nextAlias.ID().Bytes(), originAlias.ID().Bytes()))
 		assert.Equal(t, originAlias.Balances().Bytes(), nextAlias.Balances().Bytes())
 		assert.Equal(t, originAlias.GetStateIndex()+1, nextAlias.GetStateIndex())
@@ -138,7 +137,7 @@ func TestAliasOutput_NewAliasOutputNext(t *testing.T) {
 		assert.True(t, originAlias.GetAliasAddress().Equals(nextAlias.GetAliasAddress()))
 		assert.True(t, originAlias.GetStateAddress().Equals(nextAlias.GetStateAddress()))
 		assert.True(t, originAlias.GetGoverningAddress().Equals(nextAlias.GetGoverningAddress()))
-		// outputid is actually irrelevant here
+		// OutputID is actually irrelevant here
 		assert.True(t, bytes.Equal(nextAlias.ID().Bytes(), originAlias.ID().Bytes()))
 		assert.Equal(t, originAlias.Balances().Bytes(), nextAlias.Balances().Bytes())
 		assert.Equal(t, originAlias.GetStateIndex(), nextAlias.GetStateIndex())
@@ -164,7 +163,7 @@ func TestAliasOutputFromMarshalUtil(t *testing.T) {
 		// manually change output type byte
 		originBytes[0] = 1
 		marshalUtil := marshalutil.New(originBytes)
-		_, err := (&AliasOutput{}).FromMarshalUtil(marshalUtil)
+		_, err := new(AliasOutput).FromMarshalUtil(marshalUtil)
 		assert.Error(t, err)
 	})
 
@@ -383,7 +382,7 @@ func TestAliasOutput_Bytes(t *testing.T) {
 		alias := dummyAliasOutput()
 		aBytes := alias.Bytes()
 		mUtil := marshalutil.New(aBytes)
-		restoredAlias, err := (&AliasOutput{}).FromMarshalUtil(mUtil)
+		restoredAlias, err := new(AliasOutput).FromMarshalUtil(mUtil)
 		assert.NoError(t, err)
 		assert.True(t, alias.GetAliasAddress().Equals(restoredAlias.GetAliasAddress()))
 		assert.True(t, alias.GetStateAddress().Equals(restoredAlias.GetStateAddress()))
@@ -402,7 +401,7 @@ func TestAliasOutput_Compare(t *testing.T) {
 		alias := dummyAliasOutput()
 		aBytes := alias.Bytes()
 		mUtil := marshalutil.New(aBytes)
-		restoredAlias, err := (&AliasOutput{}).FromMarshalUtil(mUtil)
+		restoredAlias, err := new(AliasOutput).FromMarshalUtil(mUtil)
 		assert.NoError(t, err)
 		assert.True(t, alias.Compare(restoredAlias) == 0)
 	})
@@ -590,57 +589,57 @@ func TestAliasOutput_ObjectStorageValue(t *testing.T) {
 	// same as Bytes()
 }
 
-func TestAliasOutput_DelegationTimelock(t *testing.T) {
+func TestAliasOutput_DelegationTimeLock(t *testing.T) {
 	t.Run("CASE: Happy path", func(t *testing.T) {
 		alias := dummyAliasOutput()
-		// not a delegated aliasoutput,
+		// not a delegated AliasOutput,
 		assert.True(t, alias.DelegationTimelock().IsZero())
-		// is a delegated output, but no timelock set
+		// is a delegated output, but no time-lock set
 		alias.isDelegated = true
 		assert.True(t, alias.DelegationTimelock().IsZero())
-		// delegated output, timelock set
-		timelock := time.Now()
-		alias.delegationTimelock = timelock
-		assert.True(t, timelock.Equal(alias.DelegationTimelock()))
+		// delegated output, time-lock set
+		timeLock := time.Now()
+		alias.delegationTimelock = timeLock
+		assert.True(t, timeLock.Equal(alias.DelegationTimelock()))
 	})
 }
 
 func TestAliasOutput_DelegationTimeLockedNow(t *testing.T) {
 	t.Run("CASE: Happy path", func(t *testing.T) {
-		timelock := time.Now()
+		timeLock := time.Now()
 		alias := dummyAliasOutput()
 		alias.isDelegated = true
-		err := alias.SetDelegationTimelock(timelock)
+		err := alias.SetDelegationTimelock(timeLock)
 		assert.NoError(t, err)
 
-		assert.True(t, alias.DelegationTimeLockedNow(timelock.Add(-time.Second)))
-		assert.False(t, alias.DelegationTimeLockedNow(timelock.Add(time.Second)))
+		assert.True(t, alias.DelegationTimeLockedNow(timeLock.Add(-time.Second)))
+		assert.False(t, alias.DelegationTimeLockedNow(timeLock.Add(time.Second)))
 	})
 
-	t.Run("CASE: Delegation without timelock", func(t *testing.T) {
-		timelock := time.Now()
+	t.Run("CASE: Delegation without time-lock", func(t *testing.T) {
+		timeLock := time.Now()
 		alias := dummyAliasOutput()
 		alias.isDelegated = true
 
-		assert.False(t, alias.DelegationTimeLockedNow(timelock.Add(-time.Second)))
-		assert.False(t, alias.DelegationTimeLockedNow(timelock.Add(time.Second)))
+		assert.False(t, alias.DelegationTimeLockedNow(timeLock.Add(-time.Second)))
+		assert.False(t, alias.DelegationTimeLockedNow(timeLock.Add(time.Second)))
 	})
 }
 
-func TestAliasOutput_SetDelegationTimelock(t *testing.T) {
+func TestAliasOutput_SetDelegationTimeLock(t *testing.T) {
 	t.Run("CASE: Happy path", func(t *testing.T) {
-		timelock := time.Now()
+		timeLock := time.Now()
 		alias := dummyAliasOutput()
 		// not delegated,
-		err := alias.SetDelegationTimelock(timelock)
+		err := alias.SetDelegationTimelock(timeLock)
 		t.Log(err)
 		assert.Error(t, err)
 		assert.True(t, alias.DelegationTimelock().IsZero())
 		// delegated
 		alias.isDelegated = true
-		err = alias.SetDelegationTimelock(timelock)
+		err = alias.SetDelegationTimelock(timeLock)
 		assert.NoError(t, err)
-		assert.True(t, alias.DelegationTimelock().Equal(timelock))
+		assert.True(t, alias.DelegationTimelock().Equal(timeLock))
 	})
 }
 
@@ -718,9 +717,8 @@ func TestAliasOutput_SetIsOrigin(t *testing.T) {
 func TestAliasOutput_SetIsDelegated(t *testing.T) {
 	t.Run("CASE: Happy path", func(t *testing.T) {
 		alias := dummyAliasOutput()
-		isDelegated := true
-		alias.SetIsDelegated(isDelegated)
-		assert.Equal(t, alias.isDelegated, isDelegated)
+		alias.SetIsDelegated(true)
+		assert.Equal(t, alias.isDelegated, true)
 	})
 }
 
@@ -838,7 +836,7 @@ func TestAliasOutput_checkBasicValidity(t *testing.T) {
 		assert.Error(t, err)
 	})
 
-	t.Run("CASE: delegation timelock for non delegated output", func(t *testing.T) {
+	t.Run("CASE: delegation time-lock for non delegated output", func(t *testing.T) {
 		alias := dummyAliasOutput()
 		alias.isDelegated = false
 		alias.delegationTimelock = time.Now()
@@ -862,14 +860,14 @@ func TestAliasOutput_validateTransition(t *testing.T) {
 	t.Run("CASE: Happy path, state transition", func(t *testing.T) {
 		prev := dummyAliasOutput()
 		next := prev.NewAliasOutputNext(false)
-		err := prev.validateTransition(next, &Transaction{})
+		err := prev.validateTransition(next, new(Transaction))
 		assert.NoError(t, err)
 	})
 
 	t.Run("CASE: Happy path, governance transition", func(t *testing.T) {
 		prev := dummyAliasOutput()
 		next := prev.NewAliasOutputNext(true)
-		err := prev.validateTransition(next, &Transaction{})
+		err := prev.validateTransition(next, new(Transaction))
 		assert.NoError(t, err)
 	})
 
@@ -877,7 +875,7 @@ func TestAliasOutput_validateTransition(t *testing.T) {
 		prev := dummyAliasOutput()
 		next := prev.NewAliasOutputNext(false)
 		next.aliasAddress = *randAliasAddress()
-		err := prev.validateTransition(next, &Transaction{})
+		err := prev.validateTransition(next, new(Transaction))
 		t.Log(err)
 		assert.Error(t, err)
 	})
@@ -886,7 +884,7 @@ func TestAliasOutput_validateTransition(t *testing.T) {
 		prev := dummyAliasOutput()
 		next := prev.NewAliasOutputNext(false)
 		next.immutableData = []byte("something new")
-		err := prev.validateTransition(next, &Transaction{})
+		err := prev.validateTransition(next, new(Transaction))
 		t.Log(err)
 		assert.Error(t, err)
 	})
@@ -895,7 +893,7 @@ func TestAliasOutput_validateTransition(t *testing.T) {
 		prev := dummyAliasOutput()
 		next := prev.NewAliasOutputNext(true)
 		next.stateData = []byte("something new")
-		err := prev.validateTransition(next, &Transaction{})
+		err := prev.validateTransition(next, new(Transaction))
 		t.Log(err)
 		assert.Error(t, err)
 	})
@@ -904,7 +902,7 @@ func TestAliasOutput_validateTransition(t *testing.T) {
 		prev := dummyAliasOutput()
 		next := prev.NewAliasOutputNext(true)
 		next.stateIndex = prev.stateIndex + 1
-		err := prev.validateTransition(next, &Transaction{})
+		err := prev.validateTransition(next, new(Transaction))
 		t.Log(err)
 		assert.Error(t, err)
 	})
@@ -915,7 +913,7 @@ func TestAliasOutput_validateTransition(t *testing.T) {
 		newBalance := prev.Balances().Map()
 		newBalance[ColorIOTA]++
 		next.balances = NewColoredBalances(newBalance)
-		err := prev.validateTransition(next, &Transaction{})
+		err := prev.validateTransition(next, new(Transaction))
 		t.Log(err)
 		assert.Error(t, err)
 	})
@@ -924,7 +922,7 @@ func TestAliasOutput_validateTransition(t *testing.T) {
 		prev := dummyAliasOutput()
 		next := prev.NewAliasOutputNext(true)
 		next.stateAddress = randEd25119Address()
-		err := prev.validateTransition(next, &Transaction{})
+		err := prev.validateTransition(next, new(Transaction))
 		assert.NoError(t, err)
 	})
 
@@ -932,7 +930,7 @@ func TestAliasOutput_validateTransition(t *testing.T) {
 		prev := dummyAliasOutput()
 		next := prev.NewAliasOutputNext(true)
 		next.governingAddress = randAliasAddress()
-		err := prev.validateTransition(next, &Transaction{})
+		err := prev.validateTransition(next, new(Transaction))
 		assert.NoError(t, err)
 	})
 
@@ -940,7 +938,7 @@ func TestAliasOutput_validateTransition(t *testing.T) {
 		prev := dummyAliasOutput()
 		next := prev.NewAliasOutputNext(true)
 		next.governanceMetadata = []byte("chain is run by another VM")
-		err := prev.validateTransition(next, &Transaction{})
+		err := prev.validateTransition(next, new(Transaction))
 		assert.NoError(t, err)
 	})
 
@@ -948,7 +946,7 @@ func TestAliasOutput_validateTransition(t *testing.T) {
 		prev := dummyAliasOutput()
 		next := prev.NewAliasOutputNext(true)
 		next.isDelegated = true
-		err := prev.validateTransition(next, &Transaction{})
+		err := prev.validateTransition(next, new(Transaction))
 		assert.NoError(t, err)
 	})
 
@@ -961,40 +959,40 @@ func TestAliasOutput_validateTransition(t *testing.T) {
 	})
 
 	t.Run("CASE: Gov update, delegation with delegation lock", func(t *testing.T) {
-		timelock := time.Now()
-		prev := dummyAliasOutput().WithDelegationAndTimelock(timelock)
+		timeLock := time.Now()
+		prev := dummyAliasOutput().WithDelegationAndTimelock(timeLock)
 		next := prev.NewAliasOutputNext(true)
 		assert.Equal(t, true, next.IsDelegated())
-		// happy case, timelock expired
-		err := prev.validateTransition(next, &Transaction{essence: &TransactionEssence{timestamp: timelock.Add(time.Second)}})
+		// happy case, time-lock expired
+		err := prev.validateTransition(next, &Transaction{essence: &TransactionEssence{timestamp: timeLock.Add(time.Second)}})
 		assert.NoError(t, err)
-		// not happy case, timelock is still active
-		err = prev.validateTransition(next, &Transaction{essence: &TransactionEssence{timestamp: timelock.Add(-time.Second)}})
+		// not happy case, time-lock is still active
+		err = prev.validateTransition(next, &Transaction{essence: &TransactionEssence{timestamp: timeLock.Add(-time.Second)}})
 		t.Log(err)
 		assert.Error(t, err)
 	})
 
-	t.Run("CASE: State update, delegation without timelock", func(t *testing.T) {
+	t.Run("CASE: State update, delegation without time-lock", func(t *testing.T) {
 		prev := dummyAliasOutput().WithDelegation()
 		next := prev.NewAliasOutputNext(false)
 		err := prev.validateTransition(next, &Transaction{essence: &TransactionEssence{timestamp: time.Now()}})
 		assert.NoError(t, err)
 	})
 
-	t.Run("CASE: State update, delegation with timelock", func(t *testing.T) {
-		timelock := time.Now()
-		prev := dummyAliasOutput().WithDelegationAndTimelock(timelock)
+	t.Run("CASE: State update, delegation with time-lock", func(t *testing.T) {
+		timeLock := time.Now()
+		prev := dummyAliasOutput().WithDelegationAndTimelock(timeLock)
 		next := prev.NewAliasOutputNext(false)
-		// timelock is active state transition allowed
-		err := prev.validateTransition(next, &Transaction{essence: &TransactionEssence{timestamp: timelock.Add(-time.Second)}})
+		// time-lock is active state transition allowed
+		err := prev.validateTransition(next, &Transaction{essence: &TransactionEssence{timestamp: timeLock.Add(-time.Second)}})
 		assert.NoError(t, err)
-		// timelock expired, state transition should fail
-		err = prev.validateTransition(next, &Transaction{essence: &TransactionEssence{timestamp: timelock.Add(time.Second)}})
+		// time-lock expired, state transition should fail
+		err = prev.validateTransition(next, &Transaction{essence: &TransactionEssence{timestamp: timeLock.Add(time.Second)}})
 		t.Log(err)
 		assert.Error(t, err)
 	})
 
-	t.Run("CASE: State update, delegated, delegation timelock changed", func(t *testing.T) {
+	t.Run("CASE: State update, delegated, delegation time-lock changed", func(t *testing.T) {
 		prev := dummyAliasOutput().WithDelegation()
 		next := prev.NewAliasOutputNext(false)
 		next.delegationTimelock = time.Now()
@@ -1007,7 +1005,7 @@ func TestAliasOutput_validateTransition(t *testing.T) {
 		prev := dummyAliasOutput()
 		next := prev.NewAliasOutputNext(false)
 		next.isDelegated = true
-		err := prev.validateTransition(next, &Transaction{})
+		err := prev.validateTransition(next, new(Transaction))
 		t.Log(err)
 		assert.Error(t, err)
 	})
@@ -1019,7 +1017,7 @@ func TestAliasOutput_validateTransition(t *testing.T) {
 		bal := next.balances.Map()
 		bal[ColorIOTA]++
 		next.balances = NewColoredBalances(bal)
-		err := prev.validateTransition(next, &Transaction{})
+		err := prev.validateTransition(next, new(Transaction))
 		t.Log(err)
 		assert.Error(t, err)
 	})
@@ -1028,7 +1026,7 @@ func TestAliasOutput_validateTransition(t *testing.T) {
 		prev := dummyAliasOutput()
 		next := prev.NewAliasOutputNext(false)
 		next.stateIndex = prev.GetStateIndex() + 2
-		err := prev.validateTransition(next, &Transaction{})
+		err := prev.validateTransition(next, new(Transaction))
 		t.Log(err)
 		assert.Error(t, err)
 	})
@@ -1037,7 +1035,7 @@ func TestAliasOutput_validateTransition(t *testing.T) {
 		prev := dummyAliasOutput()
 		next := prev.NewAliasOutputNext(false)
 		next.stateAddress = randEd25119Address()
-		err := prev.validateTransition(next, &Transaction{})
+		err := prev.validateTransition(next, new(Transaction))
 		t.Log(err)
 		assert.Error(t, err)
 	})
@@ -1046,7 +1044,7 @@ func TestAliasOutput_validateTransition(t *testing.T) {
 		prev := dummyAliasOutput()
 		next := prev.NewAliasOutputNext(false)
 		next.governingAddress = randAliasAddress()
-		err := prev.validateTransition(next, &Transaction{})
+		err := prev.validateTransition(next, new(Transaction))
 		t.Log(err)
 		assert.Error(t, err)
 	})
@@ -1055,7 +1053,7 @@ func TestAliasOutput_validateTransition(t *testing.T) {
 		prev := dummyAliasOutput()
 		next := prev.NewAliasOutputNext(false)
 		next.governanceMetadata = []byte("chain is run by another VM")
-		err := prev.validateTransition(next, &Transaction{})
+		err := prev.validateTransition(next, new(Transaction))
 		t.Log(err)
 		assert.Error(t, err)
 	})
@@ -1065,7 +1063,7 @@ func TestAliasOutput_validateTransition(t *testing.T) {
 		prev.governingAddress = nil
 		next := prev.NewAliasOutputNext(false)
 		next.governingAddress = randAliasAddress()
-		err := prev.validateTransition(next, &Transaction{})
+		err := prev.validateTransition(next, new(Transaction))
 		t.Log(err)
 		assert.Error(t, err)
 	})
@@ -1074,7 +1072,7 @@ func TestAliasOutput_validateTransition(t *testing.T) {
 		prev := dummyAliasOutput()
 		next := prev.NewAliasOutputNext(false)
 		next.governingAddress = nil
-		err := prev.validateTransition(next, &Transaction{})
+		err := prev.validateTransition(next, new(Transaction))
 		t.Log(err)
 		assert.Error(t, err)
 	})
@@ -1083,7 +1081,7 @@ func TestAliasOutput_validateTransition(t *testing.T) {
 		prev := dummyAliasOutput()
 		next := prev.NewAliasOutputNext(false)
 		next.stateData = []byte("new state data")
-		err := prev.validateTransition(next, &Transaction{})
+		err := prev.validateTransition(next, new(Transaction))
 		assert.NoError(t, err)
 	})
 
@@ -1093,7 +1091,7 @@ func TestAliasOutput_validateTransition(t *testing.T) {
 		newBalance := prev.Balances().Map()
 		newBalance[ColorIOTA]++
 		next.balances = NewColoredBalances(newBalance)
-		err := prev.validateTransition(next, &Transaction{})
+		err := prev.validateTransition(next, new(Transaction))
 		assert.NoError(t, err)
 	})
 }
@@ -1143,34 +1141,34 @@ func TestAliasOutput_validateDestroyTransition(t *testing.T) {
 		assert.Error(t, err)
 	})
 
-	t.Run("CASE: Can destroy delegation if not-timelocked", func(t *testing.T) {
+	t.Run("CASE: Can destroy delegation if not-time-locked", func(t *testing.T) {
 		prev := dummyAliasOutput()
 		prev.SetIsDelegated(true)
 		err := prev.validateDestroyTransitionNow(time.Now())
 		assert.NoError(t, err)
 	})
 
-	t.Run("CASE: Can't destroy timelocked delegation", func(t *testing.T) {
+	t.Run("CASE: Can't destroy time-locked delegation", func(t *testing.T) {
 		prev := dummyAliasOutput()
 		deadline := time.Now()
-		nowis := deadline.Add(-1 * time.Nanosecond)
+		nowIs := deadline.Add(-1 * time.Nanosecond)
 		prev.SetIsDelegated(true)
 		err := prev.SetDelegationTimelock(deadline)
 		assert.NoError(t, err)
-		assert.True(t, prev.DelegationTimeLockedNow(nowis))
-		err = prev.validateDestroyTransitionNow(nowis)
+		assert.True(t, prev.DelegationTimeLockedNow(nowIs))
+		err = prev.validateDestroyTransitionNow(nowIs)
 		assert.Error(t, err)
 	})
 
-	t.Run("CASE: Can destroy timeUNlocked delegation", func(t *testing.T) {
+	t.Run("CASE: Can destroy timeUnlocked delegation", func(t *testing.T) {
 		prev := dummyAliasOutput()
 		deadline := time.Now()
-		nowis := deadline.Add(1 * time.Nanosecond)
+		nowIs := deadline.Add(1 * time.Nanosecond)
 		prev.SetIsDelegated(true)
 		err := prev.SetDelegationTimelock(deadline)
 		assert.NoError(t, err)
-		assert.False(t, prev.DelegationTimeLockedNow(nowis))
-		err = prev.validateDestroyTransitionNow(nowis)
+		assert.False(t, prev.DelegationTimeLockedNow(nowIs))
+		err = prev.validateDestroyTransitionNow(nowIs)
 		assert.NoError(t, err)
 	})
 }
@@ -1181,7 +1179,7 @@ func TestAliasOutput_findChainedOutputAndCheckFork(t *testing.T) {
 		chained := prev.NewAliasOutputNext(false)
 		outputs := Outputs{chained}
 		essence := NewTransactionEssence(0, time.Time{}, identity.ID{}, identity.ID{}, NewInputs(NewUTXOInput(prev.ID())), NewOutputs(outputs...))
-		// unlockblocks are irrelevant now
+		// unlock blocks are irrelevant now
 		tx := NewTransaction(essence, UnlockBlocks{NewReferenceUnlockBlock(0)})
 
 		found, err := prev.findChainedOutputAndCheckFork(tx)
@@ -1193,7 +1191,7 @@ func TestAliasOutput_findChainedOutputAndCheckFork(t *testing.T) {
 		prev := dummyAliasOutput()
 		outputs := Outputs{NewSigLockedSingleOutput(DustThresholdAliasOutputIOTA, randEd25119Address())}
 		essence := NewTransactionEssence(0, time.Time{}, identity.ID{}, identity.ID{}, NewInputs(NewUTXOInput(prev.ID())), NewOutputs(outputs...))
-		// unlockblocks are irrelevant now
+		// unlock blocks are irrelevant now
 		tx := NewTransaction(essence, UnlockBlocks{NewReferenceUnlockBlock(0)})
 
 		// not found means that returned output is nil, no error
@@ -1207,7 +1205,7 @@ func TestAliasOutput_findChainedOutputAndCheckFork(t *testing.T) {
 		chained2 := prev.NewAliasOutputNext(true)
 		outputs := Outputs{chained1, chained2}
 		essence := NewTransactionEssence(0, time.Time{}, identity.ID{}, identity.ID{}, NewInputs(NewUTXOInput(prev.ID())), NewOutputs(outputs...))
-		// unlockblocks are irrelevant now
+		// unlock blocks are irrelevant now
 		tx := NewTransaction(essence, UnlockBlocks{NewReferenceUnlockBlock(0)})
 
 		found, err := prev.findChainedOutputAndCheckFork(tx)
@@ -1223,7 +1221,7 @@ func TestAliasOutput_findChainedOutputAndCheckFork(t *testing.T) {
 		chainedFake.aliasAddress = *randAliasAddress()
 		outputs := Outputs{chained, chainedFake}
 		essence := NewTransactionEssence(0, time.Time{}, identity.ID{}, identity.ID{}, NewInputs(NewUTXOInput(prev.ID())), NewOutputs(outputs...))
-		// unlockblocks are irrelevant now
+		// unlock blocks are irrelevant now
 		tx := NewTransaction(essence, UnlockBlocks{NewReferenceUnlockBlock(0)})
 
 		found, err := prev.findChainedOutputAndCheckFork(tx)
@@ -1238,7 +1236,7 @@ func TestAliasOutput_hasToBeUnlockedForGovernanceUpdate(t *testing.T) {
 		chained := prev.NewAliasOutputNext(true)
 		outputs := Outputs{chained}
 		essence := NewTransactionEssence(0, time.Time{}, identity.ID{}, identity.ID{}, NewInputs(NewUTXOInput(prev.ID())), NewOutputs(outputs...))
-		// unlockblocks are irrelevant now
+		// unlock blocks are irrelevant now
 		tx := NewTransaction(essence, UnlockBlocks{NewReferenceUnlockBlock(0)})
 
 		ok := prev.hasToBeUnlockedForGovernanceUpdate(tx)
@@ -1250,7 +1248,7 @@ func TestAliasOutput_hasToBeUnlockedForGovernanceUpdate(t *testing.T) {
 		chained := prev.NewAliasOutputNext(false)
 		outputs := Outputs{chained}
 		essence := NewTransactionEssence(0, time.Time{}, identity.ID{}, identity.ID{}, NewInputs(NewUTXOInput(prev.ID())), NewOutputs(outputs...))
-		// unlockblocks are irrelevant now
+		// unlock blocks are irrelevant now
 		tx := NewTransaction(essence, UnlockBlocks{NewReferenceUnlockBlock(0)})
 
 		ok := prev.hasToBeUnlockedForGovernanceUpdate(tx)
@@ -1264,7 +1262,7 @@ func TestAliasOutput_hasToBeUnlockedForGovernanceUpdate(t *testing.T) {
 		chainedDuplicate.stateData = []byte("duplicated")
 		outputs := Outputs{chained, chainedDuplicate}
 		essence := NewTransactionEssence(0, time.Time{}, identity.ID{}, identity.ID{}, NewInputs(NewUTXOInput(prev.ID())), NewOutputs(outputs...))
-		// unlockblocks are irrelevant now
+		// unlock blocks are irrelevant now
 		tx := NewTransaction(essence, UnlockBlocks{NewReferenceUnlockBlock(0)})
 
 		ok := prev.hasToBeUnlockedForGovernanceUpdate(tx)
@@ -1276,7 +1274,7 @@ func TestAliasOutput_hasToBeUnlockedForGovernanceUpdate(t *testing.T) {
 		next := NewSigLockedSingleOutput(DustThresholdAliasOutputIOTA, randEd25119Address())
 		outputs := Outputs{next}
 		essence := NewTransactionEssence(0, time.Time{}, identity.ID{}, identity.ID{}, NewInputs(NewUTXOInput(prev.ID())), NewOutputs(outputs...))
-		// unlockblocks are irrelevant now
+		// unlock blocks are irrelevant now
 		tx := NewTransaction(essence, UnlockBlocks{NewReferenceUnlockBlock(0)})
 
 		ok := prev.hasToBeUnlockedForGovernanceUpdate(tx)
@@ -1287,31 +1285,29 @@ func TestAliasOutput_hasToBeUnlockedForGovernanceUpdate(t *testing.T) {
 func TestAliasOutput_unlockedGovernanceByAliasIndex(t *testing.T) {
 	governingAliasStateWallet := genRandomWallet()
 	governingAlias := &AliasOutput{
-		outputID:            randOutputID(),
-		outputIDMutex:       sync.RWMutex{},
-		balances:            NewColoredBalances(map[Color]uint64{ColorIOTA: DustThresholdAliasOutputIOTA}),
-		aliasAddress:        *randAliasAddress(),
-		stateAddress:        governingAliasStateWallet.address,
-		stateIndex:          10,
-		stateData:           []byte("some data"),
-		immutableData:       []byte("some data"),
-		isGovernanceUpdate:  false,
-		governingAddress:    randAliasAddress(),
-		StorableObjectFlags: objectstorage.StorableObjectFlags{},
+		outputID:           randOutputID(),
+		outputIDMutex:      sync.RWMutex{},
+		balances:           NewColoredBalances(map[Color]uint64{ColorIOTA: DustThresholdAliasOutputIOTA}),
+		aliasAddress:       *randAliasAddress(),
+		stateAddress:       governingAliasStateWallet.address,
+		stateIndex:         10,
+		stateData:          []byte("some data"),
+		immutableData:      []byte("some data"),
+		isGovernanceUpdate: false,
+		governingAddress:   randAliasAddress(),
 	}
 	aliasStateWallet := genRandomWallet()
 	alias := &AliasOutput{
-		outputID:            randOutputID(),
-		outputIDMutex:       sync.RWMutex{},
-		balances:            NewColoredBalances(map[Color]uint64{ColorIOTA: DustThresholdAliasOutputIOTA}),
-		aliasAddress:        *randAliasAddress(),
-		stateAddress:        aliasStateWallet.address,
-		stateIndex:          10,
-		stateData:           []byte("some data"),
-		immutableData:       []byte("some data"),
-		isGovernanceUpdate:  false,
-		governingAddress:    governingAlias.GetAliasAddress(),
-		StorableObjectFlags: objectstorage.StorableObjectFlags{},
+		outputID:           randOutputID(),
+		outputIDMutex:      sync.RWMutex{},
+		balances:           NewColoredBalances(map[Color]uint64{ColorIOTA: DustThresholdAliasOutputIOTA}),
+		aliasAddress:       *randAliasAddress(),
+		stateAddress:       aliasStateWallet.address,
+		stateIndex:         10,
+		stateData:          []byte("some data"),
+		immutableData:      []byte("some data"),
+		isGovernanceUpdate: false,
+		governingAddress:   governingAlias.GetAliasAddress(),
 	}
 	t.Run("CASE: Happy path", func(t *testing.T) {
 		// unlocked for gov transition
@@ -1353,7 +1349,7 @@ func TestAliasOutput_unlockedGovernanceByAliasIndex(t *testing.T) {
 		dummyAlias := dummyAliasOutput()
 		dummyAlias.governingAddress = nil
 
-		ok, err := dummyAlias.unlockedGovernanceTransitionByAliasIndex(&Transaction{}, 0, Outputs{})
+		ok, err := dummyAlias.unlockedGovernanceTransitionByAliasIndex(new(Transaction), 0, Outputs{})
 		t.Log(err)
 		assert.Error(t, err)
 		assert.False(t, ok)
@@ -1363,7 +1359,7 @@ func TestAliasOutput_unlockedGovernanceByAliasIndex(t *testing.T) {
 		dummyAlias := dummyAliasOutput()
 		dummyAlias.governingAddress = randEd25119Address()
 
-		ok, err := dummyAlias.unlockedGovernanceTransitionByAliasIndex(&Transaction{}, 0, Outputs{})
+		ok, err := dummyAlias.unlockedGovernanceTransitionByAliasIndex(new(Transaction), 0, Outputs{})
 		t.Log(err)
 		assert.Error(t, err)
 		assert.False(t, ok)
@@ -1372,7 +1368,7 @@ func TestAliasOutput_unlockedGovernanceByAliasIndex(t *testing.T) {
 	t.Run("CASE: Invalid referenced index", func(t *testing.T) {
 		dummyAlias := dummyAliasOutput()
 
-		ok, err := dummyAlias.unlockedGovernanceTransitionByAliasIndex(&Transaction{}, 1, Outputs{})
+		ok, err := dummyAlias.unlockedGovernanceTransitionByAliasIndex(new(Transaction), 1, Outputs{})
 		t.Log(err)
 		assert.Error(t, err)
 		assert.False(t, ok)
@@ -1381,7 +1377,7 @@ func TestAliasOutput_unlockedGovernanceByAliasIndex(t *testing.T) {
 	t.Run("CASE: Referenced output is not an alias", func(t *testing.T) {
 		dummyAlias := dummyAliasOutput()
 
-		ok, err := dummyAlias.unlockedGovernanceTransitionByAliasIndex(&Transaction{}, 0, Outputs{NewSigLockedSingleOutput(DustThresholdAliasOutputIOTA, randEd25119Address())})
+		ok, err := dummyAlias.unlockedGovernanceTransitionByAliasIndex(new(Transaction), 0, Outputs{NewSigLockedSingleOutput(DustThresholdAliasOutputIOTA, randEd25119Address())})
 		t.Log(err)
 		assert.Error(t, err)
 		assert.False(t, ok)
@@ -1391,7 +1387,7 @@ func TestAliasOutput_unlockedGovernanceByAliasIndex(t *testing.T) {
 		dummyAlias := dummyAliasOutput()
 		dummyGoverningAlias := dummyAliasOutput()
 
-		ok, err := dummyAlias.unlockedGovernanceTransitionByAliasIndex(&Transaction{}, 0, Outputs{dummyGoverningAlias})
+		ok, err := dummyAlias.unlockedGovernanceTransitionByAliasIndex(new(Transaction), 0, Outputs{dummyGoverningAlias})
 		t.Log(err)
 		assert.Error(t, err)
 		assert.False(t, ok)
@@ -1402,17 +1398,16 @@ func TestAliasOutput_UnlockValid(t *testing.T) {
 	w := genRandomWallet()
 	governingWallet := genRandomWallet()
 	alias := &AliasOutput{
-		outputID:            randOutputID(),
-		outputIDMutex:       sync.RWMutex{},
-		balances:            NewColoredBalances(map[Color]uint64{ColorIOTA: DustThresholdAliasOutputIOTA}),
-		aliasAddress:        *randAliasAddress(),
-		stateAddress:        w.address,
-		stateIndex:          10,
-		stateData:           []byte("some data"),
-		immutableData:       []byte("some immutable data"),
-		isGovernanceUpdate:  false,
-		governingAddress:    governingWallet.address,
-		StorableObjectFlags: objectstorage.StorableObjectFlags{},
+		outputID:           randOutputID(),
+		outputIDMutex:      sync.RWMutex{},
+		balances:           NewColoredBalances(map[Color]uint64{ColorIOTA: DustThresholdAliasOutputIOTA}),
+		aliasAddress:       *randAliasAddress(),
+		stateAddress:       w.address,
+		stateIndex:         10,
+		stateData:          []byte("some data"),
+		immutableData:      []byte("some immutable data"),
+		isGovernanceUpdate: false,
+		governingAddress:   governingWallet.address,
 	}
 
 	t.Run("CASE: Alias unlocked by signature", func(t *testing.T) {
@@ -1555,31 +1550,29 @@ func TestAliasOutput_UnlockValid(t *testing.T) {
 	t.Run("CASE: Unlocked by other alias", func(t *testing.T) {
 		governingAliasStateWallet := genRandomWallet()
 		governingAlias := &AliasOutput{
-			outputID:            randOutputID(),
-			outputIDMutex:       sync.RWMutex{},
-			balances:            NewColoredBalances(map[Color]uint64{ColorIOTA: DustThresholdAliasOutputIOTA}),
-			aliasAddress:        *randAliasAddress(),
-			stateAddress:        governingAliasStateWallet.address,
-			stateIndex:          10,
-			stateData:           []byte("some data"),
-			immutableData:       []byte("some data"),
-			isGovernanceUpdate:  false,
-			governingAddress:    randAliasAddress(),
-			StorableObjectFlags: objectstorage.StorableObjectFlags{},
+			outputID:           randOutputID(),
+			outputIDMutex:      sync.RWMutex{},
+			balances:           NewColoredBalances(map[Color]uint64{ColorIOTA: DustThresholdAliasOutputIOTA}),
+			aliasAddress:       *randAliasAddress(),
+			stateAddress:       governingAliasStateWallet.address,
+			stateIndex:         10,
+			stateData:          []byte("some data"),
+			immutableData:      []byte("some data"),
+			isGovernanceUpdate: false,
+			governingAddress:   randAliasAddress(),
 		}
 		aliasStateWallet := genRandomWallet()
 		governedAlias := &AliasOutput{
-			outputID:            randOutputID(),
-			outputIDMutex:       sync.RWMutex{},
-			balances:            NewColoredBalances(map[Color]uint64{ColorIOTA: DustThresholdAliasOutputIOTA}),
-			aliasAddress:        *randAliasAddress(),
-			stateAddress:        aliasStateWallet.address,
-			stateIndex:          10,
-			stateData:           []byte("some data"),
-			immutableData:       []byte("some data"),
-			isGovernanceUpdate:  false,
-			governingAddress:    governingAlias.GetAliasAddress(),
-			StorableObjectFlags: objectstorage.StorableObjectFlags{},
+			outputID:           randOutputID(),
+			outputIDMutex:      sync.RWMutex{},
+			balances:           NewColoredBalances(map[Color]uint64{ColorIOTA: DustThresholdAliasOutputIOTA}),
+			aliasAddress:       *randAliasAddress(),
+			stateAddress:       aliasStateWallet.address,
+			stateIndex:         10,
+			stateData:          []byte("some data"),
+			immutableData:      []byte("some data"),
+			isGovernanceUpdate: false,
+			governingAddress:   governingAlias.GetAliasAddress(),
 		}
 		// unlocked for gov transition
 		nextAlias := governedAlias.NewAliasOutputNext(true)
@@ -1705,7 +1698,7 @@ func TestExtendedLockedOutput_Bytes(t *testing.T) {
 		assert.Equal(t, o.payload, castedRestored.payload)
 	})
 
-	t.Run("CASE: Happy path, optional timelock", func(t *testing.T) {
+	t.Run("CASE: Happy path, optional time-lock", func(t *testing.T) {
 		o := NewExtendedLockedOutput(map[Color]uint64{ColorIOTA: DustThresholdAliasOutputIOTA}, randEd25119Address()).
 			WithTimeLock(time.Now().Add(1 * time.Hour))
 		oBytes := o.Bytes()
@@ -1830,7 +1823,7 @@ func TestExtendedLockedOutput_Input(t *testing.T) {
 	})
 
 	t.Run("CASE: No output id yet", func(t *testing.T) {
-		// serialized form of output doesn't have outputid
+		// serialized form of output doesn't have OutputID
 		output, _, err := OutputFromBytes(dummyExtendedLockedOutput().Bytes())
 		assert.NoError(t, err)
 		assert.Panics(t, func() {
@@ -1895,18 +1888,18 @@ func TestExtendedLockedOutput_TimeLock(t *testing.T) {
 func TestExtendedLockedOutput_TimeLockedNow(t *testing.T) {
 	t.Run("CASE: Happy path", func(t *testing.T) {
 		output := dummyExtendedLockedOutput()
-		timelockDate := time.Now()
-		output.timelock = timelockDate
-		assert.True(t, output.TimeLockedNow(timelockDate.Add(-time.Minute)))
-		assert.True(t, output.TimeLockedNow(timelockDate.Add(-time.Nanosecond)))
-		assert.False(t, output.TimeLockedNow(timelockDate))
-		assert.False(t, output.TimeLockedNow(timelockDate.Add(time.Second)))
+		timeLockDate := time.Now()
+		output.timelock = timeLockDate
+		assert.True(t, output.TimeLockedNow(timeLockDate.Add(-time.Minute)))
+		assert.True(t, output.TimeLockedNow(timeLockDate.Add(-time.Nanosecond)))
+		assert.False(t, output.TimeLockedNow(timeLockDate))
+		assert.False(t, output.TimeLockedNow(timeLockDate.Add(time.Second)))
 	})
 }
 
 func TestExtendedLockedOutput_Type(t *testing.T) {
 	t.Run("CASE: Happy path", func(t *testing.T) {
-		output := &ExtendedLockedOutput{}
+		output := new(ExtendedLockedOutput)
 		assert.Equal(t, ExtendedLockedOutputType, output.Type())
 	})
 }
@@ -1976,24 +1969,24 @@ func TestExtendedLockedOutput_WithFallbackOptions(t *testing.T) {
 	fallbackAddress := randEd25119Address()
 
 	t.Run("CASE: Happy path", func(t *testing.T) {
-		output := (&ExtendedLockedOutput{}).WithFallbackOptions(fallbackAddress, fallbackDeadline)
+		output := new(ExtendedLockedOutput).WithFallbackOptions(fallbackAddress, fallbackDeadline)
 		assert.True(t, fallbackAddress.Equals(output.FallbackAddress()))
 		assert.True(t, fallbackDeadline.Equal(output.fallbackDeadline))
 	})
 
 	t.Run("CASE: nil fallback address", func(t *testing.T) {
-		output := (&ExtendedLockedOutput{}).WithFallbackOptions(nil, fallbackDeadline)
+		output := new(ExtendedLockedOutput).WithFallbackOptions(nil, fallbackDeadline)
 		assert.Nil(t, output.FallbackAddress())
 		assert.True(t, fallbackDeadline.Equal(output.fallbackDeadline))
 	})
 }
 
 func TestExtendedLockedOutput_WithTimeLock(t *testing.T) {
-	timelock := time.Now()
+	timeLock := time.Now()
 
 	t.Run("CASE: Happy path", func(t *testing.T) {
-		output := (&ExtendedLockedOutput{}).WithTimeLock(timelock)
-		assert.True(t, timelock.Equal(output.TimeLock()))
+		output := new(ExtendedLockedOutput).WithTimeLock(timeLock)
+		assert.True(t, timeLock.Equal(output.TimeLock()))
 	})
 }
 
@@ -2012,7 +2005,7 @@ func TestExtendedOutputFromMarshalUtil(t *testing.T) {
 		output := dummyExtendedLockedOutput()
 		outputBytes := output.Bytes()
 		marshalUtil := marshalutil.New(outputBytes)
-		restored, err := (&ExtendedLockedOutput{}).FromMarshalUtil(marshalUtil)
+		restored, err := new(ExtendedLockedOutput).FromMarshalUtil(marshalUtil)
 		assert.NoError(t, err)
 		assert.Equal(t, len(outputBytes), marshalUtil.ReadOffset())
 		assert.Equal(t, outputBytes, restored.Bytes())
@@ -2023,7 +2016,7 @@ func TestExtendedOutputFromMarshalUtil(t *testing.T) {
 		outputBytes := output.Bytes()
 		outputBytes[0] = byte(AliasOutputType)
 		marshalUtil := marshalutil.New(outputBytes)
-		_, err := (&ExtendedLockedOutput{}).FromMarshalUtil(marshalUtil)
+		_, err := new(ExtendedLockedOutput).FromMarshalUtil(marshalUtil)
 		t.Log(err)
 		assert.Error(t, err)
 	})
@@ -2039,7 +2032,7 @@ func TestExtendedOutputFromMarshalUtil(t *testing.T) {
 		assert.Error(t, err)
 	})
 
-	t.Run("CASE: Timelock flag provided, missing data", func(t *testing.T) {
+	t.Run("CASE: Time-lock flag provided, missing data", func(t *testing.T) {
 		output := dummyExtendedLockedOutput().WithTimeLock(time.Time{})
 		err := output.SetPayload(nil)
 		assert.NoError(t, err)
@@ -2080,7 +2073,7 @@ func TestExtendedOutputFromMarshalUtil(t *testing.T) {
 		assert.NotEqual(t, len(outputBytes), consumedBytes)
 	})
 
-	t.Run("CASE: Timelock present, wrong flag", func(t *testing.T) {
+	t.Run("CASE: Time-lock present, wrong flag", func(t *testing.T) {
 		output := dummyExtendedLockedOutput().WithTimeLock(time.Now()).WithFallbackOptions(nil, time.Time{})
 		err := output.SetPayload(nil)
 		assert.NoError(t, err)
@@ -2179,11 +2172,11 @@ func TestExtendedLockedOutput_UnlockValid(t *testing.T) {
 
 	t.Run("CASE: Referenced input not alias", func(t *testing.T) {
 		w := genRandomWallet()
-		nowis := time.Now()
+		nowIs := time.Now()
 		input := NewExtendedLockedOutput(map[Color]uint64{ColorIOTA: 1}, w.address)
 		input.SetID(randOutputID())
 		output := NewSigLockedColoredOutput(NewColoredBalances(map[Color]uint64{ColorIOTA: 1}), randEd25119Address())
-		essence := NewTransactionEssence(0, nowis, identity.ID{}, identity.ID{}, NewInputs(input.Input()), NewOutputs(output))
+		essence := NewTransactionEssence(0, nowIs, identity.ID{}, identity.ID{}, NewInputs(input.Input()), NewOutputs(output))
 		unlockBlock := NewAliasUnlockBlock(0)
 		tx := NewTransaction(essence, UnlockBlocks{unlockBlock})
 
@@ -2202,11 +2195,11 @@ func TestExtendedLockedOutput_UnlockValid(t *testing.T) {
 			stateAddress:  randEd25119Address(), // alias state controller is our wallet
 			stateIndex:    10,
 		}
-		nowis := time.Now()
+		nowIs := time.Now()
 		input := NewExtendedLockedOutput(map[Color]uint64{ColorIOTA: 1}, randAliasAddress())
 		input.SetID(randOutputID())
 		// for the sake of this test, tx doesn't have to be valid
-		essence := NewTransactionEssence(0, nowis, identity.ID{}, identity.ID{}, NewInputs(alias.Input()), NewOutputs(input))
+		essence := NewTransactionEssence(0, nowIs, identity.ID{}, identity.ID{}, NewInputs(alias.Input()), NewOutputs(input))
 		// important is that we reference an alias that has different aliasAddress
 		unlockBlock := NewAliasUnlockBlock(0)
 		tx := NewTransaction(essence, UnlockBlocks{unlockBlock})
@@ -2217,14 +2210,14 @@ func TestExtendedLockedOutput_UnlockValid(t *testing.T) {
 		assert.False(t, valid)
 	})
 
-	t.Run("CASE: Output is timelocked, can't spend", func(t *testing.T) {
+	t.Run("CASE: Output is time-locked, can't spend", func(t *testing.T) {
 		w := genRandomWallet()
-		nowis := time.Now()
-		input := NewExtendedLockedOutput(map[Color]uint64{ColorIOTA: 1}, w.address).WithTimeLock(nowis.Add(time.Hour))
+		nowIs := time.Now()
+		input := NewExtendedLockedOutput(map[Color]uint64{ColorIOTA: 1}, w.address).WithTimeLock(nowIs.Add(time.Hour))
 		input.SetID(randOutputID())
 		output := NewSigLockedColoredOutput(NewColoredBalances(map[Color]uint64{ColorIOTA: 1}), randEd25119Address())
-		// tx timestamp before timelock
-		essence := NewTransactionEssence(0, nowis, identity.ID{}, identity.ID{}, NewInputs(input.Input()), NewOutputs(output))
+		// tx timestamp before time-lock
+		essence := NewTransactionEssence(0, nowIs, identity.ID{}, identity.ID{}, NewInputs(input.Input()), NewOutputs(output))
 		unlockBlock := NewSignatureUnlockBlock(w.sign(essence))
 		tx := NewTransaction(essence, UnlockBlocks{unlockBlock})
 
@@ -2233,14 +2226,14 @@ func TestExtendedLockedOutput_UnlockValid(t *testing.T) {
 		assert.False(t, valid)
 	})
 
-	t.Run("CASE: Output is timelocked, spend after", func(t *testing.T) {
+	t.Run("CASE: Output is time-locked, spend after", func(t *testing.T) {
 		w := genRandomWallet()
-		nowis := time.Now()
-		input := NewExtendedLockedOutput(map[Color]uint64{ColorIOTA: 1}, w.address).WithTimeLock(nowis.Add(time.Hour))
+		nowIs := time.Now()
+		input := NewExtendedLockedOutput(map[Color]uint64{ColorIOTA: 1}, w.address).WithTimeLock(nowIs.Add(time.Hour))
 		input.SetID(randOutputID())
 		output := NewSigLockedColoredOutput(NewColoredBalances(map[Color]uint64{ColorIOTA: 1}), randEd25119Address())
-		// tx timestamp is exactly timelock, output is allowed to be spent from that moment on
-		essence := NewTransactionEssence(0, nowis.Add(time.Hour), identity.ID{}, identity.ID{}, NewInputs(input.Input()), NewOutputs(output))
+		// tx timestamp is exactly time-lock, output is allowed to be spent from that moment on
+		essence := NewTransactionEssence(0, nowIs.Add(time.Hour), identity.ID{}, identity.ID{}, NewInputs(input.Input()), NewOutputs(output))
 		unlockBlock := NewSignatureUnlockBlock(w.sign(essence))
 		tx := NewTransaction(essence, UnlockBlocks{unlockBlock})
 
@@ -2253,7 +2246,7 @@ func TestExtendedLockedOutput_UnlockValid(t *testing.T) {
 		input := NewExtendedLockedOutput(map[Color]uint64{ColorIOTA: 1}, randAliasAddress())
 		unlockBlock := NewReferenceUnlockBlock(0)
 
-		valid, err := input.UnlockValid(&Transaction{essence: &TransactionEssence{}}, unlockBlock, Outputs{input})
+		valid, err := input.UnlockValid(&Transaction{essence: new(TransactionEssence)}, unlockBlock, Outputs{input})
 		t.Log(err)
 		assert.Error(t, err)
 		assert.False(t, valid)
@@ -2262,14 +2255,14 @@ func TestExtendedLockedOutput_UnlockValid(t *testing.T) {
 	t.Run("CASE: Fallback address present", func(t *testing.T) {
 		destWallet := genRandomWallet()
 		myWallet := genRandomWallet()
-		nowis := time.Now()
-		// until nowis+30 minutes, only w wallet can spend it, after that, only myWallet
-		input := NewExtendedLockedOutput(map[Color]uint64{ColorIOTA: 1}, destWallet.address).WithFallbackOptions(myWallet.address, nowis.Add(30*time.Minute))
+		nowIs := time.Now()
+		// until now is +30 minutes, only w wallet can spend it, after that, only myWallet
+		input := NewExtendedLockedOutput(map[Color]uint64{ColorIOTA: 1}, destWallet.address).WithFallbackOptions(myWallet.address, nowIs.Add(30*time.Minute))
 		input.SetID(randOutputID())
 		output := NewSigLockedColoredOutput(NewColoredBalances(map[Color]uint64{ColorIOTA: 1}), randEd25119Address())
 
-		// t =< nowis + 30 mins, destWallet can spend it
-		essence := NewTransactionEssence(0, nowis, identity.ID{}, identity.ID{}, NewInputs(input.Input()), NewOutputs(output))
+		// t =< now is + 30 minutes, destWallet can spend it
+		essence := NewTransactionEssence(0, nowIs, identity.ID{}, identity.ID{}, NewInputs(input.Input()), NewOutputs(output))
 		unlockBlock := NewSignatureUnlockBlock(destWallet.sign(essence))
 		tx := NewTransaction(essence, UnlockBlocks{unlockBlock})
 
@@ -2277,8 +2270,8 @@ func TestExtendedLockedOutput_UnlockValid(t *testing.T) {
 		assert.NoError(t, err)
 		assert.True(t, valid)
 
-		// t =< nowis + 30 mins, myWallet can't spend it
-		essence = NewTransactionEssence(0, nowis, identity.ID{}, identity.ID{}, NewInputs(input.Input()), NewOutputs(output))
+		// t =< now is + 30 minutes, myWallet can't spend it
+		essence = NewTransactionEssence(0, nowIs, identity.ID{}, identity.ID{}, NewInputs(input.Input()), NewOutputs(output))
 		unlockBlock = NewSignatureUnlockBlock(myWallet.sign(essence))
 		tx = NewTransaction(essence, UnlockBlocks{unlockBlock})
 
@@ -2286,8 +2279,8 @@ func TestExtendedLockedOutput_UnlockValid(t *testing.T) {
 		assert.NoError(t, err)
 		assert.False(t, valid)
 
-		// t > nowis + 30 mins, destWallet can't spend it
-		essence = NewTransactionEssence(0, nowis.Add(30*time.Minute).Add(time.Nanosecond), identity.ID{}, identity.ID{}, NewInputs(input.Input()), NewOutputs(output))
+		// t > now is + 30 minutes, destWallet can't spend it
+		essence = NewTransactionEssence(0, nowIs.Add(30*time.Minute).Add(time.Nanosecond), identity.ID{}, identity.ID{}, NewInputs(input.Input()), NewOutputs(output))
 		unlockBlock = NewSignatureUnlockBlock(destWallet.sign(essence))
 		tx = NewTransaction(essence, UnlockBlocks{unlockBlock})
 
@@ -2295,8 +2288,8 @@ func TestExtendedLockedOutput_UnlockValid(t *testing.T) {
 		assert.NoError(t, err)
 		assert.False(t, valid)
 
-		// t > nowis + 30 mins, myWallet can spend it
-		essence = NewTransactionEssence(0, nowis.Add(30*time.Minute).Add(time.Nanosecond), identity.ID{}, identity.ID{}, NewInputs(input.Input()), NewOutputs(output))
+		// t > now is + 30 minutes, myWallet can spend it
+		essence = NewTransactionEssence(0, nowIs.Add(30*time.Minute).Add(time.Nanosecond), identity.ID{}, identity.ID{}, NewInputs(input.Input()), NewOutputs(output))
 		unlockBlock = NewSignatureUnlockBlock(myWallet.sign(essence))
 		tx = NewTransaction(essence, UnlockBlocks{unlockBlock})
 
@@ -2343,35 +2336,33 @@ func dummyAliasOutput(origin ...bool) *AliasOutput {
 		orig = origin[0]
 	}
 	return &AliasOutput{
-		outputID:            randOutputID(),
-		outputIDMutex:       sync.RWMutex{},
-		balances:            NewColoredBalances(map[Color]uint64{ColorIOTA: DustThresholdAliasOutputIOTA}),
-		aliasAddress:        *randAliasAddress(),
-		stateAddress:        randEd25119Address(),
-		stateIndex:          0,
-		stateData:           []byte("initial"),
-		governanceMetadata:  []byte("This chain runs EVM v0.0.0"),
-		immutableData:       []byte("don't touch this"),
-		isGovernanceUpdate:  false,
-		isOrigin:            orig,
-		isDelegated:         false,
-		governingAddress:    randAliasAddress(),
-		delegationTimelock:  time.Time{},
-		StorableObjectFlags: objectstorage.StorableObjectFlags{},
+		outputID:           randOutputID(),
+		outputIDMutex:      sync.RWMutex{},
+		balances:           NewColoredBalances(map[Color]uint64{ColorIOTA: DustThresholdAliasOutputIOTA}),
+		aliasAddress:       *randAliasAddress(),
+		stateAddress:       randEd25119Address(),
+		stateIndex:         0,
+		stateData:          []byte("initial"),
+		governanceMetadata: []byte("This chain runs EVM v0.0.0"),
+		immutableData:      []byte("don't touch this"),
+		isGovernanceUpdate: false,
+		isOrigin:           orig,
+		isDelegated:        false,
+		governingAddress:   randAliasAddress(),
+		delegationTimelock: time.Time{},
 	}
 }
 
 func dummyExtendedLockedOutput() *ExtendedLockedOutput {
 	return &ExtendedLockedOutput{
-		id:                  randOutputID(),
-		idMutex:             sync.RWMutex{},
-		balances:            NewColoredBalances(map[Color]uint64{ColorIOTA: 1}),
-		address:             randEd25119Address(),
-		fallbackAddress:     randEd25119Address(),
-		fallbackDeadline:    time.Unix(1001, 0),
-		timelock:            time.Unix(2000, 0),
-		payload:             []byte("a payload"),
-		StorableObjectFlags: objectstorage.StorableObjectFlags{},
+		id:               randOutputID(),
+		idMutex:          sync.RWMutex{},
+		balances:         NewColoredBalances(map[Color]uint64{ColorIOTA: 1}),
+		address:          randEd25119Address(),
+		fallbackAddress:  randEd25119Address(),
+		fallbackDeadline: time.Unix(1001, 0),
+		timelock:         time.Unix(2000, 0),
+		payload:          []byte("a payload"),
 	}
 }
 

--- a/packages/ledgerstate/transaction.go
+++ b/packages/ledgerstate/transaction.go
@@ -228,9 +228,8 @@ func (t *Transaction) FromBytes(bytes []byte) (transaction *Transaction, err err
 
 // FromMarshalUtil unmarshals a Transaction using a MarshalUtil (for easier unmarshalling).
 func (t *Transaction) FromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (transaction *Transaction, err error) {
-	transaction = t
-	if t == nil {
-		transaction = &Transaction{}
+	if transaction = t; transaction == nil {
+		transaction = new(Transaction)
 	}
 
 	readStartOffset := marshalUtil.ReadOffset()
@@ -675,8 +674,7 @@ func (t *TransactionMetadata) FromBytes(bytes []byte) (transactionMetadata *Tran
 
 // FromMarshalUtil unmarshals an TransactionMetadata object using a MarshalUtil (for easier unmarshaling).
 func (t *TransactionMetadata) FromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (transactionMetadata *TransactionMetadata, err error) {
-	transactionMetadata = t
-	if t == nil {
+	if transactionMetadata = t; transactionMetadata == nil {
 		transactionMetadata = &TransactionMetadata{}
 	}
 	if transactionMetadata.id, err = TransactionIDFromMarshalUtil(marshalUtil); err != nil {

--- a/packages/ledgerstate/transaction_test.go
+++ b/packages/ledgerstate/transaction_test.go
@@ -20,7 +20,7 @@ func TestTransaction_Bytes(t *testing.T) {
 	input := generateOutput(ledgerstate, wallets[0].address, 0)
 	tx, _ := singleInputTransaction(ledgerstate, wallets[0], wallets[1], input)
 	bytes := tx.Bytes()
-	_tx, err := (&Transaction{}).FromBytes(bytes)
+	_tx, err := new(Transaction).FromBytes(bytes)
 	assert.NoError(t, err)
 	assert.Equal(t, tx.ID(), _tx.ID())
 }

--- a/packages/ledgerstate/utxo_dag.go
+++ b/packages/ledgerstate/utxo_dag.go
@@ -408,7 +408,7 @@ func (u *UTXODAG) bookConflictingTransaction(transaction *Transaction, transacti
 		u.bookConsumers(inputsMetadata, transaction.ID(), types.True)
 		u.bookOutputs(transaction, targetBranch)
 	}) {
-		panic(fmt.Errorf("failed to load ConflictBranch with %s", targetBranch.String()))
+		panic(fmt.Errorf("failed to load ConflictBranch with %s", targetBranch))
 	}
 
 	return
@@ -844,9 +844,8 @@ func (a *AddressOutputMapping) FromBytes(bytes []byte) (addressOutputMapping obj
 
 // FromMarshalUtil unmarshals an AddressOutputMapping using a MarshalUtil (for easier unmarshalling).
 func (a *AddressOutputMapping) FromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (addressOutputMapping *AddressOutputMapping, err error) {
-	addressOutputMapping = a
-	if a == nil {
-		addressOutputMapping = &AddressOutputMapping{}
+	if addressOutputMapping = a; addressOutputMapping == nil {
+		addressOutputMapping = new(AddressOutputMapping)
 	}
 	if addressOutputMapping.address, err = AddressFromMarshalUtil(marshalUtil); err != nil {
 		err = errors.Errorf("failed to parse consumed Address from MarshalUtil: %w", err)
@@ -896,7 +895,7 @@ func (a *AddressOutputMapping) ObjectStorageValue() (value []byte) {
 }
 
 // code contract (make sure the struct implements all required methods)
-var _ objectstorage.StorableObject = &AddressOutputMapping{}
+var _ objectstorage.StorableObject = new(AddressOutputMapping)
 
 // endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -936,7 +935,7 @@ func (c *Consumer) FromObjectStorage(key, bytes []byte) (objectstorage.StorableO
 }
 
 // FromBytes unmarshals a Consumer from a sequence of bytes.
-func (c *Consumer) FromBytes(bytes []byte) (consumer objectstorage.StorableObject, err error) {
+func (c *Consumer) FromBytes(bytes []byte) (consumer *Consumer, err error) {
 	marshalUtil := marshalutil.New(bytes)
 	if consumer, err = c.FromMarshalUtil(marshalUtil); err != nil {
 		err = errors.Errorf("failed to parse Consumer from MarshalUtil: %w", err)
@@ -948,9 +947,8 @@ func (c *Consumer) FromBytes(bytes []byte) (consumer objectstorage.StorableObjec
 
 // FromMarshalUtil unmarshals a Consumer using a MarshalUtil (for easier unmarshalling).
 func (c *Consumer) FromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (consumer *Consumer, err error) {
-	consumer = c
-	if c == nil {
-		consumer = &Consumer{}
+	if consumer = c; consumer == nil {
+		consumer = new(Consumer)
 	}
 	if consumer.consumedInput, err = OutputIDFromMarshalUtil(marshalUtil); err != nil {
 		err = errors.Errorf("failed to parse consumed Input from MarshalUtil: %w", err)
@@ -1030,6 +1028,6 @@ func (c *Consumer) ObjectStorageValue() []byte {
 }
 
 // code contract (make sure the struct implements all required methods)
-var _ objectstorage.StorableObject = &Consumer{}
+var _ objectstorage.StorableObject = new(Consumer)
 
 // endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/packages/ledgerstate/utxodb/utxodb.go
+++ b/packages/ledgerstate/utxodb/utxodb.go
@@ -60,7 +60,7 @@ func (u *UtxoDB) AddTransaction(tx *ledgerstate.Transaction) error {
 	defer u.mutex.Unlock()
 
 	// serialize/deserialize for proper semantic check
-	tx, err := (&ledgerstate.Transaction{}).FromBytes(tx.Bytes())
+	tx, err := new(ledgerstate.Transaction).FromBytes(tx.Bytes())
 	if err != nil {
 		return err
 	}

--- a/packages/mana/consensusbasevectormetadata.go
+++ b/packages/mana/consensusbasevectormetadata.go
@@ -41,7 +41,7 @@ func (c *ConsensusBasePastManaVectorMetadata) ObjectStorageValue() []byte {
 	return c.Bytes()
 }
 
-// parseMetadata unmarshals a metadata using the given marshalUtil (for easier marshaling/unmarshaling).
+// parseMetadata unmarshals a metadata using the given marshalUtil (for easier marshaling/unmarshalling).
 func parseMetadata(marshalUtil *marshalutil.MarshalUtil) (result *ConsensusBasePastManaVectorMetadata, err error) {
 	timestamp, err := marshalUtil.ReadTime()
 	if err != nil {
@@ -61,9 +61,9 @@ func (c *ConsensusBasePastManaVectorMetadata) FromObjectStorage(_, bytes []byte)
 	return c.FromBytes(bytes)
 }
 
-// FromBytes unmsarshalls bytes into a metadata.
-func (*ConsensusBasePastManaVectorMetadata) FromBytes(data []byte) (result objectstorage.StorableObject, err error) {
+// FromBytes unmarshalls bytes into a metadata.
+func (*ConsensusBasePastManaVectorMetadata) FromBytes(data []byte) (result *ConsensusBasePastManaVectorMetadata, err error) {
 	return parseMetadata(marshalutil.New(data))
 }
 
-var _ objectstorage.StorableObject = &ConsensusBasePastManaVectorMetadata{}
+var _ objectstorage.StorableObject = new(ConsensusBasePastManaVectorMetadata)

--- a/packages/mana/consensusbasevectormetadata_test.go
+++ b/packages/mana/consensusbasevectormetadata_test.go
@@ -33,8 +33,7 @@ func TestConsensusBasePastManaVectorMetadata_FromBytes(t *testing.T) {
 	c := &ConsensusBasePastManaVectorMetadata{
 		Timestamp: timestamp,
 	}
-	res, err := (&ConsensusBasePastManaVectorMetadata{}).FromBytes(c.Bytes())
+	c1, err := new(ConsensusBasePastManaVectorMetadata).FromBytes(c.Bytes())
 	assert.NoError(t, err)
-	c1 := res.(*ConsensusBasePastManaVectorMetadata)
 	assert.Equal(t, c.Bytes(), c1.Bytes(), "should be equal")
 }

--- a/packages/mana/persistablebase.go
+++ b/packages/mana/persistablebase.go
@@ -44,7 +44,7 @@ func (p *PersistableBaseMana) Bytes() []byte {
 	}
 	// create marshal helper
 	marshalUtil := marshalutil.New()
-	marshalUtil.Write(p.ManaType)
+	marshalUtil.WriteByte(byte(p.ManaType))
 	marshalUtil.WriteUint16(uint16(len(p.BaseValues)))
 	for _, baseValue := range p.BaseValues {
 		marshalUtil.WriteUint64(math.Float64bits(baseValue))
@@ -94,7 +94,7 @@ func (p *PersistableBaseMana) FromMarshalUtil(marshalUtil *marshalutil.MarshalUt
 	if err != nil {
 		return
 	}
-	persistableBaseMana.ManaType = Type(manaType)
+	persistableBaseMana.ManaType = manaType
 
 	baseValuesLength, err := marshalUtil.ReadUint16()
 	if err != nil {

--- a/packages/mana/persistablebase.go
+++ b/packages/mana/persistablebase.go
@@ -94,7 +94,7 @@ func (p *PersistableBaseMana) FromMarshalUtil(marshalUtil *marshalutil.MarshalUt
 	if err != nil {
 		return
 	}
-	persistableBaseMana.ManaType = manaType
+	persistableBaseMana.ManaType = Type(manaType)
 
 	baseValuesLength, err := marshalUtil.ReadUint16()
 	if err != nil {

--- a/packages/mana/persistablebase.go
+++ b/packages/mana/persistablebase.go
@@ -24,112 +24,111 @@ type PersistableBaseMana struct {
 	bytes []byte
 }
 
-// String returns a human readable version of the PersistableBaseMana.
-func (persistableBaseMana *PersistableBaseMana) String() string {
+// String returns a human-readable version of the PersistableBaseMana.
+func (p *PersistableBaseMana) String() string {
 	return stringify.Struct("PersistableBaseMana",
-		stringify.StructField("ManaType", fmt.Sprint(persistableBaseMana.ManaType)),
-		stringify.StructField("BaseValues", fmt.Sprint(persistableBaseMana.BaseValues)),
-		stringify.StructField("EffectiveValues", fmt.Sprint(persistableBaseMana.EffectiveValues)),
-		stringify.StructField("LastUpdated", fmt.Sprint(persistableBaseMana.LastUpdated)),
-		stringify.StructField("NodeID", persistableBaseMana.NodeID.String()),
+		stringify.StructField("ManaType", fmt.Sprint(p.ManaType)),
+		stringify.StructField("BaseValues", fmt.Sprint(p.BaseValues)),
+		stringify.StructField("EffectiveValues", fmt.Sprint(p.EffectiveValues)),
+		stringify.StructField("LastUpdated", fmt.Sprint(p.LastUpdated)),
+		stringify.StructField("NodeID", p.NodeID.String()),
 	)
 }
 
-var _ objectstorage.StorableObject = &PersistableBaseMana{}
+var _ objectstorage.StorableObject = new(PersistableBaseMana)
 
 // Bytes  marshals the persistable mana into a sequence of bytes.
-func (persistableBaseMana *PersistableBaseMana) Bytes() []byte {
-	if bytes := persistableBaseMana.bytes; bytes != nil {
+func (p *PersistableBaseMana) Bytes() []byte {
+	if bytes := p.bytes; bytes != nil {
 		return bytes
 	}
 	// create marshal helper
 	marshalUtil := marshalutil.New()
-	marshalUtil.WriteByte(byte(persistableBaseMana.ManaType))
-	marshalUtil.WriteUint16(uint16(len(persistableBaseMana.BaseValues)))
-	for _, baseValue := range persistableBaseMana.BaseValues {
+	marshalUtil.WriteByte(p.ManaType)
+	marshalUtil.WriteUint16(uint16(len(p.BaseValues)))
+	for _, baseValue := range p.BaseValues {
 		marshalUtil.WriteUint64(math.Float64bits(baseValue))
 	}
-	marshalUtil.WriteUint16(uint16(len(persistableBaseMana.EffectiveValues)))
-	for _, effectiveValue := range persistableBaseMana.EffectiveValues {
+	marshalUtil.WriteUint16(uint16(len(p.EffectiveValues)))
+	for _, effectiveValue := range p.EffectiveValues {
 		marshalUtil.WriteUint64(math.Float64bits(effectiveValue))
 	}
-	marshalUtil.WriteTime(persistableBaseMana.LastUpdated)
-	marshalUtil.WriteBytes(persistableBaseMana.NodeID.Bytes())
+	marshalUtil.WriteTime(p.LastUpdated)
+	marshalUtil.WriteBytes(p.NodeID.Bytes())
 
-	persistableBaseMana.bytes = marshalUtil.Bytes()
-	return persistableBaseMana.bytes
+	p.bytes = marshalUtil.Bytes()
+	return p.bytes
 }
 
 // ObjectStorageKey returns the key of the persistable mana.
-func (persistableBaseMana *PersistableBaseMana) ObjectStorageKey() []byte {
-	return persistableBaseMana.NodeID.Bytes()
+func (p *PersistableBaseMana) ObjectStorageKey() []byte {
+	return p.NodeID.Bytes()
 }
 
 // ObjectStorageValue returns the bytes of the persistable mana.
-func (persistableBaseMana *PersistableBaseMana) ObjectStorageValue() []byte {
-	return persistableBaseMana.Bytes()
+func (p *PersistableBaseMana) ObjectStorageValue() []byte {
+	return p.Bytes()
 }
 
 // FromObjectStorage creates an PersistableBaseMana from sequences of key and bytes.
-func (persistableBaseMana *PersistableBaseMana) FromObjectStorage(key, bytes []byte) (objectstorage.StorableObject, error) {
-	res, err := persistableBaseMana.FromBytes(bytes)
-	copy(res.(*PersistableBaseMana).NodeID[:], key)
+func (p *PersistableBaseMana) FromObjectStorage(key, bytes []byte) (objectstorage.StorableObject, error) {
+	res, err := p.FromBytes(bytes)
+	copy(res.NodeID[:], key)
 	return res, err
 
 }
 
 // FromBytes unmarshals a Persistable Base Mana from a sequence of bytes.
-func (persistableBaseMana *PersistableBaseMana) FromBytes(bytes []byte) (result objectstorage.StorableObject, err error) {
+func (p *PersistableBaseMana) FromBytes(bytes []byte) (result *PersistableBaseMana, err error) {
 	marshalUtil := marshalutil.New(bytes)
-	result, err = persistableBaseMana.FromMarshalUtil(marshalUtil)
+	result, err = p.FromMarshalUtil(marshalUtil)
 	return
 }
 
-// FromMarshalUtil unmarshals a persistableBaseMana using the given marshalUtil (for easier marshaling/unmarshaling).
-func (persistableBaseMana *PersistableBaseMana) FromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (result *PersistableBaseMana, err error) {
-	result = persistableBaseMana
-	if persistableBaseMana == nil {
-		result = &PersistableBaseMana{}
+// FromMarshalUtil unmarshals a PersistableBaseMana using the given marshalUtil (for easier marshaling/unmarshalling).
+func (p *PersistableBaseMana) FromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (persistableBaseMana *PersistableBaseMana, err error) {
+	if persistableBaseMana = p; persistableBaseMana == nil {
+		persistableBaseMana = new(PersistableBaseMana)
 	}
 	manaType, err := marshalUtil.ReadByte()
 	if err != nil {
 		return
 	}
-	result.ManaType = Type(manaType)
+	persistableBaseMana.ManaType = manaType
 
 	baseValuesLength, err := marshalUtil.ReadUint16()
 	if err != nil {
 		return
 	}
-	result.BaseValues = make([]float64, 0, baseValuesLength)
+	persistableBaseMana.BaseValues = make([]float64, 0, baseValuesLength)
 	for i := 0; i < int(baseValuesLength); i++ {
 		var baseMana uint64
 		baseMana, err = marshalUtil.ReadUint64()
 		if err != nil {
-			return result, err
+			return persistableBaseMana, err
 		}
-		result.BaseValues = append(result.BaseValues, math.Float64frombits(baseMana))
+		persistableBaseMana.BaseValues = append(persistableBaseMana.BaseValues, math.Float64frombits(baseMana))
 	}
 
 	effectiveValuesLength, err := marshalUtil.ReadUint16()
 	if err != nil {
-		return result, err
+		return persistableBaseMana, err
 	}
-	result.EffectiveValues = make([]float64, 0, effectiveValuesLength)
+	persistableBaseMana.EffectiveValues = make([]float64, 0, effectiveValuesLength)
 	for i := 0; i < int(effectiveValuesLength); i++ {
 		var effBaseMana uint64
 		effBaseMana, err = marshalUtil.ReadUint64()
 		if err != nil {
-			return result, err
+			return persistableBaseMana, err
 		}
-		result.EffectiveValues = append(result.EffectiveValues, math.Float64frombits(effBaseMana))
+		persistableBaseMana.EffectiveValues = append(persistableBaseMana.EffectiveValues, math.Float64frombits(effBaseMana))
 	}
 
 	lastUpdated, err := marshalUtil.ReadTime()
 	if err != nil {
 		return
 	}
-	result.LastUpdated = lastUpdated
+	persistableBaseMana.LastUpdated = lastUpdated
 
 	nodeIDBytes, err := marshalUtil.ReadBytes(sha256.Size)
 	if err != nil {
@@ -137,10 +136,10 @@ func (persistableBaseMana *PersistableBaseMana) FromMarshalUtil(marshalUtil *mar
 	}
 	var nodeID identity.ID
 	copy(nodeID[:], nodeIDBytes)
-	result.NodeID = nodeID
+	persistableBaseMana.NodeID = nodeID
 
 	consumedBytes := marshalUtil.ReadOffset()
-	result.bytes = make([]byte, consumedBytes)
-	copy(result.bytes, marshalUtil.Bytes())
+	persistableBaseMana.bytes = make([]byte, consumedBytes)
+	copy(persistableBaseMana.bytes, marshalUtil.Bytes())
 	return
 }

--- a/packages/mana/persistablebase.go
+++ b/packages/mana/persistablebase.go
@@ -44,7 +44,7 @@ func (p *PersistableBaseMana) Bytes() []byte {
 	}
 	// create marshal helper
 	marshalUtil := marshalutil.New()
-	marshalUtil.WriteByte(p.ManaType)
+	marshalUtil.Write(p.ManaType)
 	marshalUtil.WriteUint16(uint16(len(p.BaseValues)))
 	for _, baseValue := range p.BaseValues {
 		marshalUtil.WriteUint64(math.Float64bits(baseValue))
@@ -94,7 +94,7 @@ func (p *PersistableBaseMana) FromMarshalUtil(marshalUtil *marshalutil.MarshalUt
 	if err != nil {
 		return
 	}
-	persistableBaseMana.ManaType = manaType
+	persistableBaseMana.ManaType = Type(manaType)
 
 	baseValuesLength, err := marshalUtil.ReadUint16()
 	if err != nil {

--- a/packages/mana/persistablebase_test.go
+++ b/packages/mana/persistablebase_test.go
@@ -44,9 +44,9 @@ func TestPersistableBaseMana_ObjectStorageValue(t *testing.T) {
 
 func TestPersistableBaseMana_FromBytes(t *testing.T) {
 	p1 := newPersistableMana()
-	p2, err := (&PersistableBaseMana{}).FromBytes(p1.Bytes())
+	p2, err := new(PersistableBaseMana).FromBytes(p1.Bytes())
 	assert.Nil(t, err, "should not have returned error")
-	assert.Equal(t, p1.Bytes(), p2.(*PersistableBaseMana).Bytes(), "should be equal")
+	assert.Equal(t, p1.Bytes(), p2.Bytes(), "should be equal")
 }
 
 func newPersistableMana() *PersistableBaseMana {

--- a/packages/mana/persistableevent.go
+++ b/packages/mana/persistableevent.go
@@ -134,8 +134,8 @@ func (p *PersistableEvent) FromObjectStorage(_, bytes []byte) (objectstorage.Sto
 }
 
 // FromBytes unmarshalls bytes into a persistable event.
-func (p *PersistableEvent) FromBytes(data []byte) (result objectstorage.StorableObject, err error) {
+func (p *PersistableEvent) FromBytes(data []byte) (result *PersistableEvent, err error) {
 	return parseEvent(marshalutil.New(data))
 }
 
-var _ objectstorage.StorableObject = &PersistableEvent{}
+var _ objectstorage.StorableObject = new(PersistableEvent)

--- a/packages/mana/persistableevent_test.go
+++ b/packages/mana/persistableevent_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestPersistableEvent_Bytes(t *testing.T) {
-	ev := &PersistableEvent{}
+	ev := new(PersistableEvent)
 	marshalUtil := marshalutil.New()
 	marshalUtil.WriteByte(ev.Type)
 	marshalUtil.WriteByte(byte(ev.ManaType))
@@ -29,13 +29,13 @@ func TestPersistableEvent_Bytes(t *testing.T) {
 }
 
 func TestPersistableEvent_ObjectStorageKey(t *testing.T) {
-	ev := &PersistableEvent{}
+	ev := new(PersistableEvent)
 	key := ev.Bytes()
 	assert.Equal(t, key, ev.ObjectStorageKey(), "should be equal")
 }
 
 func TestPersistableEvent_ObjectStorageValue(t *testing.T) {
-	ev := &PersistableEvent{}
+	ev := new(PersistableEvent)
 	val := ev.ObjectStorageValue()
 	assert.Equal(t, ev.Bytes(), val, "should be equal")
 }
@@ -49,8 +49,7 @@ func TestPersistableEvent_FromBytes(t *testing.T) {
 		ManaType:      ConsensusMana,
 		TransactionID: ledgerstate.TransactionID{},
 	}
-	res, err := (&PersistableEvent{}).FromBytes(ev.Bytes())
-	ev1 := res.(*PersistableEvent)
+	ev1, err := new(PersistableEvent).FromBytes(ev.Bytes())
 	assert.NoError(t, err)
 	assert.Equal(t, ev.Bytes(), ev1.Bytes(), "should be equal")
 }

--- a/packages/markers/manager.go
+++ b/packages/markers/manager.go
@@ -221,7 +221,7 @@ func (m *Manager) initSequenceIDCounter() (self *Manager) {
 
 // initObjectStorage sets up the object storage for the Sequences.
 func (m *Manager) initObjectStorage() (self *Manager) {
-	m.sequenceStore = objectstorage.New[*Sequence](m.Options.Store.WithRealm([]byte{database.PrefixMarkers, 0}), objectstorage.CacheTime(m.Options.CacheTime))
+	m.sequenceStore = objectstorage.New[*Sequence](m.Options.Store.WithRealm([]byte{database.PrefixMarkers}), objectstorage.CacheTime(m.Options.CacheTime))
 
 	if cachedSequence, stored := m.sequenceStore.StoreIfAbsent(NewSequence(0, NewMarkers())); stored {
 		cachedSequence.Release()

--- a/packages/markers/models.go
+++ b/packages/markers/models.go
@@ -106,7 +106,7 @@ func MarkerFromBytes(markerBytes []byte) (marker *Marker, consumedBytes int, err
 
 // MarkerFromMarshalUtil unmarshals a Marker using a MarshalUtil (for easier unmarshalling).
 func MarkerFromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (marker *Marker, err error) {
-	marker = &Marker{}
+	marker = new(Marker)
 	if marker.sequenceID, err = SequenceIDFromMarshalUtil(marshalUtil); err != nil {
 		err = errors.Errorf("failed to parse SequenceID from MarshalUtil: %w", err)
 		return
@@ -1109,7 +1109,7 @@ func (s *Sequence) FromObjectStorage(key, bytes []byte) (objectstorage.StorableO
 }
 
 // FromBytes unmarshals a Sequence from a sequence of bytes.
-func (s *Sequence) FromBytes(sequenceBytes []byte) (sequence objectstorage.StorableObject, err error) {
+func (s *Sequence) FromBytes(sequenceBytes []byte) (sequence *Sequence, err error) {
 	marshalUtil := marshalutil.New(sequenceBytes)
 	if sequence, err = s.FromMarshalUtil(marshalUtil); err != nil {
 		err = errors.Errorf("failed to parse Sequence from MarshalUtil: %w", err)
@@ -1121,9 +1121,8 @@ func (s *Sequence) FromBytes(sequenceBytes []byte) (sequence objectstorage.Stora
 
 // FromMarshalUtil unmarshals a Sequence using a MarshalUtil (for easier unmarshalling).
 func (s *Sequence) FromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (sequence *Sequence, err error) {
-	sequence = s
-	if s == nil {
-		sequence = &Sequence{}
+	if sequence = s; sequence == nil {
+		sequence = new(Sequence)
 	}
 	if sequence.id, err = SequenceIDFromMarshalUtil(marshalUtil); err != nil {
 		return nil, errors.Errorf("failed to parse SequenceID from MarshalUtil: %w", err)
@@ -1277,7 +1276,7 @@ func (s *Sequence) ObjectStorageValue() []byte {
 }
 
 // code contract (make sure the type implements all required methods).
-var _ objectstorage.StorableObject = &Sequence{}
+var _ objectstorage.StorableObject = new(Sequence)
 
 // endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -1394,7 +1393,7 @@ func StructureDetailsFromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (stru
 		return
 	}
 
-	structureDetails = &StructureDetails{}
+	structureDetails = new(StructureDetails)
 	if structureDetails.Rank, err = marshalUtil.ReadUint64(); err != nil {
 		err = errors.Errorf("failed to parse Rank (%v): %w", err, cerrors.ErrParseBytesFailed)
 		return

--- a/packages/markers/models_test.go
+++ b/packages/markers/models_test.go
@@ -242,8 +242,7 @@ func TestSequence(t *testing.T) {
 	assert.Equal(t, Index(7), sequence.HighestIndex())
 
 	marshaledSequence := sequence.Bytes()
-	unmarshalledSequenceRaw, err := (&Sequence{}).FromBytes(marshaledSequence)
-	unmarshalledSequence := unmarshalledSequenceRaw.(*Sequence)
+	unmarshalledSequence, err := new(Sequence).FromBytes(marshaledSequence)
 	require.NoError(t, err)
 	assert.Equal(t, sequence.ID(), unmarshalledSequence.ID())
 	assert.Equal(t, sequence.HighestIndex(), unmarshalledSequence.HighestIndex())

--- a/packages/tangle/approvalweightmanager.go
+++ b/packages/tangle/approvalweightmanager.go
@@ -201,8 +201,7 @@ func (a *ApprovalWeightManager) determineBranchesToAdd(conflictBranchIDs ledgers
 		}
 
 		a.tangle.LedgerState.Branch(currentConflictBranchID).Consume(func(branch ledgerstate.Branch) {
-			conflictBranch := branch.(*ledgerstate.ConflictBranch)
-			addedBranchesOfCurrentBranch, allParentsOfCurrentBranchAdded := a.determineBranchesToAdd(conflictBranch.Parents(), branchVote)
+			addedBranchesOfCurrentBranch, allParentsOfCurrentBranchAdded := a.determineBranchesToAdd(branch.(*ledgerstate.ConflictBranch).Parents(), branchVote)
 			allParentsAdded = allParentsAdded && allParentsOfCurrentBranchAdded
 
 			addedBranches.AddAll(addedBranchesOfCurrentBranch)

--- a/packages/tangle/approvalweightmanager.models.go
+++ b/packages/tangle/approvalweightmanager.models.go
@@ -238,7 +238,7 @@ func (b *BranchVoters) FromObjectStorage(key, bytes []byte) (objectstorage.Stora
 }
 
 // FromBytes unmarshals a BranchVoters object from a sequence of bytes.
-func (b *BranchVoters) FromBytes(bytes []byte) (branchVoters objectstorage.StorableObject, err error) {
+func (b *BranchVoters) FromBytes(bytes []byte) (branchVoters *BranchVoters, err error) {
 	marshalUtil := marshalutil.New(bytes)
 	if branchVoters, err = b.FromMarshalUtil(marshalUtil); err != nil {
 		err = errors.Errorf("failed to parse SequenceVoters from MarshalUtil: %w", err)

--- a/packages/tangle/approvalweightmanager.models.go
+++ b/packages/tangle/approvalweightmanager.models.go
@@ -64,9 +64,8 @@ func (b *BranchWeight) FromBytes(bytes []byte) (branchWeight *BranchWeight, err 
 
 // FromMarshalUtil unmarshals a BranchWeight object using a MarshalUtil (for easier unmarshalling).
 func (b *BranchWeight) FromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (branchWeight *BranchWeight, err error) {
-	branchWeight = b
-	if b == nil {
-		branchWeight = &BranchWeight{}
+	if branchWeight = b; branchWeight == nil {
+		branchWeight = new(BranchWeight)
 	}
 	if branchWeight.branchID, err = ledgerstate.BranchIDFromMarshalUtil(marshalUtil); err != nil {
 		err = errors.Errorf("failed to parse BranchID from MarshalUtil: %w", err)
@@ -138,7 +137,7 @@ func (b *BranchWeight) ObjectStorageValue() []byte {
 }
 
 // code contract (make sure the struct implements all required methods).
-var _ objectstorage.StorableObject = &BranchWeight{}
+var _ objectstorage.StorableObject = new(BranchWeight)
 
 // endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -249,9 +248,8 @@ func (b *BranchVoters) FromBytes(bytes []byte) (branchVoters *BranchVoters, err 
 
 // FromMarshalUtil unmarshals a BranchVoters object using a MarshalUtil (for easier unmarshalling).
 func (b *BranchVoters) FromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (branchVoters *BranchVoters, err error) {
-	branchVoters = b
-	if b == nil {
-		branchVoters = &BranchVoters{}
+	if branchVoters = b; branchVoters == nil {
+		branchVoters = new(BranchVoters)
 	}
 	if branchVoters.branchID, err = ledgerstate.BranchIDFromMarshalUtil(marshalUtil); err != nil {
 		err = errors.Errorf("failed to parse BranchID from MarshalUtil: %w", err)
@@ -375,7 +373,7 @@ func (b *BranchVoters) ObjectStorageValue() []byte {
 }
 
 // code contract (make sure the struct implements all required methods).
-var _ objectstorage.StorableObject = &BranchVoters{}
+var _ objectstorage.StorableObject = new(BranchVoters)
 
 // endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -445,7 +443,7 @@ func (l *LatestMarkerVotes) FromObjectStorage(key, bytes []byte) (objectstorage.
 }
 
 // FromBytes unmarshals a LatestMarkerVotes from a sequence of bytes.
-func (l *LatestMarkerVotes) FromBytes(bytes []byte) (latestMarkerVotes objectstorage.StorableObject, err error) {
+func (l *LatestMarkerVotes) FromBytes(bytes []byte) (latestMarkerVotes *LatestMarkerVotes, err error) {
 	marshalUtil := marshalutil.New(bytes)
 	if latestMarkerVotes, err = l.FromMarshalUtil(marshalUtil); err != nil {
 		err = errors.Errorf("failed to parse LatestBranchVotes from MarshalUtil: %w", err)
@@ -456,9 +454,8 @@ func (l *LatestMarkerVotes) FromBytes(bytes []byte) (latestMarkerVotes objectsto
 
 // FromMarshalUtil unmarshals a LatestMarkerVotes using a MarshalUtil (for easier unmarshalling).
 func (l *LatestMarkerVotes) FromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (latestMarkerVotes *LatestMarkerVotes, err error) {
-	latestMarkerVotes = l
-	if l == nil {
-		latestMarkerVotes = &LatestMarkerVotes{}
+	if latestMarkerVotes = l; latestMarkerVotes == nil {
+		latestMarkerVotes = new(LatestMarkerVotes)
 	}
 
 	if latestMarkerVotes.sequenceID, err = markers.SequenceIDFromMarshalUtil(marshalUtil); err != nil {
@@ -581,7 +578,7 @@ func (l *LatestMarkerVotes) ObjectStorageValue() []byte {
 	return marshalUtil.Bytes()
 }
 
-var _ objectstorage.StorableObject = &LatestMarkerVotes{}
+var _ objectstorage.StorableObject = new(LatestMarkerVotes)
 
 // endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -661,7 +658,7 @@ func (l *LatestBranchVotes) FromObjectStorage(key, bytes []byte) (objectstorage.
 }
 
 // FromBytes unmarshals a LatestBranchVotes object from a sequence of bytes.
-func (l *LatestBranchVotes) FromBytes(bytes []byte) (latestBranchVotes objectstorage.StorableObject, err error) {
+func (l *LatestBranchVotes) FromBytes(bytes []byte) (latestBranchVotes *LatestBranchVotes, err error) {
 	marshalUtil := marshalutil.New(bytes)
 	if latestBranchVotes, err = l.FromMarshalUtil(marshalUtil); err != nil {
 		err = errors.Errorf("failed to parse LatestBranchVotes from MarshalUtil: %w", err)
@@ -673,9 +670,8 @@ func (l *LatestBranchVotes) FromBytes(bytes []byte) (latestBranchVotes objectsto
 
 // FromMarshalUtil unmarshals a LatestBranchVotes object using a MarshalUtil (for easier unmarshalling).
 func (l *LatestBranchVotes) FromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (latestBranchVotes *LatestBranchVotes, err error) {
-	latestBranchVotes = l
-	if l == nil {
-		latestBranchVotes = &LatestBranchVotes{}
+	if latestBranchVotes = l; l == nil {
+		latestBranchVotes = new(LatestBranchVotes)
 	}
 	if latestBranchVotes.voter, err = identity.IDFromMarshalUtil(marshalUtil); err != nil {
 		return nil, errors.Errorf("failed to parse Voter from MarshalUtil: %w", err)
@@ -742,7 +738,7 @@ func (l *LatestBranchVotes) ObjectStorageValue() []byte {
 }
 
 // code contract (make sure the struct implements all required methods).
-var _ objectstorage.StorableObject = &LatestBranchVotes{}
+var _ objectstorage.StorableObject = new(LatestBranchVotes)
 
 // endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -758,7 +754,7 @@ type BranchVote struct {
 
 // VoteFromMarshalUtil unmarshals a Vote structure using a MarshalUtil (for easier unmarshalling).
 func VoteFromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (vote *BranchVote, err error) {
-	vote = &BranchVote{}
+	vote = new(BranchVote)
 
 	if vote.Voter, err = identity.IDFromMarshalUtil(marshalUtil); err != nil {
 		return nil, errors.Errorf("failed to parse Voter from MarshalUtil: %w", err)

--- a/packages/tangle/approvalweightmanager_test.go
+++ b/packages/tangle/approvalweightmanager_test.go
@@ -82,8 +82,7 @@ func TestBranchVotersMarshalling(t *testing.T) {
 		branchVoters.AddVoter(identity.GenerateIdentity().ID())
 	}
 
-	branchVotersFromBytesRaw, err := (&BranchVoters{}).FromBytes(branchVoters.Bytes())
-	branchVotersFromBytes := branchVotersFromBytesRaw.(*BranchVoters)
+	branchVotersFromBytes, err := new(BranchVoters).FromBytes(branchVoters.Bytes())
 	require.NoError(t, err)
 
 	// verify that branchVotersFromBytes has all voters from branchVoters

--- a/packages/tangle/message.go
+++ b/packages/tangle/message.go
@@ -760,7 +760,7 @@ func (m *Message) String() string {
 	return builder.String()
 }
 
-var _ objectstorage.StorableObject = &Message{}
+var _ objectstorage.StorableObject = new(Message)
 
 // endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -897,7 +897,7 @@ func (m *MessageMetadata) FromObjectStorage(key, bytes []byte) (objectstorage.St
 }
 
 // FromBytes unmarshals the given bytes into a MessageMetadata.
-func (m *MessageMetadata) FromBytes(bytes []byte) (result objectstorage.StorableObject, err error) {
+func (m *MessageMetadata) FromBytes(bytes []byte) (result *MessageMetadata, err error) {
 	marshalUtil := marshalutil.New(bytes)
 	result, err = m.FromMarshalUtil(marshalUtil)
 
@@ -905,57 +905,56 @@ func (m *MessageMetadata) FromBytes(bytes []byte) (result objectstorage.Storable
 }
 
 // FromMarshalUtil parses a Message from the given MarshalUtil.
-func (m *MessageMetadata) FromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (result *MessageMetadata, err error) {
-	result = m
-	if m == nil {
-		result = &MessageMetadata{}
+func (m *MessageMetadata) FromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (messageMetadata *MessageMetadata, err error) {
+	if messageMetadata = m; messageMetadata == nil {
+		messageMetadata = new(MessageMetadata)
 	}
 
-	if result.messageID, err = ReferenceFromMarshalUtil(marshalUtil); err != nil {
+	if messageMetadata.messageID, err = ReferenceFromMarshalUtil(marshalUtil); err != nil {
 		err = fmt.Errorf("failed to parse message ID of message metadata: %w", err)
 		return
 	}
-	if result.receivedTime, err = marshalUtil.ReadTime(); err != nil {
+	if messageMetadata.receivedTime, err = marshalUtil.ReadTime(); err != nil {
 		err = fmt.Errorf("failed to parse received time of message metadata: %w", err)
 		return
 	}
-	if result.solidificationTime, err = marshalUtil.ReadTime(); err != nil {
+	if messageMetadata.solidificationTime, err = marshalUtil.ReadTime(); err != nil {
 		err = fmt.Errorf("failed to parse solidification time of message metadata: %w", err)
 		return
 	}
-	if result.solid, err = marshalUtil.ReadBool(); err != nil {
+	if messageMetadata.solid, err = marshalUtil.ReadBool(); err != nil {
 		err = fmt.Errorf("failed to parse solid flag of message metadata: %w", err)
 		return
 	}
-	if result.structureDetails, err = markers.StructureDetailsFromMarshalUtil(marshalUtil); err != nil {
+	if messageMetadata.structureDetails, err = markers.StructureDetailsFromMarshalUtil(marshalUtil); err != nil {
 		err = errors.Errorf("failed to parse StructureDetails from MarshalUtil: %w", err)
 		return
 	}
-	if result.addedBranchIDs, err = ledgerstate.BranchIDFromMarshalUtil(marshalUtil); err != nil {
+	if messageMetadata.addedBranchIDs, err = ledgerstate.BranchIDFromMarshalUtil(marshalUtil); err != nil {
 		err = errors.Errorf("failed to parse added BranchID from MarshalUtil: %w", err)
 		return
 	}
-	if result.subtractedBranchIDs, err = ledgerstate.BranchIDFromMarshalUtil(marshalUtil); err != nil {
+	if messageMetadata.subtractedBranchIDs, err = ledgerstate.BranchIDFromMarshalUtil(marshalUtil); err != nil {
 		err = errors.Errorf("failed to parse subtracted BranchID from MarshalUtil: %w", err)
 		return
 	}
-	if result.scheduled, err = marshalUtil.ReadBool(); err != nil {
+	if messageMetadata.scheduled, err = marshalUtil.ReadBool(); err != nil {
 		err = fmt.Errorf("failed to parse scheduled flag of message metadata: %w", err)
 		return
 	}
-	if result.scheduledTime, err = marshalUtil.ReadTime(); err != nil {
+	if messageMetadata.scheduledTime, err = marshalUtil.ReadTime(); err != nil {
 		err = fmt.Errorf("failed to parse scheduled time of message metadata: %w", err)
 		return
 	}
-	if result.booked, err = marshalUtil.ReadBool(); err != nil {
+	if messageMetadata.booked, err = marshalUtil.ReadBool(); err != nil {
 		err = fmt.Errorf("failed to parse booked flag of message metadata: %w", err)
 		return
 	}
-	if result.bookedTime, err = marshalUtil.ReadTime(); err != nil {
+	if messageMetadata.bookedTime, err = marshalUtil.ReadTime(); err != nil {
 		err = fmt.Errorf("failed to parse booked time of message metadata: %w", err)
 		return
 	}
-	if result.objectivelyInvalid, err = marshalUtil.ReadBool(); err != nil {
+	if messageMetadata.objectivelyInvalid, err = marshalUtil.ReadBool(); err != nil {
 		err = fmt.Errorf("failed to parse invalid flag of message metadata: %w", err)
 		return
 	}
@@ -964,8 +963,8 @@ func (m *MessageMetadata) FromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) 
 		err = fmt.Errorf("failed to parse grade of finality of message metadata: %w", err)
 		return
 	}
-	result.gradeOfFinality = gof.GradeOfFinality(gradeOfFinality)
-	if result.gradeOfFinalityTime, err = marshalUtil.ReadTime(); err != nil {
+	messageMetadata.gradeOfFinality = gof.GradeOfFinality(gradeOfFinality)
+	if messageMetadata.gradeOfFinalityTime, err = marshalUtil.ReadTime(); err != nil {
 		err = fmt.Errorf("failed to parse gradeOfFinality time of message metadata: %w", err)
 		return
 	}
@@ -1344,7 +1343,7 @@ func (m *MessageMetadata) String() string {
 	)
 }
 
-var _ objectstorage.StorableObject = &MessageMetadata{}
+var _ objectstorage.StorableObject = new(MessageMetadata)
 
 // endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/packages/tangle/message.go
+++ b/packages/tangle/message.go
@@ -445,7 +445,7 @@ func (m *Message) FromObjectStorage(key, data []byte) (result objectstorage.Stor
 		err = fmt.Errorf("failed to parse message ID from object storage: %w", err)
 		return
 	}
-	message.(*Message).id = &id
+	message.id = &id
 
 	// assign result
 	result = message
@@ -454,9 +454,9 @@ func (m *Message) FromObjectStorage(key, data []byte) (result objectstorage.Stor
 }
 
 // FromBytes parses the given bytes into a message.
-func (m *Message) FromBytes(bytes []byte) (result objectstorage.StorableObject, err error) {
+func (m *Message) FromBytes(bytes []byte) (message *Message, err error) {
 	marshalUtil := marshalutil.New(bytes)
-	result, err = m.FromMarshalUtil(marshalUtil)
+	message, err = m.FromMarshalUtil(marshalUtil)
 	if err != nil {
 		return
 	}

--- a/packages/tangle/message_test.go
+++ b/packages/tangle/message_test.go
@@ -210,9 +210,9 @@ func TestMessage_UnmarshalTransaction(t *testing.T) {
 		ed25519.Signature{})
 	assert.NoError(t, err)
 
-	restoredMessage, err := (&Message{}).FromBytes(testMessage.Bytes())
+	restoredMessage, err := new(Message).FromBytes(testMessage.Bytes())
 	assert.NoError(t, err)
-	assert.Equal(t, testMessage.ID(), restoredMessage.(*Message).ID())
+	assert.Equal(t, testMessage.ID(), restoredMessage.ID())
 }
 
 func TestMessage_MarshalUnmarshal(t *testing.T) {
@@ -227,8 +227,7 @@ func TestMessage_MarshalUnmarshal(t *testing.T) {
 
 	t.Log(testMessage)
 
-	restoredMessageRaw, err := (&Message{}).FromBytes(testMessage.Bytes())
-	restoredMessage := restoredMessageRaw.(*Message)
+	restoredMessage, err := new(Message).FromBytes(testMessage.Bytes())
 	if assert.NoError(t, err, err) {
 		assert.Equal(t, testMessage.ID(), restoredMessage.ID())
 		assert.ElementsMatch(t, testMessage.ParentsByType(StrongParentType), restoredMessage.ParentsByType(StrongParentType))
@@ -699,7 +698,7 @@ func TestMessage_Bytes(t *testing.T) {
 		copy(tmp, msgBytes[3:35])
 		copy(msgBytes[3:35], msgBytes[3+32:35+32])
 		copy(msgBytes[3+32:35+32], tmp)
-		_, err = (&Message{}).FromBytes(msgBytes)
+		_, err = new(Message).FromBytes(msgBytes)
 		assert.Error(t, err)
 	})
 
@@ -765,8 +764,7 @@ func TestMessageFromBytes(t *testing.T) {
 		assert.NoError(t, err)
 
 		msgBytes := msg.Bytes()
-		resultRaw, err := (&Message{}).FromBytes(msgBytes)
-		result := resultRaw.(*Message)
+		result, err := (&Message{}).FromBytes(msgBytes)
 		assert.NoError(t, err)
 		assert.Equal(t, msg.Version(), result.Version())
 		assert.Equal(t, msg.ParentsByType(StrongParentType), result.ParentsByType(StrongParentType))

--- a/packages/tangle/message_test.go
+++ b/packages/tangle/message_test.go
@@ -764,7 +764,7 @@ func TestMessageFromBytes(t *testing.T) {
 		assert.NoError(t, err)
 
 		msgBytes := msg.Bytes()
-		result, err := (&Message{}).FromBytes(msgBytes)
+		result, err := new(Message).FromBytes(msgBytes)
 		assert.NoError(t, err)
 		assert.Equal(t, msg.Version(), result.Version())
 		assert.Equal(t, msg.ParentsByType(StrongParentType), result.ParentsByType(StrongParentType))
@@ -798,7 +798,7 @@ func TestMessageFromBytes(t *testing.T) {
 		msgBytes := msg.Bytes()
 		// put some bytes at the end
 		msgBytes = append(msgBytes, []byte{0, 1, 2, 3, 4}...)
-		_, err = (&Message{}).FromBytes(msgBytes)
+		_, err = new(Message).FromBytes(msgBytes)
 		assert.Error(t, err)
 		assert.True(t, errors.Is(err, cerrors.ErrParseBytesFailed))
 	})
@@ -825,7 +825,7 @@ func TestMessageFromMarshalUtil(t *testing.T) {
 	t.Run("CASE: Missing version", func(t *testing.T) {
 		marshaller := marshalutil.New([]byte{})
 		// missing version
-		_, err := (&Message{}).FromMarshalUtil(marshaller)
+		_, err := new(Message).FromMarshalUtil(marshaller)
 		assert.Error(t, err)
 		assert.True(t, strings.Contains(err.Error(), "failed to parse message version"))
 	})
@@ -834,7 +834,7 @@ func TestMessageFromMarshalUtil(t *testing.T) {
 		msgBytes := createTestMsgBytes(MaxParentsCount/2, MaxParentsCount/2)
 		// missing parentsCount
 		marshaller := marshalutil.New(msgBytes[:1])
-		_, err := (&Message{}).FromMarshalUtil(marshaller)
+		_, err := new(Message).FromMarshalUtil(marshaller)
 		assert.Error(t, err)
 		assert.True(t, strings.Contains(err.Error(), "failed to parse parents count"))
 	})
@@ -843,7 +843,7 @@ func TestMessageFromMarshalUtil(t *testing.T) {
 		msgBytes := createTestMsgBytes(MaxParentsCount/2, MaxParentsCount/2)
 		msgBytes[1] = MinParentsCount - 1
 		marshaller := marshalutil.New(msgBytes[:2])
-		_, err := (&Message{}).FromMarshalUtil(marshaller)
+		_, err := new(Message).FromMarshalUtil(marshaller)
 		assert.Error(t, err)
 		assert.EqualError(t, err, fmt.Sprintf("parents count %d not allowed: failed to parse bytes", MinParentsCount-1))
 	})
@@ -852,7 +852,7 @@ func TestMessageFromMarshalUtil(t *testing.T) {
 		msgBytes := createTestMsgBytes(MaxParentsCount/2, MaxParentsCount/2)
 		msgBytes[1] = MaxParentsCount + 1
 		marshaller := marshalutil.New(msgBytes[:2])
-		_, err := (&Message{}).FromMarshalUtil(marshaller)
+		_, err := new(Message).FromMarshalUtil(marshaller)
 		assert.Error(t, err)
 		assert.EqualError(t, err, fmt.Sprintf("parents count %d not allowed: failed to parse bytes", MaxParentsCount+1))
 	})
@@ -860,7 +860,7 @@ func TestMessageFromMarshalUtil(t *testing.T) {
 	t.Run("CASE: Missing parent types", func(t *testing.T) {
 		msgBytes := createTestMsgBytes(MaxParentsCount/2, MaxParentsCount/2)
 		marshaller := marshalutil.New(msgBytes[:2])
-		_, err := (&Message{}).FromMarshalUtil(marshaller)
+		_, err := new(Message).FromMarshalUtil(marshaller)
 		assert.Error(t, err)
 		assert.True(t, strings.Contains(err.Error(), "failed to parse parent types"))
 	})
@@ -868,7 +868,7 @@ func TestMessageFromMarshalUtil(t *testing.T) {
 	t.Run("CASE: Missing parents (all)", func(t *testing.T) {
 		msgBytes := createTestMsgBytes(MaxParentsCount/2, MaxParentsCount/2)
 		marshaller := marshalutil.New(msgBytes[:3])
-		_, err := (&Message{}).FromMarshalUtil(marshaller)
+		_, err := new(Message).FromMarshalUtil(marshaller)
 		assert.Error(t, err)
 		assert.True(t, strings.Contains(err.Error(), "failed to parse parent"))
 	})
@@ -876,7 +876,7 @@ func TestMessageFromMarshalUtil(t *testing.T) {
 	t.Run("CASE: Missing parents (one)", func(t *testing.T) {
 		msgBytes := createTestMsgBytes(MaxParentsCount/2, MaxParentsCount/2)
 		marshaller := marshalutil.New(msgBytes[:3+(MaxParentsCount-1)*32])
-		_, err := (&Message{}).FromMarshalUtil(marshaller)
+		_, err := new(Message).FromMarshalUtil(marshaller)
 		assert.Error(t, err)
 		assert.True(t, strings.Contains(err.Error(), "failed to parse parent"))
 	})

--- a/packages/tangle/parser.go
+++ b/packages/tangle/parser.go
@@ -145,13 +145,13 @@ func (p *Parser) setupMessageFilterDataFlow() {
 
 // parses the given message and emits
 func (p *Parser) parseMessage(bytes []byte, peer *peer.Peer) {
-	if parsedMessage, err := (&Message{}).FromBytes(bytes); err != nil {
+	if parsedMessage, err := new(Message).FromBytes(bytes); err != nil {
 		p.Events.BytesRejected.Trigger(&BytesRejectedEvent{
 			Bytes: bytes,
 			Peer:  peer,
 		}, err)
 	} else {
-		p.messageFilters[0].Filter(parsedMessage.(*Message), peer)
+		p.messageFilters[0].Filter(parsedMessage, peer)
 	}
 }
 

--- a/packages/tangle/parser.go
+++ b/packages/tangle/parser.go
@@ -273,7 +273,7 @@ type MessageSignatureFilter struct {
 
 // NewMessageSignatureFilter creates a new message signature filter.
 func NewMessageSignatureFilter() *MessageSignatureFilter {
-	return &MessageSignatureFilter{}
+	return new(MessageSignatureFilter)
 }
 
 // Filter filters up on the given bytes and peer and calls the acceptance callback
@@ -465,7 +465,7 @@ func (r *RecentlySeenBytesFilter) getRejectCallback() (result func(bytes []byte,
 
 // NewTransactionFilter creates a new transaction filter.
 func NewTransactionFilter() *TransactionFilter {
-	return &TransactionFilter{}
+	return new(TransactionFilter)
 }
 
 // TransactionFilter filters messages based on their timestamps and transaction timestamp.
@@ -480,7 +480,7 @@ type TransactionFilter struct {
 // Filter compares the timestamps between the message, and it's transaction payload and calls the corresponding callback.
 func (f *TransactionFilter) Filter(msg *Message, peer *peer.Peer) {
 	if payload := msg.Payload(); payload.Type() == ledgerstate.TransactionType {
-		transaction, err := (&ledgerstate.Transaction{}).FromBytes(payload.Bytes())
+		transaction, err := new(ledgerstate.Transaction).FromBytes(payload.Bytes())
 		if err != nil {
 			f.getRejectCallback()(msg, err, peer)
 			return

--- a/packages/tangle/storage.go
+++ b/packages/tangle/storage.go
@@ -622,9 +622,7 @@ func (a *Approver) FromObjectStorage(key, _ []byte) (objectstorage.StorableObjec
 
 // FromBytes parses the given bytes into an approver.
 func (a *Approver) FromBytes(bytes []byte) (result *Approver, err error) {
-	marshalUtil := marshalutil.New(bytes)
-	result, err = a.FromMarshalUtil(marshalUtil)
-	return
+	return a.FromMarshalUtil(marshalutil.New(bytes))
 }
 
 // FromMarshalUtil parses a new approver from the given marshal util.
@@ -727,9 +725,7 @@ func (a *Attachment) FromObjectStorage(key, _ []byte) (objectstorage.StorableObj
 // FromBytes unmarshals an Attachment from a sequence of bytes - it either creates a new object or fills the
 // optionally provided one with the parsed information.
 func (a *Attachment) FromBytes(bytes []byte) (result *Attachment, err error) {
-	marshalUtil := marshalutil.New(bytes)
-	result, err = a.FromMarshalUtil(marshalUtil)
-	return
+	return a.FromMarshalUtil(marshalutil.New(bytes))
 }
 
 // FromMarshalUtil is a wrapper for simplified unmarshaling of Attachments from a byte stream using the marshalUtil

--- a/packages/tangle/storage.go
+++ b/packages/tangle/storage.go
@@ -468,8 +468,7 @@ type DBStatsResult struct {
 // the average time it takes to solidify messages.
 func (s *Storage) DBStats() (res DBStatsResult) {
 	s.messageMetadataStorage.ForEach(func(key []byte, cachedObject *objectstorage.CachedObject[*MessageMetadata]) bool {
-		cachedObject.Consume(func(object *MessageMetadata) {
-			msgMetaData := object
+		cachedObject.Consume(func(msgMetaData *MessageMetadata) {
 			res.StoredCount++
 			received := msgMetaData.ReceivedTime()
 			if msgMetaData.IsSolid() {
@@ -503,14 +502,13 @@ func (s *Storage) DBStats() (res DBStatsResult) {
 // TODO: improve this function.
 func (s *Storage) RetrieveAllTips() (tips []MessageID) {
 	s.messageMetadataStorage.ForEach(func(key []byte, cachedMessage *objectstorage.CachedObject[*MessageMetadata]) bool {
-		cachedMessage.Consume(func(object *MessageMetadata) {
-			messageMetadata := object
+		cachedMessage.Consume(func(messageMetadata *MessageMetadata) {
 			if messageMetadata != nil && messageMetadata.IsSolid() {
 				cachedApprovers := s.Approvers(messageMetadata.messageID)
 				if len(cachedApprovers) == 0 {
 					tips = append(tips, messageMetadata.messageID)
 				}
-				cachedApprovers.Consume(func(approver *Approver) {})
+				cachedApprovers.Release()
 			}
 		})
 		return true
@@ -623,27 +621,26 @@ func (a *Approver) FromObjectStorage(key, _ []byte) (objectstorage.StorableObjec
 }
 
 // FromBytes parses the given bytes into an approver.
-func (a *Approver) FromBytes(bytes []byte) (result objectstorage.StorableObject, err error) {
+func (a *Approver) FromBytes(bytes []byte) (result *Approver, err error) {
 	marshalUtil := marshalutil.New(bytes)
 	result, err = a.FromMarshalUtil(marshalUtil)
 	return
 }
 
 // FromMarshalUtil parses a new approver from the given marshal util.
-func (a *Approver) FromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (result *Approver, err error) {
-	result = a
-	if a == nil {
-		result = &Approver{}
+func (a *Approver) FromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (approver *Approver, err error) {
+	if approver = a; approver == nil {
+		approver = new(Approver)
 	}
-	if result.referencedMessageID, err = ReferenceFromMarshalUtil(marshalUtil); err != nil {
+	if approver.referencedMessageID, err = ReferenceFromMarshalUtil(marshalUtil); err != nil {
 		err = errors.Errorf("failed to parse referenced MessageID from MarshalUtil: %w", err)
 		return
 	}
-	if result.approverType, err = ApproverTypeFromMarshalUtil(marshalUtil); err != nil {
+	if approver.approverType, err = ApproverTypeFromMarshalUtil(marshalUtil); err != nil {
 		err = errors.Errorf("failed to parse ApproverType from MarshalUtil: %w", err)
 		return
 	}
-	if result.approverMessageID, err = ReferenceFromMarshalUtil(marshalUtil); err != nil {
+	if approver.approverMessageID, err = ReferenceFromMarshalUtil(marshalUtil); err != nil {
 		err = errors.Errorf("failed to parse approver MessageID from MarshalUtil: %w", err)
 		return
 	}
@@ -695,7 +692,7 @@ func (a *Approver) ObjectStorageValue() (result []byte) {
 }
 
 // interface contract (allow the compiler to check if the implementation has all of the required methods).
-var _ objectstorage.StorableObject = &Approver{}
+var _ objectstorage.StorableObject = new(Approver)
 
 // endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -729,7 +726,7 @@ func (a *Attachment) FromObjectStorage(key, _ []byte) (objectstorage.StorableObj
 
 // FromBytes unmarshals an Attachment from a sequence of bytes - it either creates a new object or fills the
 // optionally provided one with the parsed information.
-func (a *Attachment) FromBytes(bytes []byte) (result objectstorage.StorableObject, err error) {
+func (a *Attachment) FromBytes(bytes []byte) (result *Attachment, err error) {
 	marshalUtil := marshalutil.New(bytes)
 	result, err = a.FromMarshalUtil(marshalUtil)
 	return
@@ -737,16 +734,15 @@ func (a *Attachment) FromBytes(bytes []byte) (result objectstorage.StorableObjec
 
 // FromMarshalUtil is a wrapper for simplified unmarshaling of Attachments from a byte stream using the marshalUtil
 // package.
-func (a *Attachment) FromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (result *Attachment, err error) {
-	result = a
-	if a == nil {
-		result = &Attachment{}
+func (a *Attachment) FromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (attachment *Attachment, err error) {
+	if attachment = a; attachment == nil {
+		attachment = new(Attachment)
 	}
-	if result.transactionID, err = ledgerstate.TransactionIDFromMarshalUtil(marshalUtil); err != nil {
+	if attachment.transactionID, err = ledgerstate.TransactionIDFromMarshalUtil(marshalUtil); err != nil {
 		err = errors.Errorf("failed to parse transaction ID in attachment: %w", err)
 		return
 	}
-	if result.messageID, err = ReferenceFromMarshalUtil(marshalUtil); err != nil {
+	if attachment.messageID, err = ReferenceFromMarshalUtil(marshalUtil); err != nil {
 		err = errors.Errorf("failed to parse message ID in attachment: %w", err)
 		return
 	}
@@ -789,7 +785,7 @@ func (a *Attachment) ObjectStorageValue() (data []byte) {
 }
 
 // Interface contract: make compiler warn if the interface is not implemented correctly.
-var _ objectstorage.StorableObject = &Attachment{}
+var _ objectstorage.StorableObject = new(Attachment)
 
 // AttachmentLength holds the length of a marshaled Attachment in bytes.
 const AttachmentLength = ledgerstate.TransactionIDLength + MessageIDLength
@@ -824,18 +820,15 @@ func (m *MissingMessage) FromObjectStorage(key, bytes []byte) (objectstorage.Sto
 }
 
 // FromBytes parses the given bytes into a MissingMessage.
-func (m *MissingMessage) FromBytes(bytes []byte) (result objectstorage.StorableObject, err error) {
-	marshalUtil := marshalutil.New(bytes)
-	result, err = m.FromMarshalUtil(marshalUtil)
-
-	return
+func (m *MissingMessage) FromBytes(bytes []byte) (result *MissingMessage, err error) {
+	return m.FromMarshalUtil(marshalutil.New(bytes))
 }
 
 // FromMarshalUtil parses a MissingMessage from the given MarshalUtil.
 func (m *MissingMessage) FromMarshalUtil(marshalUtil *marshalutil.MarshalUtil) (result *MissingMessage, err error) {
 	result = m
 	if m == nil {
-		result = &MissingMessage{}
+		result = new(MissingMessage)
 	}
 
 	if result.messageID, err = ReferenceFromMarshalUtil(marshalUtil); err != nil {
@@ -882,6 +875,6 @@ func (m *MissingMessage) ObjectStorageValue() (result []byte) {
 }
 
 // Interface contract: make compiler warn if the interface is not implemented correctly.
-var _ objectstorage.StorableObject = &MissingMessage{}
+var _ objectstorage.StorableObject = new(MissingMessage)
 
 // endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/packages/tangle/tangle_test.go
+++ b/packages/tangle/tangle_test.go
@@ -52,10 +52,10 @@ func BenchmarkVerifyDataMessages(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		currentIndex := i
 		pool.Submit(func() {
-			if msg, err := (&Message{}).FromBytes(messages[currentIndex]); err != nil {
+			if msg, err := new(Message).FromBytes(messages[currentIndex]); err != nil {
 				b.Error(err)
 			} else {
-				msg.(*Message).VerifySignature()
+				msg.VerifySignature()
 			}
 		})
 	}

--- a/packages/txstream/msg.go
+++ b/packages/txstream/msg.go
@@ -166,43 +166,43 @@ func DecodeMsg(data []byte, expectedFlags uint8) (interface{}, error) {
 
 	switch msgType {
 	case msgTypeChunk:
-		ret = &MsgChunk{}
+		ret = new(MsgChunk)
 
 	case msgTypePostTransaction:
-		ret = &MsgPostTransaction{}
+		ret = new(MsgPostTransaction)
 
 	case msgTypeSubscribe:
-		ret = &MsgUpdateSubscriptions{}
+		ret = new(MsgUpdateSubscriptions)
 
 	case msgTypeGetConfirmedTransaction:
-		ret = &MsgGetConfirmedTransaction{}
+		ret = new(MsgGetConfirmedTransaction)
 
 	case msgTypeGetTxInclusionState:
-		ret = &MsgGetTxInclusionState{}
+		ret = new(MsgGetTxInclusionState)
 
 	case msgTypeGetBacklog:
-		ret = &MsgGetBacklog{}
+		ret = new(MsgGetBacklog)
 
 	case msgTypeSetID:
-		ret = &MsgSetID{}
+		ret = new(MsgSetID)
 
 	case msgTypeTransaction:
-		ret = &MsgTransaction{}
+		ret = new(MsgTransaction)
 
 	case msgTypeTxGoF:
-		ret = &MsgTxGoF{}
+		ret = new(MsgTxGoF)
 
 	case msgTypeGetConfirmedOutput:
-		ret = &MsgGetConfirmedOutput{}
+		ret = new(MsgGetConfirmedOutput)
 
 	case msgTypeGetUnspentAliasOutput:
-		ret = &MsgGetUnspentAliasOutput{}
+		ret = new(MsgGetUnspentAliasOutput)
 
 	case msgTypeOutput:
-		ret = &MsgOutput{}
+		ret = new(MsgOutput)
 
 	case msgTypeUnspentAliasOutput:
-		ret = &MsgUnspentAliasOutput{}
+		ret = new(MsgUnspentAliasOutput)
 
 	default:
 		return nil, fmt.Errorf("unknown message type %d", msgType)
@@ -219,7 +219,7 @@ func (msg *MsgPostTransaction) Write(w *marshalutil.MarshalUtil) {
 
 func (msg *MsgPostTransaction) Read(m *marshalutil.MarshalUtil) error {
 	var err error
-	if msg.Tx, err = (&ledgerstate.Transaction{}).FromMarshalUtil(m); err != nil {
+	if msg.Tx, err = new(ledgerstate.Transaction).FromMarshalUtil(m); err != nil {
 		return err
 	}
 	return nil
@@ -346,7 +346,7 @@ func (msg *MsgTransaction) Read(m *marshalutil.MarshalUtil) error {
 	if msg.Address, err = ledgerstate.AddressFromMarshalUtil(m); err != nil {
 		return err
 	}
-	if msg.Tx, err = (&ledgerstate.Transaction{}).FromMarshalUtil(m); err != nil {
+	if msg.Tx, err = new(ledgerstate.Transaction).FromMarshalUtil(m); err != nil {
 		return err
 	}
 	return nil
@@ -435,7 +435,7 @@ func (msg *MsgOutput) Read(m *marshalutil.MarshalUtil) error {
 		return err
 	}
 	msg.Output.SetID(id)
-	if msg.OutputMetadata, err = (&ledgerstate.OutputMetadata{}).FromMarshalUtil(m); err != nil {
+	if msg.OutputMetadata, err = new(ledgerstate.OutputMetadata).FromMarshalUtil(m); err != nil {
 		return err
 	}
 	return err
@@ -459,7 +459,7 @@ func (msg *MsgUnspentAliasOutput) Read(m *marshalutil.MarshalUtil) error {
 	if msg.AliasAddress, err = ledgerstate.AliasAddressFromMarshalUtil(m); err != nil {
 		return err
 	}
-	if msg.AliasOutput, err = (&ledgerstate.AliasOutput{}).FromMarshalUtil(m); err != nil {
+	if msg.AliasOutput, err = new(ledgerstate.AliasOutput).FromMarshalUtil(m); err != nil {
 		return err
 	}
 	id, err := ledgerstate.OutputIDFromMarshalUtil(m)
@@ -470,7 +470,7 @@ func (msg *MsgUnspentAliasOutput) Read(m *marshalutil.MarshalUtil) error {
 	if msg.Timestamp, err = m.ReadTime(); err != nil {
 		return err
 	}
-	if msg.OutputMetadata, err = (&ledgerstate.OutputMetadata{}).FromMarshalUtil(m); err != nil {
+	if msg.OutputMetadata, err = new(ledgerstate.OutputMetadata).FromMarshalUtil(m); err != nil {
 		return err
 	}
 	return err

--- a/plugins/dashboard/payload_handler.go
+++ b/plugins/dashboard/payload_handler.go
@@ -165,7 +165,7 @@ func processDrngPayload(p payload.Payload) (dp DrngPayload) {
 
 // processTransactionPayload handles Value payload
 func processTransactionPayload(p payload.Payload) (tp TransactionPayload) {
-	tx, err := (&ledgerstate.Transaction{}).FromBytes(p.Bytes())
+	tx, err := new(ledgerstate.Transaction).FromBytes(p.Bytes())
 	if err != nil {
 		return
 	}

--- a/plugins/webapi/ledgerstate/plugin.go
+++ b/plugins/webapi/ledgerstate/plugin.go
@@ -163,7 +163,7 @@ func GetAddressUnspentOutputs(c echo.Context) error {
 
 // PostAddressUnspentOutputs is the handler for the /ledgerstate/addresses/unspentOutputs endpoint.
 func PostAddressUnspentOutputs(c echo.Context) error {
-	req := &jsonmodels.PostAddressesUnspentOutputsRequest{}
+	req := new(jsonmodels.PostAddressesUnspentOutputsRequest)
 	if err := c.Bind(&req); err != nil {
 		return c.JSON(http.StatusBadRequest, jsonmodels.NewErrorResponse(err))
 	}
@@ -180,7 +180,7 @@ func PostAddressUnspentOutputs(c echo.Context) error {
 		UnspentOutputs: make([]*jsonmodels.WalletOutputsOnAddress, len(addresses)),
 	}
 	for i, addy := range addresses {
-		res.UnspentOutputs[i] = &jsonmodels.WalletOutputsOnAddress{}
+		res.UnspentOutputs[i] = new(jsonmodels.WalletOutputsOnAddress)
 		cachedOutputs := deps.Tangle.LedgerState.CachedOutputsOnAddress(addy)
 		res.UnspentOutputs[i].Address = jsonmodels.Address{
 			Type:   addy.Type().String(),
@@ -318,18 +318,18 @@ func GetBranchVoters(c echo.Context) (err error) {
 
 // GetBranchSequenceIDs is the handler for the /ledgerstate/branch/:branchID endpoint.
 func GetBranchSequenceIDs(c echo.Context) (err error) {
-	//branchID, err := branchIDFromContext(c)
-	//if err != nil {
+	// branchID, err := branchIDFromContext(c)
+	// if err != nil {
 	//	return c.JSON(http.StatusBadRequest, jsonmodels.NewErrorResponse(err))
-	//}
+	// }
 	//
-	//sequenceIDs := make([]string, 0)
-	//deps.Tangle.Booker.MarkersManager.SequenceAliasMapping(markers.NewSequenceAlias(branchID.Bytes())).Consume(func(sequenceAliasMapping *markers.SequenceAliasMapping) {
+	// sequenceIDs := make([]string, 0)
+	// deps.Tangle.Booker.MarkersManager.SequenceAliasMapping(markers.NewSequenceAlias(branchID.Bytes())).Consume(func(sequenceAliasMapping *markers.SequenceAliasMapping) {
 	//	sequenceAliasMapping.ForEachSequenceID(func(sequenceID markers.SequenceID) bool {
 	//		sequenceIDs = append(sequenceIDs, strconv.FormatUint(uint64(sequenceID), 10))
 	//		return true
 	//	})
-	//})
+	// })
 
 	return c.JSON(http.StatusOK, "ok")
 }
@@ -492,7 +492,7 @@ func PostTransaction(c echo.Context) error {
 	}
 
 	// parse tx
-	tx, err := (&ledgerstate.Transaction{}).FromBytes(request.TransactionBytes)
+	tx, err := new(ledgerstate.Transaction).FromBytes(request.TransactionBytes)
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, &jsonmodels.PostTransactionResponse{Error: err.Error()})
 	}


### PR DESCRIPTION
# Description of change

This PR contains cleanup of the generics PR.

## Type of change

- Code Cleanup

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
