### PR TITLE
Fix: syncing and bootstrapping

### DIFF
--- a/packages/notarization/manager.go
+++ b/packages/notarization/manager.go
@@ -206,6 +206,8 @@ func (m *Manager) OnBlockAccepted(block *tangle.Block) {
 		m.log.Error(err)
 		return
 	}
+	m.updateEpochsBootstrapped(ei)
+
 	m.Events.TangleTreeInserted.Trigger(&TangleTreeUpdatedEvent{EI: ei, BlockID: block.ID()})
 }
 
@@ -566,7 +568,6 @@ func (m *Manager) moveLatestCommittableEpoch(currentEpoch epoch.Index) ([]*Epoch
 
 func (m *Manager) triggerEpochEvents(epochCommittableEvents []*EpochCommittableEvent, manaVectorUpdateEvents []*ManaVectorUpdateEvent) {
 	for _, epochCommittableEvent := range epochCommittableEvents {
-		m.updateEpochsBootstrapped(epochCommittableEvent.EI)
 		m.Events.EpochCommittable.Trigger(epochCommittableEvent)
 	}
 	for _, manaVectorUpdateEvent := range manaVectorUpdateEvents {

--- a/plugins/blocklayer/parameters.go
+++ b/plugins/blocklayer/parameters.go
@@ -21,7 +21,7 @@ type ParametersDefinition struct {
 	}
 
 	// TangleTimeWindow defines the time window in which the node considers itself as synced according to TangleTime.
-	TangleTimeWindow time.Duration `default:"20m" usage:"the time window in which the node considers itself as synced according to TangleTime"`
+	TangleTimeWindow time.Duration `default:"20s" usage:"the time window in which the node considers itself as synced according to TangleTime"`
 
 	// StartSynced defines if the node should start as synced.
 	StartSynced bool `default:"false" usage:"start as synced"`


### PR DESCRIPTION
# Description of change

Do not consider the notarization bootstrapped before we are actually certain that the epoch-related events have been processed.
Consider it bootstrapped when we are able to succesffully consider a block accepted into a recent epoch, according to wall clock.

Also: consider the node in sync with a smaller window than TSC.