### PR TITLE
Fix: do not trigger BlockRateLimiter if not bootstrapped

### DIFF
--- a/plugins/gossip/parameters.go
+++ b/plugins/gossip/parameters.go
@@ -17,7 +17,7 @@ type ParametersDefinition struct {
 
 type blocksLimitParameters struct {
 	Interval time.Duration `default:"10s" usage:"the time interval for which we count the blocks rate"`
-	Limit    int           `default:"3000" usage:"the base limit of blocks per interval"`
+	Limit    int           `default:"50000" usage:"the base limit of blocks per interval"`
 }
 
 type blockRequestsLimitParameters struct {


### PR DESCRIPTION
# Description of change

Do not drop peers if, while bootstrapping the node, the rate limiter threshold is reached.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)