### PR TITLE
Avoid failing on duplicated unlock blocks with serix

### DIFF
--- a/packages/ledgerstate/unlockblock.go
+++ b/packages/ledgerstate/unlockblock.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 
 	"github.com/cockroachdb/errors"
-	"github.com/iotaledger/hive.go/serializer/v2"
 	"github.com/iotaledger/hive.go/serix"
 	"github.com/iotaledger/hive.go/stringify"
 )
@@ -26,7 +25,8 @@ func init() {
 		panic(fmt.Errorf("error registering SignatureUnlockBlock type settings: %w", err))
 	}
 	err = serix.DefaultAPI.RegisterTypeSettings(UnlockBlocks{}, serix.TypeSettings{}.WithLengthPrefixType(serix.LengthPrefixTypeAsUint16).WithArrayRules(&serix.ArrayRules{
-		ValidationMode: serializer.ArrayValidationModeNoDuplicates,
+		// TODO: Avoid failing on duplicated unlock blocks. They seem to have been wrongly generated in the old snapshot.
+		// ValidationMode: serializer.ArrayValidationModeNoDuplicates,
 	}))
 	if err != nil {
 		panic(fmt.Errorf("error registering SignatureUnlockBlock type settings: %w", err))

--- a/packages/ledgerstate/unlockblock_test.go
+++ b/packages/ledgerstate/unlockblock_test.go
@@ -25,12 +25,13 @@ func TestUnlockBlockFromBytes(t *testing.T) {
 	}
 
 	// test an invalid set of UnlockBlocks
-	{
-		unlockBlocks := UnlockBlocks{
-			NewSignatureUnlockBlock(NewED25519Signature(keyPair.PublicKey, keyPair.PrivateKey.Sign([]byte("testdata")))),
-			NewSignatureUnlockBlock(NewED25519Signature(keyPair.PublicKey, keyPair.PrivateKey.Sign([]byte("testdata")))),
-		}
-		_, _, err := UnlockBlocksFromBytes(unlockBlocks.Bytes())
-		assert.Error(t, err)
-	}
+	// TODO: this should be enabled again once duplicate validation is enabled
+	// {
+	// 	unlockBlocks := UnlockBlocks{
+	// 		NewSignatureUnlockBlock(NewED25519Signature(keyPair.PublicKey, keyPair.PrivateKey.Sign([]byte("testdata")))),
+	// 		NewSignatureUnlockBlock(NewED25519Signature(keyPair.PublicKey, keyPair.PrivateKey.Sign([]byte("testdata")))),
+	// 	}
+	// 	_, _, err := UnlockBlocksFromBytes(unlockBlocks.Bytes())
+	// 	assert.Error(t, err)
+	// }
 }


### PR DESCRIPTION
The old snapshot has been created with duplicated unlock blocks and not properly verified when creating transactions. With serix there is now validation for this, so the old snapshot does not work anymore. As a quick fix we ignore duplicated unlock blocks.