### PR TITLE
Switch to Go1.18

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on:
       - ubuntu-latest
     container:
-      image: gohornet/goreleaser-cgo-cross-compiler:1.18rc1
+      image: gohornet/goreleaser-cgo-cross-compiler:1.18
       volumes: [/repo]
     steps:
       - name: Checkout
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18rc1
+          go-version: 1.18
 
       - name: Copy config.default.json to config.json
         run: cp config.default.json config.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@
 ARG REMOTE_DEBUGGING=0
 
 ############################
-# golang 1.18rc1-buster multi-arch
-FROM golang:1.18rc1-buster AS build
+# golang 1.18-bullseye multi-arch
+FROM golang:1.18-bullseye AS build
 
 ARG RUN_TEST=0
 ARG BUILD_TAGS=rocksdb,builtin_static

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@
 ARG REMOTE_DEBUGGING=0
 
 ############################
-# golang 1.18-bullseye multi-arch
-FROM golang:1.18-bullseye AS build
+# golang 1.18-buster multi-arch
+FROM golang:1.18-buster AS build
 
 ARG RUN_TEST=0
 ARG BUILD_TAGS=rocksdb,builtin_static

--- a/tools/integration-tests/tester/docker-compose.ci.yml
+++ b/tools/integration-tests/tester/docker-compose.ci.yml
@@ -3,7 +3,7 @@ version: "3.5"
 services:
   tester:
     container_name: tester
-    image: golang:1.18rc1
+    image: golang:1.18
     working_dir: /tmp/goshimmer/tools/integration-tests/tester
     command: /tmp/assets/entrypoint.sh
     environment:

--- a/tools/integration-tests/tester/docker-compose.yml
+++ b/tools/integration-tests/tester/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.5"
 services:
   tester:
     container_name: tester
-    image: golang:1.18rc1
+    image: golang:1.18
     working_dir: /tmp/goshimmer/tools/integration-tests/tester
     command: /tmp/assets/entrypoint.sh
     environment:


### PR DESCRIPTION
# Description of change

Go1.18 just got released. Update repo and workflows to use it.

[goreleaser-cgo-cross-compiler:1.18](https://hub.docker.com/layers/gohornet/goreleaser-cgo-cross-compiler/1.18/images/sha256-3d2e67f1e39a7b4edbc465bbe08aebe155c6b2129d7cf8cec984c1ba172800c8?context=explore) just got released too.
