### PR TITLE
Version bumps for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.9.8 - 2022-09-06
+
+> This release disables the Warpsync plugin, which is still experimental.
+
+- Disable Warpsync by default (#2421)
+
 # v0.9.7 - 2022-09-05
 
 > This release introduces major bugfixes to the networking and the faucet.

--- a/plugins/autopeering/discovery/parameters.go
+++ b/plugins/autopeering/discovery/parameters.go
@@ -5,7 +5,7 @@ import "github.com/iotaledger/goshimmer/plugins/config"
 // ParametersDefinitionDiscovery contains the definition of configuration parameters used by the autopeering peer discovery.
 type ParametersDefinitionDiscovery struct {
 	// NetworkVersion defines the config flag of the network version.
-	NetworkVersion uint32 `default:"65" usage:"autopeering network version"`
+	NetworkVersion uint32 `default:"66" usage:"autopeering network version"`
 
 	// EntryNodes defines the config flag of the entry nodes.
 	EntryNodes []string `default:"2PV5487xMw5rasGBXXWeqSi4hLz7r19YBt8Y1TGAsQbj@analysisentry-01.devnet.shimmer.iota.cafe:15626,5EDH4uY78EA6wrBkHHAVBWBMDt7EcksRq6pjzipoW15B@entry-0.devnet.tanglebay.com:14646,CAB87iQZR6BjBrCgEBupQJ4gpEBgvGKKv3uuGVRBKb4n@entry-1.devnet.tanglebay.com:14646" usage:"list of trusted entry nodes for auto peering"`

--- a/plugins/banner/plugin.go
+++ b/plugins/banner/plugin.go
@@ -15,7 +15,7 @@ var (
 	Plugin = node.NewPlugin(PluginName, nil, node.Enabled, configure, run)
 
 	// AppVersion version number
-	AppVersion = "v0.9.7"
+	AppVersion = "v0.9.8"
 	// SimplifiedAppVersion is the version number without commit hash
 	SimplifiedAppVersion = simplifiedVersion(AppVersion)
 )

--- a/plugins/database/versioning.go
+++ b/plugins/database/versioning.go
@@ -11,7 +11,7 @@ import (
 const (
 	// DBVersion defines the version of the database schema this version of GoShimmer supports.
 	// Every time there's a breaking change regarding the stored data, this version flag should be adjusted.
-	DBVersion = 65
+	DBVersion = 66
 )
 
 var (


### PR DESCRIPTION
# v0.9.8 - 2022-09-06

> This release disables the Warpsync plugin, which is still experimental.

- Disable Warpsync by default (#2421)