### PR TITLE
WarpSync: simplify & fix send on closed channel

### DIFF
--- a/packages/node/warpsync/manager.go
+++ b/packages/node/warpsync/manager.go
@@ -61,7 +61,7 @@ type epochChannels struct {
 	startChan chan *epochSyncStart
 	blockChan chan *epochSyncBlock
 	endChan   chan *epochSyncEnd
-	stopChan  chan struct{}
+	active    bool
 }
 
 // NewManager creates a new Manager.

--- a/packages/node/warpsync/manager.go
+++ b/packages/node/warpsync/manager.go
@@ -61,6 +61,7 @@ type epochChannels struct {
 	startChan chan *epochSyncStart
 	blockChan chan *epochSyncBlock
 	endChan   chan *epochSyncEnd
+	stopChan  chan struct{}
 	active    bool
 }
 
@@ -117,9 +118,6 @@ func (m *Manager) WarpRange(ctx context.Context, start, end epoch.Index, startEC
 		m.log.Debugf("WarpRange: already synced to %d", m.successfulSyncEpoch)
 		return nil
 	}
-
-	// We always request from the last successfully-warpsynced epoch.
-	start = m.successfulSyncEpoch
 
 	m.active.Set()
 	defer m.active.UnSet()

--- a/packages/node/warpsync/validation.go
+++ b/packages/node/warpsync/validation.go
@@ -99,7 +99,7 @@ func (m *Manager) validateBackwards(ctx context.Context, start, end epoch.Index,
 					}
 					proposedECRecord := epochCommitment.ecRecord
 					if ecRecordChain[epochToValidate+1].PrevEC() != proposedECRecord.ComputeEC() {
-						m.log.Infof("ignoring commitment outside of the target chain", "peer", peerID)
+						m.log.Infow("ignoring commitment outside of the target chain", "peer", peerID)
 						validPeers.Delete(peerID)
 						continue
 					}


### PR DESCRIPTION
# Description of change

A race condition existed where both the epoch's stopChan and another communication channel could be closed at the same time while a select on both channels could randomly try to send on the latter.

This PR uses the https://pkg.go.dev/golang.org/x/sync/errgroup package to simplify epoch syncing goroutines synchronization.