### PR TITLE
Fix Reference Creation

### DIFF
--- a/packages/ledgerstate/branch_dag_test.go
+++ b/packages/ledgerstate/branch_dag_test.go
@@ -134,7 +134,7 @@ func TestBranchDAG_SetBranchConfirmed(t *testing.T) {
 
 	assert.True(t, ledgerstate.BranchDAG.SetBranchConfirmed(branchIDs["Branch8"]))
 
-	// Create a new Branch in an already-decided Conflict Set results in straight Reject
+	// Create a new Branch in an already-decided Conflict set results in straight Reject
 	branchIDs["Branch9"] = createBranch(t, ledgerstate, "Branch9", NewBranchIDs(MasterBranchID), NewConflictIDs(ConflictID{2}))
 
 	assertInclusionStates(t, ledgerstate, branchIDs, map[string]InclusionState{

--- a/packages/tangle/message.go
+++ b/packages/tangle/message.go
@@ -218,10 +218,24 @@ func (m MessageIDs) AddAll(messageIDs MessageIDs) MessageIDs {
 	return m
 }
 
+// Empty checks if MessageIDs is empty.
+func (m MessageIDs) Empty() (empty bool) {
+	return len(m) == 0
+}
+
 // Contains checks if the given target MessageID is part of the MessageIDs.
 func (m MessageIDs) Contains(target MessageID) (contains bool) {
 	_, contains = m[target]
 	return
+}
+
+// Subtract removes all other from the collection and returns the collection to enable chaining.
+func (m MessageIDs) Subtract(other MessageIDs) MessageIDs {
+	for messageID := range other {
+		delete(m, messageID)
+	}
+
+	return m
 }
 
 // First returns the first element in MessageIDs (not ordered). This method only makes sense if there is exactly one

--- a/packages/tangle/messagefactory.go
+++ b/packages/tangle/messagefactory.go
@@ -383,10 +383,8 @@ func PrepareReferences(strongParents MessageIDs, issuingTime time.Time, tangle *
 
 			if tangle.Utils.AllBranchesLiked(strongParentPayloadBranchIDs) {
 				references.Add(WeakParentType, strongParent)
-				continue
 			}
-			// If we can't add express the opinion AND not add a weak reference, the message needs to be removed from
-			// the tip pool.
+			// If we can't add express the opinion (can't reference past cone), the message needs to be removed from the tip pool.
 			referenceNotPossible.Add(strongParent)
 			continue
 		}

--- a/packages/tangle/messagefactory_test.go
+++ b/packages/tangle/messagefactory_test.go
@@ -200,7 +200,7 @@ func TestMessageFactory_PrepareLikedReferences_1(t *testing.T) {
 
 	tangle.OTVConsensusManager = NewOTVConsensusManager(mockOTV)
 
-	references, err, referenceNotPossible := PrepareReferences(NewMessageIDs(testFramework.Message("3").ID(), testFramework.Message("2").ID()), time.Now(), tangle)
+	references, referenceNotPossible, err := PrepareReferences(NewMessageIDs(testFramework.Message("3").ID(), testFramework.Message("2").ID()), time.Now(), tangle)
 
 	require.NoError(t, err)
 
@@ -358,13 +358,13 @@ func TestMessageFactory_PrepareLikedReferences_3(t *testing.T) {
 
 	tangle.OTVConsensusManager = NewOTVConsensusManager(mockOTV)
 
-	_, err, referenceNotPossible := PrepareReferences(NewMessageIDs(testFramework.Message("3").ID(), testFramework.Message("2").ID()), time.Now(), tangle)
+	_, referenceNotPossible, err := PrepareReferences(NewMessageIDs(testFramework.Message("3").ID(), testFramework.Message("2").ID()), time.Now(), tangle)
 	require.Error(t, err)
 	assert.Equal(t, NewMessageIDs(testFramework.Message("3").ID(), testFramework.Message("2").ID()), referenceNotPossible)
 }
 
 func checkReferences(t *testing.T, tangle *Tangle, parents MessageIDs, expectedReferences map[ParentsType]MessageIDs, issuingTime time.Time, errorExpected ...bool) {
-	actualReferences, err, referenceNotPossible := PrepareReferences(parents, issuingTime, tangle)
+	actualReferences, referenceNotPossible, err := PrepareReferences(parents, issuingTime, tangle)
 	if len(errorExpected) > 0 && errorExpected[0] {
 		require.Error(t, err)
 		return

--- a/packages/tangle/testutils.go
+++ b/packages/tangle/testutils.go
@@ -915,8 +915,8 @@ func (o *SimpleMockOnTangleVoting) BranchLiked(branchID ledgerstate.BranchID) (b
 	return likedConflictMembers.conflictMembers.Contains(branchID)
 }
 
-func emptyLikeReferences(parents MessageIDs, _ time.Time, _ *Tangle) (references ParentMessageIDs, err error) {
-	return emptyLikeReferencesFromStrongParents(parents), nil
+func emptyLikeReferences(parents MessageIDs, _ time.Time, _ *Tangle) (references ParentMessageIDs, err error, referenceNotPossible MessageIDs) {
+	return emptyLikeReferencesFromStrongParents(parents), nil, nil
 }
 
 func emptyLikeReferencesFromStrongParents(parents MessageIDs) (references ParentMessageIDs) {

--- a/packages/tangle/testutils.go
+++ b/packages/tangle/testutils.go
@@ -915,7 +915,7 @@ func (o *SimpleMockOnTangleVoting) BranchLiked(branchID ledgerstate.BranchID) (b
 	return likedConflictMembers.conflictMembers.Contains(branchID)
 }
 
-func emptyLikeReferences(parents MessageIDs, _ time.Time, _ *Tangle) (references ParentMessageIDs, err error, referenceNotPossible MessageIDs) {
+func emptyLikeReferences(parents MessageIDs, _ time.Time, _ *Tangle) (references ParentMessageIDs, referenceNotPossible MessageIDs, err error) {
 	return emptyLikeReferencesFromStrongParents(parents), nil, nil
 }
 

--- a/tools/integration-tests/tester/tests/common/common_synchronization_test.go
+++ b/tools/integration-tests/tester/tests/common/common_synchronization_test.go
@@ -157,7 +157,7 @@ func TestConfirmMessage(t *testing.T) {
 	metadata, err := peers[0].GetMessageMetadata(msgID)
 	require.Nil(t, err)
 	log.Printf("gof of msg %s = %s", msgID, metadata.GradeOfFinality.String())
-	tests.TryConfirmMessage(t, n, peers[:], msgID, 5*time.Second, 1*time.Millisecond)
+	tests.TryConfirmMessage(t, n, peers[:], msgID, 30*time.Second, 100*time.Millisecond)
 }
 
 func createNewPeerConfig(t *testing.T, snapshotInfo framework.SnapshotInfo, peerIndex int) config.GoShimmer {


### PR DESCRIPTION
The transaction issued in this message broke the devnet:  http://public-node-01.devnet.shimmer.iota.cafe:8081/explorer/message/CK6x17YPtryqfJmXGzPTRxfepnpbcaM4DAM6kpBov8et

**Problem:**  It reintroduced an old conflict branch. So naturally, every node wanted to set a like reference to the branch that was "winning". However, that branch was created in a message 3 days ago and so the like reference could not be set because it's too old (max parent age is 30min).

**Bug:** Now, every time a node selects tips, this message ends up in the strong parents (because there are only so few tips), and currently we throw the error message below if any of the strong parents could not be referenced. That, in turn, means that every time a node tried to select tips it failed. -> no ne messages can be created -> all nodes run out of sync

**Solution:** In this case the message should just be orphaned, i.e., if we can't express the opinion on it we can't select it as a tip and it should be removed and its parent re-added to the tip pool.