### PR TITLE
Evil Wallet: deep spamming with EvilScenarios

### DIFF
--- a/client/evilspammer/errors.go
+++ b/client/evilspammer/errors.go
@@ -31,16 +31,15 @@ func NewErrorCount() *ErrorCounter {
 }
 
 func (e *ErrorCounter) CountError(err error) {
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+
 	// check if error is already in the map
 	if _, ok := e.errorsMap[err]; !ok {
-		e.mutex.Lock()
 		e.errorsMap[err] = atomic.NewInt64(0)
-		e.mutex.Unlock()
 	}
 	e.errInTotalCount.Add(1)
-	e.mutex.Lock()
 	e.errorsMap[err].Add(1)
-	e.mutex.Unlock()
 }
 
 func (e *ErrorCounter) GetTotalErrorCount() int64 {

--- a/client/evilspammer/options.go
+++ b/client/evilspammer/options.go
@@ -52,7 +52,7 @@ func WithBatchesSent(maxBatchesSent int) Options {
 // WithSpamWallet provides evil wallet instance, that will handle all spam logic according to provided EvilScenario
 func WithSpamWallet(initWallets *evilwallet.EvilWallet) Options {
 	return func(s *Spammer) {
-		s.SpamWallet = initWallets
+		s.EvilWallet = initWallets
 	}
 }
 

--- a/client/evilspammer/options.go
+++ b/client/evilspammer/options.go
@@ -78,7 +78,7 @@ func WithLogTickerInterval(interval time.Duration) Options {
 }
 
 // WithSpammingFunc sets core function of the spammer with spamming logic, needs to use done spammer's channel to communicate.
-// end of spamming and errors.
+// end of spamming and errors. Default one is the CustomConflictSpammingFunc.
 func WithSpammingFunc(spammerFunc func(s *Spammer)) Options {
 	return func(s *Spammer) {
 		s.spamFunc = spammerFunc

--- a/client/evilspammer/options.go
+++ b/client/evilspammer/options.go
@@ -49,8 +49,8 @@ func WithBatchesSent(maxBatchesSent int) Options {
 	}
 }
 
-// WithSpamWallet provides evil wallet instance, that will handle all spam logic according to provided EvilScenario
-func WithSpamWallet(initWallets *evilwallet.EvilWallet) Options {
+// WithEvilWallet provides evil wallet instance, that will handle all spam logic according to provided EvilScenario
+func WithEvilWallet(initWallets *evilwallet.EvilWallet) Options {
 	return func(s *Spammer) {
 		s.EvilWallet = initWallets
 	}

--- a/client/evilspammer/spammer.go
+++ b/client/evilspammer/spammer.go
@@ -136,7 +136,7 @@ func (s *Spammer) Spam() {
 			case <-s.State.logTicker.C:
 				s.log.Infof("Messages issued so far: %d, errors encountered: %d", s.State.txSent.Load(), s.ErrCounter.GetTotalErrorCount())
 			case <-timeExceeded:
-				s.log.Infof("Maximum spam duration exceeded, stoping spammer....")
+				s.log.Infof("Maximum spam duration exceeded, stopping spammer....")
 				s.StopSpamming()
 				return
 			case <-s.done:

--- a/client/evilspammer/spammer.go
+++ b/client/evilspammer/spammer.go
@@ -35,7 +35,7 @@ type Spammer struct {
 	State       *State
 
 	Clients      evilwallet.Connector
-	SpamWallet   *evilwallet.EvilWallet
+	EvilWallet   *evilwallet.EvilWallet
 	EvilScenario *evilwallet.EvilScenario
 	ErrCounter   *ErrorCounter
 	log          Logger
@@ -71,12 +71,12 @@ func NewSpammer(options ...Options) *Spammer {
 	}
 
 	s.setup()
-	s.Clients = s.SpamWallet.Connector()
+	s.Clients = s.EvilWallet.Connector()
 	return s
 }
 
 func (s *Spammer) setup() {
-	s.Clients = s.SpamWallet.Connector()
+	s.Clients = s.EvilWallet.Connector()
 
 	s.setupSpamDetails()
 

--- a/client/evilspammer/spammer.go
+++ b/client/evilspammer/spammer.go
@@ -1,6 +1,7 @@
 package evilspammer
 
 import (
+	"github.com/cockroachdb/errors"
 	"time"
 
 	"github.com/iotaledger/goshimmer/client/evilwallet"
@@ -112,7 +113,7 @@ func (s *Spammer) setupSpamDetails() {
 func (s *Spammer) initLogger() {
 	config := configuration.New()
 	_ = logger.InitGlobalLogger(config)
-	logger.SetLevel(logger.LevelInfo)
+	logger.SetLevel(logger.LevelDebug)
 	s.log = logger.NewLogger("Spammer")
 }
 
@@ -182,7 +183,7 @@ func (s *Spammer) PostTransaction(tx *ledgerstate.Transaction, clt evilwallet.Cl
 	txID, err = clt.PostTransaction(tx)
 	if err != nil {
 		s.log.Debugf("error: %v", err)
-		s.ErrCounter.CountError(ErrFailPostTransaction)
+		s.ErrCounter.CountError(errors.Newf("%s: %w", ErrFailPostTransaction, err))
 		return
 	}
 	count := s.State.txSent.Add(1)

--- a/client/evilspammer/spammer.go
+++ b/client/evilspammer/spammer.go
@@ -169,7 +169,7 @@ func (s *Spammer) StopSpamming() {
 
 // PostTransaction use provided client to issue a transaction. It chooses API method based on Spammer options. Counts errors,
 // counts transactions and provides debug logs.
-func (s *Spammer) PostTransaction(tx *ledgerstate.Transaction) (success bool) {
+func (s *Spammer) PostTransaction(tx *ledgerstate.Transaction, clt evilwallet.Client) (success bool) {
 	if tx == nil {
 		s.log.Debugf("transaction provided to PostTransaction is nil")
 		s.ErrCounter.CountError(ErrTransactionIsNil)
@@ -177,7 +177,6 @@ func (s *Spammer) PostTransaction(tx *ledgerstate.Transaction) (success bool) {
 
 	var err error
 	var txID ledgerstate.TransactionID
-	clt := s.Clients.GetClient()
 	txID, err = clt.PostTransaction(tx)
 	if err != nil {
 		s.log.Debugf("error: %v", err)

--- a/client/evilspammer/spammer.go
+++ b/client/evilspammer/spammer.go
@@ -49,7 +49,7 @@ type Spammer struct {
 	NumberOfSpends            int
 }
 
-// NewSpammer constructor of Spammer
+// NewSpammer is a constructor of Spammer.
 func NewSpammer(options ...Options) *Spammer {
 	state := &State{
 		txSent:        atomic.NewInt64(0),
@@ -58,7 +58,9 @@ func NewSpammer(options ...Options) *Spammer {
 	}
 	s := &Spammer{
 		SpamDetails:    DefaultSpamDetails,
+		spamFunc:       CustomConflictSpammingFunc,
 		State:          state,
+		EvilScenario:   evilwallet.NewEvilScenario(),
 		done:           make(chan bool),
 		shutdown:       make(chan types.Empty),
 		NumberOfSpends: 2,

--- a/client/evilspammer/spammer_test.go
+++ b/client/evilspammer/spammer_test.go
@@ -111,12 +111,12 @@ func TestReuseOutputsOnTheFly(t *testing.T) {
 		evilwallet.WithScenarioDeepSpamEnabled(),
 		evilwallet.WithScenarioInputWalletForDeepSpam(outWallet),
 		evilwallet.WithScenarioReuseOutputWallet(outWallet),
-		evilwallet.WithScenarioCustomConflicts(evilwallet.NoConflictsScenario1()),
+		evilwallet.WithScenarioCustomConflicts(evilwallet.Scenario1()),
 	)
 
 	options := []Options{
-		WithSpamRate(10, time.Minute),
-		WithBatchesSent(5),
+		WithSpamRate(1, time.Second),
+		WithBatchesSent(200),
 		WithSpamWallet(evilWallet),
 	}
 	customOptions := append(options, WithEvilScenario(customScenario))

--- a/client/evilspammer/spammer_test.go
+++ b/client/evilspammer/spammer_test.go
@@ -14,13 +14,11 @@ func TestSpamTransactions(t *testing.T) {
 	err := evilWallet.RequestFreshBigFaucetWallet()
 	require.NoError(t, err)
 
-	outWallet := evilWallet.NewWallet(evilwallet.Reuse)
-
-	scenario := evilwallet.NewEvilScenario(evilwallet.WithScenarioReuseOutputWallet(outWallet))
+	scenario := evilwallet.NewEvilScenario()
 	options := []Options{
 		WithSpamRate(5, time.Second),
 		WithBatchesSent(20),
-		WithSpammingFunc(ValueSpammingFunc),
+		WithSpammingFunc(CustomConflictSpammingFunc),
 		WithSpamWallet(evilWallet),
 		WithEvilScenario(scenario),
 	}
@@ -40,7 +38,7 @@ func TestSpamDoubleSpend(t *testing.T) {
 
 	options := []Options{
 		WithSpamRate(5, time.Second),
-		WithSpamDuration(time.Second * 10),
+		WithSpamDuration(time.Second * 19),
 		WithSpammingFunc(CustomConflictSpammingFunc),
 		WithSpamWallet(evilWallet),
 	}

--- a/client/evilspammer/spammer_test.go
+++ b/client/evilspammer/spammer_test.go
@@ -116,7 +116,7 @@ func TestReuseOutputsOnTheFly(t *testing.T) {
 
 	options := []Options{
 		WithSpamRate(10, time.Minute),
-		WithBatchesSent(5000),
+		WithBatchesSent(5),
 		WithSpamWallet(evilWallet),
 	}
 	customOptions := append(options, WithEvilScenario(customScenario))

--- a/client/evilspammer/spammer_test.go
+++ b/client/evilspammer/spammer_test.go
@@ -48,7 +48,7 @@ func TestSpamDoubleSpend(t *testing.T) {
 func TestCustomConflictScenario(t *testing.T) {
 	evilWallet := evilwallet.NewEvilWallet()
 	// request 10000 outputs for spamming
-	err := evilWallet.RequestFreshBigFaucetWallet()
+	err := evilWallet.RequestFreshFaucetWallet()
 	require.NoError(t, err)
 
 	customScenario := evilwallet.NewEvilScenario(
@@ -87,7 +87,7 @@ func TestReuseRestrictedOutputs(t *testing.T) {
 
 	options := []Options{
 		WithSpamRate(5, time.Second),
-		WithSpamDuration(time.Second * 10),
+		WithBatchesSent(1000),
 		WithSpamWallet(evilWallet),
 	}
 	txOptions := append(options, WithEvilScenario(scenarioTx))
@@ -97,46 +97,31 @@ func TestReuseRestrictedOutputs(t *testing.T) {
 	customDeepSpammer := NewSpammer(customOptions...)
 
 	txSpammer.Spam()
-	//txDeepSpammer.Spam()
 	customDeepSpammer.Spam()
 }
 
 func TestReuseOutputsOnTheFly(t *testing.T) {
 	evilWallet := evilwallet.NewEvilWallet()
 
-	err := evilWallet.RequestFreshBigFaucetWallet()
+	err := evilWallet.RequestFreshFaucetWallet()
 	require.NoError(t, err)
-
-	//outWallet := evilWallet.NewWallet(evilwallet.Reuse)
-	restrictedOutWallet := evilWallet.NewWallet(evilwallet.RestrictedReuse)
-
-	scenarioTx := evilwallet.NewEvilScenario(evilwallet.WithScenarioReuseOutputWallet(restrictedOutWallet))
-
-	//scenarioDeepTx := evilwallet.NewEvilScenario(
-	//	evilwallet.WithScenarioReuseOutputWallet(outWallet),
-	//	evilwallet.WithScenarioDeepSpamEnabled(),
-	//)
+	outWallet := evilWallet.NewWallet(evilwallet.Reuse)
 
 	customScenario := evilwallet.NewEvilScenario(
 		evilwallet.WithScenarioDeepSpamEnabled(),
-		evilwallet.WithScenarioInputWalletForDeepSpam(restrictedOutWallet),
-		evilwallet.WithScenarioCustomConflicts(evilwallet.Scenario1()),
+		evilwallet.WithScenarioInputWalletForDeepSpam(outWallet),
+		evilwallet.WithScenarioReuseOutputWallet(outWallet),
+		evilwallet.WithScenarioCustomConflicts(evilwallet.NoConflictsScenario1()),
 	)
 
 	options := []Options{
-		WithSpamRate(5, time.Second),
-		WithSpamDuration(time.Second * 10),
+		WithSpamRate(10, time.Minute),
+		WithBatchesSent(5000),
 		WithSpamWallet(evilWallet),
 	}
-	txOptions := append(options, WithEvilScenario(scenarioTx))
-	//deepTxOptions := append(options, WithEvilScenario(scenarioDeepTx))
 	customOptions := append(options, WithEvilScenario(customScenario))
 
-	txSpammer := NewSpammer(txOptions...)
-	//txDeepSpammer := NewSpammer(deepTxOptions...)
 	customDeepSpammer := NewSpammer(customOptions...)
 
-	txSpammer.Spam()
-	//txDeepSpammer.Spam()
 	customDeepSpammer.Spam()
 }

--- a/client/evilspammer/spammer_test.go
+++ b/client/evilspammer/spammer_test.go
@@ -19,7 +19,7 @@ func TestSpamTransactions(t *testing.T) {
 	options := []Options{
 		WithSpamRate(5, time.Second),
 		WithBatchesSent(5),
-		WithSpamWallet(evilWallet),
+		WithEvilWallet(evilWallet),
 	}
 	spammer := NewSpammer(options...)
 	spammer.Spam()
@@ -37,7 +37,7 @@ func TestSpamDoubleSpend(t *testing.T) {
 	options := []Options{
 		WithSpamRate(5, time.Second),
 		WithSpamDuration(time.Second * 10),
-		WithSpamWallet(evilWallet),
+		WithEvilWallet(evilWallet),
 	}
 	dsOptions := append(options, WithEvilScenario(scenarioDs))
 
@@ -58,7 +58,7 @@ func TestCustomConflictScenario(t *testing.T) {
 	options := []Options{
 		WithSpamRate(5, time.Second),
 		WithSpamDuration(time.Second * 10),
-		WithSpamWallet(evilWallet),
+		WithEvilWallet(evilWallet),
 	}
 	customOptions := append(options, WithEvilScenario(customScenario))
 	customSpammer := NewSpammer(customOptions...)
@@ -88,7 +88,7 @@ func TestReuseRestrictedOutputs(t *testing.T) {
 	options := []Options{
 		WithSpamRate(5, time.Second),
 		WithBatchesSent(1000),
-		WithSpamWallet(evilWallet),
+		WithEvilWallet(evilWallet),
 	}
 	txOptions := append(options, WithEvilScenario(scenarioTx))
 	customOptions := append(options, WithEvilScenario(customScenario))
@@ -117,7 +117,7 @@ func TestReuseOutputsOnTheFly(t *testing.T) {
 	options := []Options{
 		WithSpamRate(1, time.Second),
 		WithBatchesSent(200),
-		WithSpamWallet(evilWallet),
+		WithEvilWallet(evilWallet),
 	}
 	customOptions := append(options, WithEvilScenario(customScenario))
 

--- a/client/evilspammer/spamming_functions.go
+++ b/client/evilspammer/spamming_functions.go
@@ -23,17 +23,6 @@ func DataSpammingFunction(s *Spammer) {
 	s.CheckIfAllSent()
 }
 
-func ValueSpammingFunc(s *Spammer) {
-	tx, err := s.SpamWallet.PrepareTransaction(s.EvilScenario)
-	if err != nil {
-		s.ErrCounter.CountError(ErrFailToPrepareTransaction)
-		return
-	}
-	s.PostTransaction(tx)
-	s.State.batchPrepared.Add(1)
-	s.CheckIfAllSent()
-}
-
 func CustomConflictSpammingFunc(s *Spammer) {
 	conflictBatch, err := s.SpamWallet.PrepareCustomConflictsSpam(s.EvilScenario)
 	if err != nil {

--- a/client/evilspammer/spamming_functions.go
+++ b/client/evilspammer/spamming_functions.go
@@ -3,6 +3,7 @@ package evilspammer
 import (
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/cockroachdb/errors"
 	"github.com/iotaledger/goshimmer/client/evilwallet"

--- a/client/evilspammer/spamming_functions.go
+++ b/client/evilspammer/spamming_functions.go
@@ -24,7 +24,7 @@ func DataSpammingFunction(s *Spammer) {
 }
 
 func CustomConflictSpammingFunc(s *Spammer) {
-	conflictBatch, err := s.SpamWallet.PrepareCustomConflictsSpam(s.EvilScenario)
+	conflictBatch, err := s.EvilWallet.PrepareCustomConflictsSpam(s.EvilScenario)
 	if err != nil {
 		s.ErrCounter.CountError(errors.Newf("custom conflict batch could not be prepared: %w", err))
 	}
@@ -46,5 +46,6 @@ func CustomConflictSpammingFunc(s *Spammer) {
 		wg.Wait()
 	}
 	s.State.batchPrepared.Add(1)
+	s.EvilWallet.ClearAliases()
 	s.CheckIfAllSent()
 }

--- a/client/evilspammer/spamming_functions.go
+++ b/client/evilspammer/spamming_functions.go
@@ -3,7 +3,6 @@ package evilspammer
 import (
 	"fmt"
 	"sync"
-	"time"
 
 	"github.com/cockroachdb/errors"
 	"github.com/iotaledger/goshimmer/client/evilwallet"

--- a/client/evilspammer/spamming_functions.go
+++ b/client/evilspammer/spamming_functions.go
@@ -40,7 +40,7 @@ func CustomConflictSpammingFunc(s *Spammer) {
 			wg.Add(1)
 			go func(clt evilwallet.Client, tx *ledgerstate.Transaction) {
 				defer wg.Done()
-				clt.PostTransaction(tx)
+				s.PostTransaction(tx, clt)
 			}(clients[i], tx)
 		}
 		wg.Wait()

--- a/client/evilspammer/spamming_functions.go
+++ b/client/evilspammer/spamming_functions.go
@@ -28,6 +28,7 @@ func CustomConflictSpammingFunc(s *Spammer) {
 	if err != nil {
 		s.ErrCounter.CountError(errors.Newf("custom conflict batch could not be prepared: %w", err))
 	}
+
 	for _, txs := range conflictBatch {
 		clients := s.Clients.GetClients(len(txs))
 		if len(txs) > len(clients) {
@@ -40,7 +41,11 @@ func CustomConflictSpammingFunc(s *Spammer) {
 			wg.Add(1)
 			go func(clt evilwallet.Client, tx *ledgerstate.Transaction) {
 				defer wg.Done()
-				s.PostTransaction(tx, clt)
+				//s.EvilWallet.AwaitInputsSolidity(tx.Essence().Inputs(), clt)
+				ok := s.PostTransaction(tx, clt)
+				if ok {
+					s.EvilWallet.SetTxOutputsSolid(tx.Essence().Outputs(), clt.Url())
+				}
 			}(clients[i], tx)
 		}
 		wg.Wait()

--- a/client/evilwallet/aliasmanager.go
+++ b/client/evilwallet/aliasmanager.go
@@ -63,13 +63,26 @@ func (a *AliasManager) GetOutput(aliasName string) ledgerstate.Output {
 	return a.outputMap[aliasName]
 }
 
-// ClearAliases clears all aliases.
-func (a *AliasManager) ClearAliases() {
+// ClearAllAliases clears all aliases.
+func (a *AliasManager) ClearAllAliases() {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
 	a.inputMap = make(map[string]ledgerstate.Input)
 	a.outputMap = make(map[string]ledgerstate.Output)
+}
+
+// ClearAliases clears provided aliases.
+func (a *AliasManager) ClearAliases(aliases ScenarioAlias) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	for _, in := range aliases.Inputs {
+		delete(a.inputMap, in)
+	}
+	for _, out := range aliases.Outputs {
+		delete(a.outputMap, out)
+	}
 }
 
 // AddOutputAliases batch adds the outputs their respective aliases.

--- a/client/evilwallet/customscenarios.go
+++ b/client/evilwallet/customscenarios.go
@@ -58,3 +58,15 @@ func Scenario1() EvilBatch {
 		},
 	}
 }
+
+func NoConflictsScenario1() EvilBatch {
+	return EvilBatch{
+		[]ScenarioAlias{
+			{Inputs: []string{"1"}, Outputs: []string{"3", "4"}},
+			{Inputs: []string{"2"}, Outputs: []string{"5", "6"}},
+			{Inputs: []string{"6", "4"}, Outputs: []string{"7"}},
+			{Inputs: []string{"3", "5"}, Outputs: []string{"8"}},
+			{Inputs: []string{"8", "7"}, Outputs: []string{"11"}},
+		},
+	}
+}

--- a/client/evilwallet/deepdoublespend_test.go
+++ b/client/evilwallet/deepdoublespend_test.go
@@ -31,5 +31,5 @@ func TestDeepDoubleSpend(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	evilwallet.ClearAliases()
+	evilwallet.ClearAllAliases()
 }

--- a/client/evilwallet/doublespend_test.go
+++ b/client/evilwallet/doublespend_test.go
@@ -26,6 +26,5 @@ func TestDoubleSpend(t *testing.T) {
 	_, err = clients[1].PostTransaction(txB)
 	require.NoError(t, err)
 
-	evilwallet.ClearAliases()
-	//EvilWallet.ConflictManager.AddConflict(WithConflictID("1"), WithConflictMembers("2", "3"))
+	evilwallet.ClearAllAliases()
 }

--- a/client/evilwallet/evilwallet.go
+++ b/client/evilwallet/evilwallet.go
@@ -667,10 +667,13 @@ func (e *EvilWallet) makeTransaction(inputs ledgerstate.Inputs, outputs ledgerst
 		if err2 != nil {
 			return nil, err2
 		}
+		var wallet *Wallet
 		if w == nil { // aliases provided with inputs, use wallet saved in outputManager
-			w = e.outputManager.OutputIDWalletMap(input.Base58())
+			wallet = e.outputManager.OutputIDWalletMap(input.Base58())
+		} else {
+			wallet = w
 		}
-		unlockBlocks[i] = ledgerstate.NewSignatureUnlockBlock(w.Sign(addr, txEssence))
+		unlockBlocks[i] = ledgerstate.NewSignatureUnlockBlock(wallet.Sign(addr, txEssence))
 	}
 	return ledgerstate.NewTransaction(txEssence, unlockBlocks), nil
 }

--- a/client/evilwallet/evilwallet.go
+++ b/client/evilwallet/evilwallet.go
@@ -705,9 +705,8 @@ func (e *EvilWallet) PrepareTransaction(scenario *EvilScenario) (tx *ledgerstate
 		}
 		evilInput = wallet.GetUnspentOutput()
 	}
-	input := wallet.GetUnspentOutput()
-
-	tx, err = e.CreateTransaction(WithInputs(input), WithOutputs([]*OutputOption{{amount: outBalance}}), WithOutputWallet(scenario.OutputWallet), WithIssuer(wallet))
+	outBalance := getIotaColorAmount(evilInput.Balance)
+	tx, err = e.CreateTransaction(WithInputs(evilInput.OutputID), WithOutputs([]*OutputOption{{amount: outBalance}}), WithOutputWallet(scenario.OutputWallet), WithIssuer(wallet))
 	return
 }
 

--- a/client/evilwallet/evilwallet.go
+++ b/client/evilwallet/evilwallet.go
@@ -279,9 +279,14 @@ func (e *EvilWallet) handleInputOutputDuringSplitOutputs(splitNumber int, inputW
 
 // region EvilWallet functionality ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-// ClearAliases remove all registered alias names.
-func (e *EvilWallet) ClearAliases() {
-	e.aliasManager.ClearAliases()
+// ClearAliases remove only provided aliases from AliasManager.
+func (e *EvilWallet) ClearAliases(aliases ScenarioAlias) {
+	e.aliasManager.ClearAliases(aliases)
+}
+
+// ClearAllAliases remove all registered alias names.
+func (e *EvilWallet) ClearAllAliases() {
+	e.aliasManager.ClearAllAliases()
 }
 
 func (e *EvilWallet) PrepareCustomConflicts(conflictsMaps []ConflictSlice) (conflictBatch [][]*ledgerstate.Transaction, err error) {

--- a/client/evilwallet/evilwallet.go
+++ b/client/evilwallet/evilwallet.go
@@ -170,9 +170,9 @@ func (e *EvilWallet) RequestFreshBigFaucetWallet() (err error) {
 
 // RequestFreshFaucetWallet creates a new wallet and fills the wallet with 100 outputs created from funds
 // requested from the Faucet.
-func (e *EvilWallet) RequestFreshFaucetWallet() (wallet *Wallet, err error) {
+func (e *EvilWallet) RequestFreshFaucetWallet() (err error) {
 	initWallet := NewWallet()
-	wallet, err = e.requestAndSplitFaucetFunds(initWallet)
+	wallet, err := e.requestAndSplitFaucetFunds(initWallet)
 	if err != nil {
 		return
 	}

--- a/client/evilwallet/evilwallet.go
+++ b/client/evilwallet/evilwallet.go
@@ -22,8 +22,13 @@ const (
 	// FaucetRequestSplitNumber defines the number of outputs to split from a faucet request.
 	FaucetRequestSplitNumber = 100
 
-	waitForConfirmation = 60 * time.Second
-	WaitForTxSolid      = 2 * time.Second
+	waitForConfirmation   = 60 * time.Second
+	waitForSolidification = 10 * time.Second
+
+	awaitConfirmationSleep   = time.Second
+	awaitSolidificationSleep = time.Millisecond * 500
+
+	WaitForTxSolid = 2 * time.Second
 
 	maxGoroutines = 5
 )
@@ -754,6 +759,20 @@ func (e *EvilWallet) prepareConflictSliceForScenario(scenario *EvilScenario) (co
 	}
 
 	return conflictSlice, nil
+}
+
+func (e *EvilWallet) AwaitInputsSolidity(inputs ledgerstate.Inputs, clt Client) {
+	awaitSolid := make([]string, 0)
+	for _, in := range inputs {
+		awaitSolid = append(awaitSolid, in.Base58())
+	}
+	e.outputManager.AwaitOutputsToBeSolid(awaitSolid, clt, maxGoroutines)
+}
+
+func (e *EvilWallet) SetTxOutputsSolid(outputs ledgerstate.Outputs, clientID string) {
+	for _, out := range outputs {
+		e.outputManager.SetOutputIDSolidForIssuer(out.ID().Base58(), clientID)
+	}
 }
 
 // endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/client/evilwallet/faucet_test.go
+++ b/client/evilwallet/faucet_test.go
@@ -26,7 +26,7 @@ func TestFaucetRequests(t *testing.T) {
 		require.NoError(t, err)
 		_, err = clients[1].PostTransaction(txB)
 		require.NoError(t, err)
-		evilwallet.ClearAliases()
+		evilwallet.ClearAllAliases()
 	}
 
 	err = evilwallet.RequestFreshBigFaucetWallet()

--- a/client/evilwallet/faucet_test.go
+++ b/client/evilwallet/faucet_test.go
@@ -11,10 +11,10 @@ func TestFaucetRequests(t *testing.T) {
 
 	clients := evilwallet.GetClients(2)
 
-	_, err := evilwallet.RequestFreshFaucetWallet()
+	err := evilwallet.RequestFreshFaucetWallet()
 	require.NoError(t, err)
 
-	_, err = evilwallet.RequestFreshFaucetWallet()
+	err = evilwallet.RequestFreshFaucetWallet()
 	require.NoError(t, err)
 
 	for i := 0; i < 200; i++ {

--- a/client/evilwallet/options.go
+++ b/client/evilwallet/options.go
@@ -239,3 +239,47 @@ func WithOutputAlias(aliasName string) FaucetRequestOption {
 }
 
 // endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// region EvilScenario Options /////////////////////////////////////////////////////////////////////////////////////////
+
+type ScenarioOption func(scenario *EvilScenario)
+
+// WithScenarioCustomConflicts specifies the EvilBatch that describes the UTXO structure that should be used for the spam.
+func WithScenarioCustomConflicts(batch EvilBatch) ScenarioOption {
+	return func(options *EvilScenario) {
+		if batch != nil {
+			options.ConflictBatch = batch
+		}
+	}
+}
+
+// WithScenarioDeepSpamEnabled enables deep spam, the outputs from available Reuse wallets or RestrictedReuse wallet
+// if provided with WithReuseInputWalletForDeepSpam option will be used for spam instead fresh faucet outputs.
+func WithScenarioDeepSpamEnabled() ScenarioOption {
+	return func(options *EvilScenario) {
+		options.Reuse = true
+	}
+}
+
+// WithScenarioReuseOutputWallet the outputs from the spam will be saved into this wallet, accepted types of wallet: Reuse, RestrictedReuse.
+func WithScenarioReuseOutputWallet(wallet *Wallet) ScenarioOption {
+	return func(options *EvilScenario) {
+		if wallet != nil {
+			if wallet.walletType == Reuse || wallet.walletType == RestrictedReuse {
+				options.OutputWallet = wallet
+			}
+		}
+	}
+}
+
+// WithScenarioInputWalletForDeepSpam reuse set to true, outputs from this wallet will be used for deep spamming,
+// allows for controllable building of UTXO deep structures. Accepts only RestrictedReuse wallet type.
+func WithScenarioInputWalletForDeepSpam(wallet *Wallet) ScenarioOption {
+	return func(options *EvilScenario) {
+		if wallet.walletType == RestrictedReuse {
+			options.RestrictedInputWallet = wallet
+		}
+	}
+}
+
+// endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/client/evilwallet/options.go
+++ b/client/evilwallet/options.go
@@ -24,6 +24,8 @@ type Options struct {
 	shallowDislikeParents    map[string]types.Empty
 	inputWallet              *Wallet
 	outputWallet             *Wallet
+	outputBatchAliases       map[string]types.Empty
+	reuse                    bool
 	issuingTime              time.Time
 	reattachmentMessageAlias string
 	sequenceNumber           uint64
@@ -197,6 +199,20 @@ func WithIssuer(issuer *Wallet) Option {
 func WithOutputWallet(wallet *Wallet) Option {
 	return func(options *Options) {
 		options.outputWallet = wallet
+	}
+}
+
+// WithOutputBatchAliases returns a MessageOption that is used to determine which outputs should be added to the outWallet.
+func WithOutputBatchAliases(outputAliases map[string]types.Empty) Option {
+	return func(options *Options) {
+		options.outputBatchAliases = outputAliases
+	}
+}
+
+// WithReuseOutputs returns a MessageOption that is used to enable deep spamming with Reuse wallet outputs.
+func WithReuseOutputs() Option {
+	return func(options *Options) {
+		options.reuse = true
 	}
 }
 

--- a/client/evilwallet/output_manager.go
+++ b/client/evilwallet/output_manager.go
@@ -180,11 +180,14 @@ func (o *OutputManager) GetOutput(outputID ledgerstate.OutputID) (output *Output
 	// get output info from via web api
 	if output == nil {
 		clt := o.connector.GetClient()
-		o := clt.GetOutput(outputID)
+		out := clt.GetOutput(outputID)
+		if out == nil {
+			return nil
+		}
 		output = &Output{
-			OutputID: o.ID(),
-			Address:  o.Address(),
-			Balance:  o.Balances(),
+			OutputID: out.ID(),
+			Address:  out.Address(),
+			Balance:  out.Balances(),
 		}
 	}
 

--- a/client/evilwallet/output_manager.go
+++ b/client/evilwallet/output_manager.go
@@ -106,7 +106,7 @@ func (o *OutputManager) Track(outputIDs []ledgerstate.OutputID) (allConfirmed bo
 	return
 }
 
-// CreateEmptyOutput creates output without outputID, stores it in wallet w and return output instance.
+// CreateEmptyOutput creates output without outputID, stores it in the wallet w and returns an output instance.
 // OutputManager maps are not updated, as outputID is not known yet.
 func (o *OutputManager) CreateEmptyOutput(w *Wallet, balance *ledgerstate.ColoredBalances) *Output {
 	addr := w.Address()
@@ -128,6 +128,7 @@ func (o *OutputManager) CreateOutputFromAddress(w *Wallet, addr address.Address,
 	return out
 }
 
+// AddOutput adds existing output from wallet w to the OutputManager.
 func (o *OutputManager) AddOutput(w *Wallet, output ledgerstate.Output) *Output {
 	outputID := output.ID()
 	idx := w.AddrIndexMap(output.Address().Base58())

--- a/client/evilwallet/wallets.go
+++ b/client/evilwallet/wallets.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	"github.com/cockroachdb/errors"
+	"sync"
 
 	"github.com/iotaledger/hive.go/types"
 	"go.uber.org/atomic"
@@ -52,6 +53,7 @@ func NewWallets() *Wallets {
 	return &Wallets{
 		wallets:       make(map[walletID]*Wallet),
 		faucetWallets: make([]walletID, 0),
+		reuseWallets:  make(map[walletID]bool),
 		lastWalletID:  *atomic.NewInt64(-1),
 	}
 }
@@ -92,6 +94,8 @@ func (w *Wallets) GetNextWallet(walletType WalletType, minOutputsLeft int) (*Wal
 		for id, ready := range w.reuseWallets {
 			wal := w.wallets[id]
 			if wal.UnspentOutputsLeft() > minOutputsLeft {
+				// if are solid
+
 				return wal, nil
 			}
 			// no outputs will be ever added to this wallet, so it can be deleted

--- a/client/evilwallet/wallets.go
+++ b/client/evilwallet/wallets.go
@@ -116,7 +116,7 @@ func (w *Wallets) addWallet(wallet *Wallet) {
 
 }
 
-// addWallet stores newly created wallet.
+// addReuseWallet stores newly created wallet.
 func (w *Wallets) addReuseWallet(wallet *Wallet) {
 	w.mu.Lock()
 	defer w.mu.Unlock()

--- a/client/evilwallet/wallets.go
+++ b/client/evilwallet/wallets.go
@@ -113,9 +113,9 @@ func (w *Wallets) IsFaucetWalletAvailable() bool {
 	return len(w.faucetWallets) > 0
 }
 
-// FreshWallet returns the first non-empty wallet from the faucetWallets queue. If current wallet is empty,
+// freshWallet returns the first non-empty wallet from the faucetWallets queue. If current wallet is empty,
 // it is removed and the next enqueued one is returned.
-func (w *Wallets) FreshWallet() (*Wallet, error) {
+func (w *Wallets) freshWallet() (*Wallet, error) {
 	wallet, err := w.GetNextWallet(Fresh)
 	if err != nil {
 		w.removeWallet(Fresh)
@@ -127,13 +127,13 @@ func (w *Wallets) FreshWallet() (*Wallet, error) {
 	return wallet, nil
 }
 
-// ReuseWallet returns the first non-empty wallet from the reuseWallets queue. If current wallet is empty,
+// reuseWallet returns the first non-empty wallet from the reuseWallets queue. If current wallet is empty,
 // it is removed and the next enqueued one is returned.
-func (w *Wallets) ReuseWallet() (*Wallet, error) {
+func (w *Wallets) reuseWallet() (*Wallet, error) {
 	wallet, err := w.GetNextWallet(Reuse)
 	if err != nil {
-		w.removeWallet(Fresh)
-		wallet, err = w.GetNextWallet(Fresh)
+		w.removeWallet(Reuse)
+		wallet, err = w.GetNextWallet(Reuse)
 		if err != nil {
 			return nil, err
 		}

--- a/client/evilwallet/wallets.go
+++ b/client/evilwallet/wallets.go
@@ -342,7 +342,6 @@ func (w *Wallet) GetUnspentOutput() *Output {
 func (w *Wallet) Sign(addr ledgerstate.Address, txEssence *ledgerstate.TransactionEssence) *ledgerstate.ED25519Signature {
 	w.RLock()
 	defer w.RUnlock()
-
 	index := w.AddrIndexMap(addr.Base58())
 	kp := w.seed.KeyPair(index)
 	return ledgerstate.NewED25519Signature(kp.PublicKey, kp.PrivateKey.Sign(txEssence.Bytes()))


### PR DESCRIPTION
# Description of change
Creation of deep structures is now possible also through spamming, with EvilScenarios andEvilSpammer what allows for creating large and deep DAG structures.
Fixes: #2104
The main changes introduced: 
 - introduced reuse wallets, whichare selecting outputs without an order (as it is in fresh wallets)
 - added aliases prefixes for scenario batches to allow for deleting aliases by name, and not affecting other batches creation during the spam
 - fix not solid inputs problem by adding await functionsand tracking solidity per node


<img width="837" alt="Zrzut ekranu 2022-04-05 225819" src="https://user-images.githubusercontent.com/44535712/161850457-2df6b83c-a1d4-41ab-a681-56879e17a2a2.png">
<img width="928" alt="Zrzut ekranu 2022-04-05 225159" src="https://user-images.githubusercontent.com/44535712/161850466-69dcfda8-fb79-4cc7-8130-b92a330acf99.png">
<img width="683" alt="Zrzut ekranu 2022-04-05 225223" src="https://user-images.githubusercontent.com/44535712/161850534-e2d3473f-e030-4c59-9e7e-1a3aea99a4be.png">

## Type of change
- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested
Spam in Docker network

## Change checklist
- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
