### PR TITLE
Fix: several bugs in Notarization and Networking

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	go.uber.org/atomic v1.9.0
 	go.uber.org/dig v1.15.0
 	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa
+	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
 	google.golang.org/protobuf v1.28.1
 	gopkg.in/src-d/go-git.v4 v4.13.1
 )
@@ -184,7 +185,6 @@ require (
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.22.0 // indirect
 	golang.org/x/net v0.0.0-20220809012201-f428fae20770 // indirect
-	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 // indirect
 	golang.org/x/sys v0.0.0-20220808155132-1c4a2a72c664 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect

--- a/packages/core/mana/events.go
+++ b/packages/core/mana/events.go
@@ -9,6 +9,8 @@ import (
 	"github.com/iotaledger/hive.go/core/stringify"
 	"github.com/mr-tron/base58"
 
+	"github.com/iotaledger/goshimmer/packages/core/epoch"
+	"github.com/iotaledger/goshimmer/packages/core/ledger"
 	"github.com/iotaledger/goshimmer/packages/core/ledger/utxo"
 )
 
@@ -56,6 +58,16 @@ type Event interface {
 	ToPersistable() *PersistableEvent
 	// String returns a human readable version of the event.
 	String() string
+}
+
+// ManaVectorUpdateEvent is a container that acts as a dictionary for the EpochCommittable event related parameters.
+type ManaVectorUpdateEvent struct {
+	// EI is the index of committable epoch.
+	EI epoch.Index
+	// Spent are outputs that is spent in a transaction.
+	Spent []*ledger.OutputWithMetadata
+	// Created are the outputs created in a transaction.
+	Created []*ledger.OutputWithMetadata
 }
 
 // PledgedEvent is the struct that is passed along with triggering a Pledged event.

--- a/packages/core/notarization/commitments.go
+++ b/packages/core/notarization/commitments.go
@@ -345,7 +345,10 @@ func (f *EpochCommitmentFactory) newEpochRoots(ei epoch.Index) (commitmentRoots 
 	}
 
 	// We advance the LedgerState to the next epoch.
-	f.commitLedgerState(ei - epoch.Index(f.snapshotDepth))
+	epochToCommit := ei - epoch.Index(f.snapshotDepth)
+	if epochToCommit > 0 {
+		f.commitLedgerState(epochToCommit)
+	}
 
 	commitmentRoots = &epoch.CommitmentRoots{
 		StateRoot:         epoch.NewMerkleRoot(stateRoot),

--- a/packages/core/notarization/commitments.go
+++ b/packages/core/notarization/commitments.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/iotaledger/hive.go/core/generics/lo"
 	"github.com/iotaledger/hive.go/core/generics/objectstorage"
+	"github.com/iotaledger/hive.go/core/generics/shrinkingmap"
 	"github.com/iotaledger/hive.go/core/kvstore"
 	"golang.org/x/crypto/blake2b"
 
@@ -49,7 +50,7 @@ type CommitmentTrees struct {
 
 // EpochCommitmentFactory manages epoch commitmentTrees.
 type EpochCommitmentFactory struct {
-	commitmentTrees map[epoch.Index]*CommitmentTrees
+	commitmentTrees *shrinkingmap.ShrinkingMap[epoch.Index, *CommitmentTrees]
 
 	storage *EpochCommitmentStorage
 	tangle  *tangleold.Tangle
@@ -74,7 +75,7 @@ func NewEpochCommitmentFactory(store kvstore.KVStore, tangle *tangleold.Tangle, 
 	manaRootTreeValueStore := objectstorage.NewStoreWithRealm(epochCommitmentStorage.baseStore, database.PrefixNotarization, prefixManaTreeValues)
 
 	return &EpochCommitmentFactory{
-		commitmentTrees: make(map[epoch.Index]*CommitmentTrees),
+		commitmentTrees: shrinkingmap.New[epoch.Index, *CommitmentTrees](),
 		storage:         epochCommitmentStorage,
 		tangle:          tangle,
 		snapshotDepth:   snapshotDepth,
@@ -354,7 +355,7 @@ func (f *EpochCommitmentFactory) newEpochRoots(ei epoch.Index) (commitmentRoots 
 	}
 
 	// We are never going to use this epoch's commitment trees again.
-	delete(f.commitmentTrees, ei)
+	f.commitmentTrees.Delete(ei)
 
 	return commitmentRoots, nil
 }
@@ -383,10 +384,10 @@ func (f *EpochCommitmentFactory) getCommitmentTrees(ei epoch.Index) (commitmentT
 	if ei <= lastCommittedEpoch {
 		return nil, errors.Errorf("cannot get commitment trees for epoch %d, because it is already committed", ei)
 	}
-	commitmentTrees, ok := f.commitmentTrees[ei]
+	commitmentTrees, ok := f.commitmentTrees.Get(ei)
 	if !ok {
 		commitmentTrees = f.newCommitmentTrees(ei)
-		f.commitmentTrees[ei] = commitmentTrees
+		f.commitmentTrees.Set(ei, commitmentTrees)
 	}
 	return
 }

--- a/packages/core/notarization/events.go
+++ b/packages/core/notarization/events.go
@@ -4,6 +4,7 @@ import (
 	"github.com/iotaledger/goshimmer/packages/core/epoch"
 	"github.com/iotaledger/goshimmer/packages/core/ledger"
 	"github.com/iotaledger/goshimmer/packages/core/ledger/utxo"
+	"github.com/iotaledger/goshimmer/packages/core/mana"
 	"github.com/iotaledger/goshimmer/packages/core/tangleold"
 	"github.com/iotaledger/hive.go/core/generics/event"
 	"github.com/iotaledger/hive.go/core/identity"
@@ -20,7 +21,7 @@ type Events struct {
 	// CompetingCommitmentDetected is an event that gets triggered whenever a competing epoch commitment is detected.
 	CompetingCommitmentDetected *event.Event[*CompetingCommitmentDetectedEvent]
 	// ManaVectorUpdate is an event that gets triggered whenever the consensus mana vector needs to be updated.
-	ManaVectorUpdate *event.Event[*ManaVectorUpdateEvent]
+	ManaVectorUpdate *event.Event[*mana.ManaVectorUpdateEvent]
 	// TangleTreeInserted is an event that gets triggered when a Block is inserted into the Tangle smt.
 	TangleTreeInserted *event.Event[*TangleTreeUpdatedEvent]
 	// TangleTreeRemoved is an event that gets triggered when a Block is removed from Tangle smt.
@@ -69,10 +70,10 @@ type StateMutationTreeUpdatedEvent struct {
 type UTXOUpdatedEvent struct {
 	// EI is the index of updated UTXO.
 	EI epoch.Index
-	// Created are the outputs created in a transaction.
-	Created []*ledger.OutputWithMetadata
 	// Spent are outputs that is spent in a transaction.
 	Spent []*ledger.OutputWithMetadata
+	// Created are the outputs created in a transaction.
+	Created []*ledger.OutputWithMetadata
 }
 
 // EpochCommittableEvent is a container that acts as a dictionary for the EpochCommittable event related parameters.
@@ -93,12 +94,6 @@ type EpochConfirmedEvent struct {
 type CompetingCommitmentDetectedEvent struct {
 	// Block is the block that contains the competing commitment.
 	Block *tangleold.Block
-}
-
-// ManaVectorUpdateEvent is a container that acts as a dictionary for the EpochCommittable event related parameters.
-type ManaVectorUpdateEvent struct {
-	// EI is the index of committable epoch.
-	EI epoch.Index
 }
 
 // SyncRangeEvent is a container that acts as a dictionary for the SyncRange event related parameters.

--- a/packages/core/notarization/manager.go
+++ b/packages/core/notarization/manager.go
@@ -329,8 +329,6 @@ func (m *Manager) OnBlockStored(block *tangleold.Block) {
 	latestCommittableEI := lo.PanicOnErr(m.epochCommitmentFactory.storage.latestCommittableEpochIndex())
 	epochDeltaSeconds := time.Duration(int64(blockEI-latestCommittableEI)*epoch.Duration) * time.Second
 
-	m.log.Debugf("block committing to epoch %d stored, latest committable epoch is %d", blockEI, latestCommittableEI)
-
 	// If we are too far behind, we will warpsync
 	if epochDeltaSeconds > m.options.BootstrapWindow {
 		m.Events.SyncRange.Trigger(&SyncRangeEvent{

--- a/packages/core/notarization/proofs.go
+++ b/packages/core/notarization/proofs.go
@@ -55,12 +55,16 @@ func (f *EpochCommitmentFactory) verifyRoot(proof CommitmentProof, key []byte, v
 // ProofStateRoot returns the merkle proof for the outputID against the state root.
 func (f *EpochCommitmentFactory) ProofStateRoot(ei epoch.Index, outID utxo.OutputID) (*CommitmentProof, error) {
 	key := outID.Bytes()
-	root := f.commitmentTrees[ei].tangleTree.Root()
-	proof, err := f.stateRootTree.ProveForRoot(key, root)
+	root, exists := f.commitmentTrees.Get(ei)
+	if !exists {
+		return nil, errors.Errorf("could not obtain commitment trees for epoch %d", ei)
+	}
+	tangleRoot := root.tangleTree.Root()
+	proof, err := f.stateRootTree.ProveForRoot(key, tangleRoot)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not generate the state root proof")
 	}
-	return &CommitmentProof{ei, proof, root}, nil
+	return &CommitmentProof{ei, proof, tangleRoot}, nil
 }
 
 // ProofStateMutationRoot returns the merkle proof for the transactionID against the state mutation root.

--- a/packages/core/notarization/testutils.go
+++ b/packages/core/notarization/testutils.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/iotaledger/goshimmer/packages/core/consensus/acceptance"
 	"github.com/iotaledger/goshimmer/packages/core/ledger/utxo"
+	"github.com/iotaledger/goshimmer/packages/core/mana"
 )
 
 const (
@@ -106,7 +107,7 @@ func (e *EventMock) EpochCommittable(event *EpochCommittableEvent) {
 }
 
 // ManaVectorUpdate is the mocked ManaVectorUpdate event.
-func (e *EventMock) ManaVectorUpdate(event *ManaVectorUpdateEvent) {
+func (e *EventMock) ManaVectorUpdate(event *mana.ManaVectorUpdateEvent) {
 	e.Called(event.EI)
 	atomic.AddUint64(&e.calledEvents, 1)
 }

--- a/packages/node/p2p/neighbor.go
+++ b/packages/node/p2p/neighbor.go
@@ -106,9 +106,6 @@ func (n *Neighbor) readLoop() {
 				packet := stream.packetFactory()
 				err := stream.ReadPacket(packet)
 				if err != nil {
-					if isTimeoutError(err) {
-						continue
-					}
 					n.Log.Infow("Stream read packet error", "err", err)
 					if disconnectErr := n.disconnect(); disconnectErr != nil {
 						n.Log.Warnw("Failed to disconnect", "err", disconnectErr)

--- a/packages/node/warpsync/syncing_dataflow.go
+++ b/packages/node/warpsync/syncing_dataflow.go
@@ -122,7 +122,11 @@ func (m *Manager) epochVerifyCommand(params *syncingFlowParams, next dataflow.Ne
 
 func (m *Manager) epochProcessBlocksCommand(params *syncingFlowParams, next dataflow.Next[*syncingFlowParams]) (err error) {
 	for _, blk := range params.epochBlocks {
-		m.blockProcessorFunc(blk, m.p2pManager.GetNeighborsByID([]identity.ID{params.peerID})[0].Peer)
+		neighbors := m.p2pManager.GetNeighborsByID([]identity.ID{params.peerID})
+		if len(neighbors) != 1 {
+			return errors.Errorf("neighbor %s not peered anymore after receiving warpsynced block")
+		}
+		m.blockProcessorFunc(blk, neighbors[0].Peer)
 	}
 
 	return next(params)

--- a/plugins/blocklayer/notarization_plugin.go
+++ b/plugins/blocklayer/notarization_plugin.go
@@ -86,6 +86,7 @@ func newNotarizationManager(deps notarizationManagerDependencies) *notarization.
 		deps.Tangle,
 		notarization.MinCommittableEpochAge(NotarizationParameters.MinEpochCommittableAge),
 		notarization.BootstrapWindow(NotarizationParameters.BootstrapWindow),
+		notarization.ManaEpochDelay(ManaParameters.EpochDelay),
 		notarization.Log(Plugin.Logger()))
 }
 


### PR DESCRIPTION
# Description of change

Fixes:
- epochProcessBlockCommand: index out of range [0] with length 0.
- p2p concurrent map write.
- objectstoreage creation leak from mana_plugin.
- tentative fix: readloop still seems to consume too much CPU (maybe still in an endless loop?).
- implemented shrinkingnmaps in notarization manager.