### PR TITLE
Release v0.9.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# v0.9.5 - 2022-08-31
+
+> This release introduces a warpsync plugin for fast epochs retrieval, a simplified faucet, local snapshot improvements, and network and general bug fixes.
+
+- WarpSync: simplify & fix send on closed channel (#2407)
+- Fix network and warpsync bugs & reset genesis time (#2406)
+- Mana vector fixes (#2396)
+- Implement simplified faucet (#2391)
+- Update to latest hive.go (#2400)
+- Warpsync: epoch syncing (#2367)
+- Activity committments and activity log based on epochs (#2345)
+- Implement solid entry points (#2373)
+
 # v0.9.4 - 2022-08-08
 
 > This release mostly include maintenance changes to the deployment scripts and minor bug fixes.

--- a/plugins/autopeering/discovery/parameters.go
+++ b/plugins/autopeering/discovery/parameters.go
@@ -5,7 +5,7 @@ import "github.com/iotaledger/goshimmer/plugins/config"
 // ParametersDefinitionDiscovery contains the definition of configuration parameters used by the autopeering peer discovery.
 type ParametersDefinitionDiscovery struct {
 	// NetworkVersion defines the config flag of the network version.
-	NetworkVersion uint32 `default:"62" usage:"autopeering network version"`
+	NetworkVersion uint32 `default:"63" usage:"autopeering network version"`
 
 	// EntryNodes defines the config flag of the entry nodes.
 	EntryNodes []string `default:"2PV5487xMw5rasGBXXWeqSi4hLz7r19YBt8Y1TGAsQbj@analysisentry-01.devnet.shimmer.iota.cafe:15626,5EDH4uY78EA6wrBkHHAVBWBMDt7EcksRq6pjzipoW15B@entry-0.devnet.tanglebay.com:14646,CAB87iQZR6BjBrCgEBupQJ4gpEBgvGKKv3uuGVRBKb4n@entry-1.devnet.tanglebay.com:14646" usage:"list of trusted entry nodes for auto peering"`

--- a/plugins/banner/plugin.go
+++ b/plugins/banner/plugin.go
@@ -15,7 +15,7 @@ var (
 	Plugin = node.NewPlugin(PluginName, nil, node.Enabled, configure, run)
 
 	// AppVersion version number
-	AppVersion = "v0.9.4"
+	AppVersion = "v0.9.5"
 	// SimplifiedAppVersion is the version number without commit hash
 	SimplifiedAppVersion = simplifiedVersion(AppVersion)
 )

--- a/plugins/database/versioning.go
+++ b/plugins/database/versioning.go
@@ -11,7 +11,7 @@ import (
 const (
 	// DBVersion defines the version of the database schema this version of GoShimmer supports.
 	// Every time there's a breaking change regarding the stored data, this version flag should be adjusted.
-	DBVersion = 62
+	DBVersion = 63
 )
 
 var (


### PR DESCRIPTION
# v0.9.5 - 2022-08-31

> This release introduces a warpsync plugin for fast epochs retrieval, a simplified faucet, local snapshot improvements, and network and general bug fixes.

- WarpSync: simplify & fix send on closed channel (#2407)
- Fix network and warpsync bugs & reset genesis time (#2406)
- Mana vector fixes (#2396)
- Implement simplified faucet (#2391)
- Update to latest hive.go (#2400)
- Warpsync: epoch syncing (#2367)
- Activity committments and activity log based on epochs (#2345)
- Implement solid entry points (#2373)