### PR TITLE
Fix snapshot location in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,7 +113,7 @@ EXPOSE 8081/tcp
 EXPOSE 8061/tcp
 
 # Copy configuration
-COPY --from=build /tmp/snapshot.bin /snapshot.bin
+COPY --from=build /tmp/snapshot.bin /tmp/snapshot.bin
 COPY config.default.json /config.json
 
 # Copy the Pre-built binary file from the previous stage


### PR DESCRIPTION
# Description of change

After changing to `WORKDIR /tmp` in the Dockerfile, the default location for the snapshot `./snapshot` points to an invalid location. Therefore, changing the location to `/tmp/snapshot.bin` should fix the problem and make it usable without specifying the path to the snapshot when starting the container.