### PR TITLE
Protocol eviction

### DIFF
--- a/packages/core/causalorder/testframework.go
+++ b/packages/core/causalorder/testframework.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/iotaledger/hive.go/core/debug"
 	"github.com/iotaledger/hive.go/core/generics/options"
+	"github.com/iotaledger/hive.go/core/generics/set"
 	"github.com/stretchr/testify/require"
 
 	"github.com/iotaledger/goshimmer/packages/core/epoch"
@@ -39,8 +40,8 @@ func NewTestFramework(test *testing.T, opts ...options.Option[TestFramework]) (n
 		evictedEntities: make(map[string]*MockedOrderedEntity),
 	}, opts, func(t *TestFramework) {
 		t.CausalOrder = New[MockedEntityID, *MockedOrderedEntity](
-			eviction.NewManager[MockedEntityID](func(id MockedEntityID) (isRootBlock bool) {
-				return id.id == 0
+			eviction.NewManager[MockedEntityID](0, func(index epoch.Index) *set.AdvancedSet[MockedEntityID] {
+				return set.NewAdvancedSet(NewMockedEntityID(0))
 			}),
 			func(id MockedEntityID) (entity *MockedOrderedEntity, exists bool) {
 				return t.Get(id.alias)
@@ -143,7 +144,7 @@ func (t *TestFramework) EntityIDs(aliases ...string) (entityIDs []MockedEntityID
 
 // EvictEpoch evicts all Entities that are older than the given epoch.
 func (t *TestFramework) EvictEpoch(index epoch.Index) {
-	t.evictionManager.EvictEpoch(index)
+	t.evictionManager.EvictUntilEpoch(index)
 	t.CausalOrder.EvictEpoch(index)
 }
 

--- a/packages/network/network.go
+++ b/packages/network/network.go
@@ -1,7 +1,6 @@
 package network
 
 import (
-	"github.com/iotaledger/hive.go/core/autopeering/peer"
 	"github.com/iotaledger/hive.go/core/generics/options"
 	"github.com/iotaledger/hive.go/core/logger"
 
@@ -25,16 +24,18 @@ func New(p2pManager *p2p.Manager, blockProvider func(models.BlockID) *models.Blo
 		P2PManager: p2pManager,
 	}, opts)
 
-	network.WarpSyncMgr = warpsync.NewManager(network.P2PManager, blockProvider, func(block *models.Block, peer *peer.Peer) {
-		network.Events.BlockReceived.Trigger(&BlockReceivedEvent{
-			Block: block,
-			Peer:  peer,
-		})
-	}, logger)
+	// TODO: fix types
+	// network.WarpSyncMgr = warpsync.NewManager(network.P2PManager, blockProvider, func(block *models.Block, peer *peer.Peer) {
+	// 	network.Events.BlockReceived.Trigger(&BlockReceivedEvent{
+	// 		Block: block,
+	// 		Peer:  peer,
+	// 	})
+	// }, logger)
 
-	network.GossipMgr = gossip.NewManager(network.P2PManager, func(blockId models.BlockID) ([]byte, error) {
-		return blockProvider(blockId).Bytes()
-	}, logger)
+	// TODO: fix types
+	// network.GossipMgr = gossip.NewManager(network.P2PManager, func(blockId models.BlockID) ([]byte, error) {
+	// 	return blockProvider(blockId).Bytes()
+	// }, logger)
 
 	return network
 }

--- a/packages/protocol/engine/consensus/acceptance/testframework.go
+++ b/packages/protocol/engine/consensus/acceptance/testframework.go
@@ -54,7 +54,7 @@ func NewTestFramework(test *testing.T, opts ...options.Option[TestFramework]) (t
 				}
 
 				if t.optsEvictionManager == nil {
-					t.optsEvictionManager = eviction.NewManager[models.BlockID](models.IsEmptyBlockID)
+					t.optsEvictionManager = eviction.NewManager[models.BlockID](0, models.GenesisRootBlockProvider)
 				}
 
 				if t.optsValidatorSet == nil {

--- a/packages/protocol/engine/tangle/blockdag/blockdag_test.go
+++ b/packages/protocol/engine/tangle/blockdag/blockdag_test.go
@@ -330,7 +330,7 @@ func TestBlockDAG_AttachInvalid(t *testing.T) {
 	}
 
 	// Prune BlockDAG.
-	tf.BlockDAG.EvictionManager.EvictEpoch(epochCount / 2)
+	tf.BlockDAG.EvictionManager.EvictUntilEpoch(epochCount / 2)
 	tf.WaitUntilAllTasksProcessed()
 	assert.EqualValues(t, epochCount/2, tf.BlockDAG.EvictionManager.MaxEvictedEpoch(), "maxDroppedEpoch should be epochCount/2")
 
@@ -461,7 +461,7 @@ func TestBlockDAG_Prune(t *testing.T) {
 
 	validateState(tf, 0, epochCount)
 
-	tf.BlockDAG.EvictionManager.EvictEpoch(epochCount / 4)
+	tf.BlockDAG.EvictionManager.EvictUntilEpoch(epochCount / 4)
 	tf.WaitUntilAllTasksProcessed()
 
 	assert.EqualValues(t, epochCount/4, tf.BlockDAG.EvictionManager.MaxEvictedEpoch(), "maxDroppedEpoch should be epochCount/4")
@@ -469,11 +469,11 @@ func TestBlockDAG_Prune(t *testing.T) {
 	// All orphan blocks should be marked as invalid due to invalidity propagation.
 	tf.AssertInvalidCount(epochCount, "should have invalid blocks")
 
-	tf.BlockDAG.EvictionManager.EvictEpoch(epochCount / 10)
+	tf.BlockDAG.EvictionManager.EvictUntilEpoch(epochCount / 10)
 	tf.WaitUntilAllTasksProcessed()
 	assert.EqualValues(t, epochCount/4, tf.BlockDAG.EvictionManager.MaxEvictedEpoch(), "maxDroppedEpoch should be epochCount/4")
 
-	tf.BlockDAG.EvictionManager.EvictEpoch(epochCount / 2)
+	tf.BlockDAG.EvictionManager.EvictUntilEpoch(epochCount / 2)
 	tf.WaitUntilAllTasksProcessed()
 	assert.EqualValues(t, epochCount/2, tf.BlockDAG.EvictionManager.MaxEvictedEpoch(), "maxDroppedEpoch should be epochCount/2")
 

--- a/packages/protocol/engine/tangle/blockdag/testframework.go
+++ b/packages/protocol/engine/tangle/blockdag/testframework.go
@@ -45,7 +45,7 @@ func NewTestFramework(test *testing.T, opts ...options.Option[TestFramework]) (n
 	}, opts, func(t *TestFramework) {
 		if t.BlockDAG == nil {
 			if t.evictionManager == nil {
-				t.evictionManager = eviction.NewManager(models.IsEmptyBlockID)
+				t.evictionManager = eviction.NewManager(0, models.GenesisRootBlockProvider)
 			}
 
 			t.BlockDAG = New(t.evictionManager, t.optsBlockDAG...)

--- a/packages/protocol/engine/tangle/booker/booker_test.go
+++ b/packages/protocol/engine/tangle/booker/booker_test.go
@@ -746,7 +746,7 @@ func Test_Prune(t *testing.T) {
 
 	validateState(tf, 0, epochCount)
 
-	tf.BlockDAG.EvictionManager.EvictEpoch(epochCount / 4)
+	tf.BlockDAG.EvictionManager.EvictUntilEpoch(epochCount / 4)
 	event.Loop.WaitUntilAllTasksProcessed()
 
 	require.EqualValues(t, epochCount/4, tf.BlockDAG.EvictionManager.MaxEvictedEpoch(), "maxDroppedEpoch of booker should be epochCount/4")
@@ -754,12 +754,12 @@ func Test_Prune(t *testing.T) {
 	// All orphan blocks should be marked as invalid due to invalidity propagation.
 	tf.AssertInvalidCount(0, "should have invalid blocks")
 
-	tf.BlockDAG.EvictionManager.EvictEpoch(epochCount / 10)
+	tf.BlockDAG.EvictionManager.EvictUntilEpoch(epochCount / 10)
 	event.Loop.WaitUntilAllTasksProcessed()
 
 	require.EqualValues(t, epochCount/4, tf.BlockDAG.EvictionManager.MaxEvictedEpoch(), "maxDroppedEpoch of booker should be epochCount/4")
 
-	tf.BlockDAG.EvictionManager.EvictEpoch(epochCount / 2)
+	tf.BlockDAG.EvictionManager.EvictUntilEpoch(epochCount / 2)
 	event.Loop.WaitUntilAllTasksProcessed()
 
 	require.EqualValues(t, epochCount/2, tf.BlockDAG.EvictionManager.MaxEvictedEpoch(), "maxDroppedEpoch of booker should be epochCount/2")

--- a/packages/protocol/engine/tangle/booker/markermanager/markermanager_test.go
+++ b/packages/protocol/engine/tangle/booker/markermanager/markermanager_test.go
@@ -54,12 +54,12 @@ func Test_PruneMarkerBlockMapping(t *testing.T) {
 
 	validateBlockMarkerMappingPruning(t, markerBlockMapping, markerManager, 0)
 
-	tf.BlockDAG.EvictionManager.EvictEpoch(epochCount / 2)
+	tf.BlockDAG.EvictionManager.EvictUntilEpoch(epochCount / 2)
 	event.Loop.WaitUntilAllTasksProcessed()
 
 	validateBlockMarkerMappingPruning(t, markerBlockMapping, markerManager, epochCount/2)
 
-	tf.BlockDAG.EvictionManager.EvictEpoch(epochCount)
+	tf.BlockDAG.EvictionManager.EvictUntilEpoch(epochCount)
 	event.Loop.WaitUntilAllTasksProcessed()
 
 	validateBlockMarkerMappingPruning(t, markerBlockMapping, markerManager, epochCount)

--- a/packages/protocol/engine/tangle/models/testframework.go
+++ b/packages/protocol/engine/tangle/models/testframework.go
@@ -5,6 +5,9 @@ import (
 	"sync/atomic"
 
 	"github.com/iotaledger/hive.go/core/generics/options"
+	"github.com/iotaledger/hive.go/core/generics/set"
+
+	"github.com/iotaledger/goshimmer/packages/core/epoch"
 )
 
 // region TestFramework ////////////////////////////////////////////////////////////////////////////////////////////////
@@ -78,3 +81,7 @@ func WithBlock(alias string, block *Block) options.Option[TestFramework] {
 }
 
 // endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+func GenesisRootBlockProvider(index epoch.Index) *set.AdvancedSet[BlockID] {
+	return set.NewAdvancedSet[BlockID](EmptyBlockID)
+}

--- a/packages/protocol/engine/tangle/testframework.go
+++ b/packages/protocol/engine/tangle/testframework.go
@@ -38,7 +38,7 @@ func NewTestFramework(test *testing.T, opts ...options.Option[TestFramework]) (n
 			}
 
 			if t.optsEvictionManager == nil {
-				t.optsEvictionManager = eviction.NewManager[models.BlockID](models.IsEmptyBlockID)
+				t.optsEvictionManager = eviction.NewManager[models.BlockID](0, models.GenesisRootBlockProvider)
 			}
 
 			if t.optsValidatorSet == nil {

--- a/packages/protocol/engine/testframework.go
+++ b/packages/protocol/engine/testframework.go
@@ -44,7 +44,7 @@ func NewTestFramework(test *testing.T, opts ...options.Option[TestFramework]) (t
 			}
 
 			if t.optsEvictionManager == nil {
-				t.optsEvictionManager = eviction.NewManager(models.IsEmptyBlockID)
+				t.optsEvictionManager = eviction.NewManager(0, models.GenesisRootBlockProvider)
 			}
 
 			if t.optsValidatorSet == nil {

--- a/packages/protocol/protocol.go
+++ b/packages/protocol/protocol.go
@@ -4,13 +4,13 @@ import (
 	"time"
 
 	"github.com/iotaledger/hive.go/core/generics/event"
-	"github.com/iotaledger/hive.go/core/generics/lo"
 	"github.com/iotaledger/hive.go/core/generics/options"
+	"github.com/iotaledger/hive.go/core/generics/set"
 
+	"github.com/iotaledger/goshimmer/packages/core/epoch"
 	"github.com/iotaledger/goshimmer/packages/core/notarization"
-	"github.com/iotaledger/goshimmer/packages/core/tangleold"
+	"github.com/iotaledger/goshimmer/packages/core/snapshot"
 	"github.com/iotaledger/goshimmer/packages/network"
-	"github.com/iotaledger/goshimmer/packages/network/gossip"
 	"github.com/iotaledger/goshimmer/packages/protocol/database"
 	"github.com/iotaledger/goshimmer/packages/protocol/engine"
 	"github.com/iotaledger/goshimmer/packages/protocol/engine/tangle/models"
@@ -28,6 +28,7 @@ type Protocol struct {
 	Network             *network.Network
 	DatabaseManager     *database.Manager
 	NotarizationManager *notarization.Manager
+	SnapshotManager     *snapshot.Manager
 	EvictionManager     *eviction.Manager[models.BlockID]
 	Engine              *engine.Engine
 	Solidification      *solidification.Solidification
@@ -45,7 +46,11 @@ func New(network *network.Network, opts ...options.Option[Protocol]) (protocol *
 
 		var genesisTime time.Time
 
-		p.EvictionManager = eviction.NewManager(models.IsEmptyBlockID)
+		p.EvictionManager = eviction.NewManager(0, func(index epoch.Index) *set.AdvancedSet[models.BlockID] {
+			// TODO: implement me and set snapshot epoch!
+			// p.SnapshotManager.GetSolidEntryPoints(index)
+			return set.NewAdvancedSet[models.BlockID]()
+		})
 		p.DatabaseManager = database.NewManager(p.optsDBManagerOptions...)
 		p.SybilProtection = sybilprotection.New()
 
@@ -57,26 +62,33 @@ func New(network *network.Network, opts ...options.Option[Protocol]) (protocol *
 	})
 }
 
+func (p *Protocol) setupNotarization() {
+	// Once an epoch becomes committable, nothing can change anymore. We can safely evict until the given epoch index.
+	p.NotarizationManager.Events.EpochCommittable.Attach(event.NewClosure(func(event *notarization.EpochCommittableEvent) {
+		p.EvictionManager.EvictUntilEpoch(event.EI)
+	}))
+}
+
 func (p *Protocol) Start() {
 	// configure flow of incoming blocks
-	p.Network.GossipMgr.Events.BlockReceived.Attach(event.NewClosure(func(event *gossip.BlockReceivedEvent) {
-		p.Engine.Tangle.ProcessGossipBlock(event.Data, event.Peer)
-	}))
-
-	// configure flow of outgoing blocks (gossip upon dispatched blocks)
-	p.Events.Engine.Scheduler.Events.BlockScheduled.Attach(event.NewClosure(func(event *tangleold.BlockScheduledEvent) {
-		deps.Tangle.Storage.Block(event.BlockID).Consume(func(block *tangleold.Block) {
-			deps.GossipMgr.SendBlock(lo.PanicOnErr(block.Bytes()))
-		})
-	}))
-
-	// request missing blocks
-	deps.Tangle.Requester.Events.RequestIssued.Attach(event.NewClosure(func(event *tangleold.RequestIssuedEvent) {
-		id := event.BlockID
-		Plugin.LogDebugf("requesting missing Block with %s", id)
-
-		deps.GossipMgr.RequestBlock(id.Bytes())
-	}))
+	// p.Network.GossipMgr.Events.BlockReceived.Attach(event.NewClosure(func(event *gossip.BlockReceivedEvent) {
+	// 	p.Engine.Tangle.ProcessGossipBlock(event.Data, event.Peer)
+	// }))
+	//
+	// // configure flow of outgoing blocks (gossip upon dispatched blocks)
+	// p.Events.Engine.Scheduler.Events.BlockScheduled.Attach(event.NewClosure(func(event *tangleold.BlockScheduledEvent) {
+	// 	deps.Tangle.Storage.Block(event.BlockID).Consume(func(block *tangleold.Block) {
+	// 		deps.GossipMgr.SendBlock(lo.PanicOnErr(block.Bytes()))
+	// 	})
+	// }))
+	//
+	// // request missing blocks
+	// deps.Tangle.Requester.Events.RequestIssued.Attach(event.NewClosure(func(event *tangleold.RequestIssuedEvent) {
+	// 	id := event.BlockID
+	// 	Plugin.LogDebugf("requesting missing Block with %s", id)
+	//
+	// 	deps.GossipMgr.RequestBlock(id.Bytes())
+	// }))
 }
 
 // endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
# Description of change

Wire up the protocol to support eviction and adjust the eviction procedure so that an epoch is first marked as evicted and the new root blocks (solid entry points) for this epoch are retrieved atomically. Then, the eviction manager fires the corresponding events which in turn lets each component evict asynchronously at any given point in time.