### PR TITLE
Added doc about rand-seed and rand-address

### DIFF
--- a/documentation/docs/tooling/overview.md
+++ b/documentation/docs/tooling/overview.md
@@ -21,4 +21,4 @@ We provide a documentation for the following tools:
 - The [integration tests](integration_tests.md) spins up a `tester` container within which every test can specify its own GoShimmer network with Docker.
 - The [cli-wallet](../tutorials/wallet_library.md) is described as part of the tutorial section.
 - The [DAGs Visualizer](dags_visualizer.md) is the all-round tool for visualizing DAGs.
-- The [rand-seed and rand-address](rand_seed_and_random_address.md) are used to randomly generate a seed, with the relative public key, or a random address.
+- The [rand-seed and rand-address](rand_seed_and_rand_address.md) to randomly generate a seed, with the relative public key, or a random address.

--- a/documentation/docs/tooling/overview.md
+++ b/documentation/docs/tooling/overview.md
@@ -21,3 +21,4 @@ We provide a documentation for the following tools:
 - The [integration tests](integration_tests.md) spins up a `tester` container within which every test can specify its own GoShimmer network with Docker.
 - The [cli-wallet](../tutorials/wallet_library.md) is described as part of the tutorial section.
 - The [DAGs Visualizer](dags_visualizer.md) is the all-round tool for visualizing DAGs.
+- The [rand-seed and rand-address](rand_seed_and_random_address.md) are used to randomly generate a seed, with the relative public key, or a random address.

--- a/documentation/docs/tooling/rand_seed_and_rand_address.md
+++ b/documentation/docs/tooling/rand_seed_and_rand_address.md
@@ -24,7 +24,7 @@ go run main.go
 
 Right after the execution, you will have a new randomly generated address.
 
-## Rand seed
+## Rand Seed
 
 The rand seed tool is a CLI script a bit more complete than the previous one. It let you generate in a text file a seed (encoded in base58 and base64), its relative identity and its public key. The execution is still simple:
 

--- a/documentation/docs/tooling/rand_seed_and_rand_address.md
+++ b/documentation/docs/tooling/rand_seed_and_rand_address.md
@@ -44,14 +44,14 @@ cd tools/rand-seed
 go run main.go
 ```
 
-The script will generate a `.txt` file containing, for example, the following:
+### Expected Output
 
-```shell
+The script will generate a `random-seed.txt` file in the current working directory, for example:
+
+```plaintext
 base64:ri9C8oAT3IPsus2j+IllMbW2B3nOqe4uC56zfr344zY=
 base58:CiwjnjMRwEbCGiATWjNsrVptBTNH13AHrVNmG31KK9cy
 Identity - base58:BCUnRc6c
 Identity - base58:BCUnRc6cv4YVnB3Rw5DDfdsFuVVUW97MyLEBzWxHqfQj
 Public Key - base58:Ht9VR8qAgmruDPzsQbak3AJvXcJY6q6Mxyaz4pDicDEw
 ```
-
-These tools are useful if you have to run, for example, a Docker Private Network and you want to setup the exact nodes running in the network.

--- a/documentation/docs/tooling/rand_seed_and_rand_address.md
+++ b/documentation/docs/tooling/rand_seed_and_rand_address.md
@@ -33,7 +33,7 @@ The script will output a Base58 string representing the newly generated address,
 
 You can use the `rand-address` tool to generate a text file with the following:
 
-* A [seed](/../tutorials/send_transaction#seed), represented in Base64 and Base58.
+* A [seed](../tutorials/send_transaction#seed), represented in Base64 and Base58.
 * The seed's relative identity, as a Base58 string. 
 * The relative identity's public, key in Base58.
 

--- a/documentation/docs/tooling/rand_seed_and_rand_address.md
+++ b/documentation/docs/tooling/rand_seed_and_rand_address.md
@@ -19,10 +19,15 @@ You can use the `rand-address` tool to generate a random address by running the 
 ```shell
 cd tools/rand-address
 go run main.go
-13n6HnqiLQVaE2sp8BExM51C2z1BLw7SrFjNAUK439YCC
 ```
 
-Right after the execution, you will have a new randomly generated address.
+### Expected Output
+
+The script will output a Base58 string representing the newly generated address, for example:
+
+```shell
+13n6HnqiLQVaE2sp8BExM51C2z1BLw7SrFjNAUK439YCC
+```
 
 ## Rand Seed
 

--- a/documentation/docs/tooling/rand_seed_and_rand_address.md
+++ b/documentation/docs/tooling/rand_seed_and_rand_address.md
@@ -8,7 +8,9 @@ keywords:
 - generate
 - generation
 ---
-# Rand seed and rand address
+# Rand Seed and Rand Address
+
+You can use the [`rand-address`](#rand-address) and [`rand-seed`](#rand-seed) tools to generate addresses and seeds in a single command.
 
 ## Rand address
 

--- a/documentation/docs/tooling/rand_seed_and_rand_address.md
+++ b/documentation/docs/tooling/rand_seed_and_rand_address.md
@@ -1,5 +1,5 @@
 ---
-description: Running these tools let you generate random seeds and addresses through a simple command.
+description: 'You can use the rand-address and rand-seed tools to generate random seeds and addresses through a simple command.'
 keywords:
 - address
 - seed

--- a/documentation/docs/tooling/rand_seed_and_rand_address.md
+++ b/documentation/docs/tooling/rand_seed_and_rand_address.md
@@ -12,9 +12,9 @@ keywords:
 
 You can use the [`rand-address`](#rand-address) and [`rand-seed`](#rand-seed) tools to generate addresses and seeds in a single command.
 
-## Rand address
+## Rand Address
 
-Rand address is a tool realized through a Go script that let you generate a random address. Its execution is pretty simple:
+You can use the `rand-address` tool to generate a random address by running the following command from the `tools/rand-address` directory:
 
 ```shell
 cd tools/rand-address

--- a/documentation/docs/tooling/rand_seed_and_rand_address.md
+++ b/documentation/docs/tooling/rand_seed_and_rand_address.md
@@ -31,7 +31,13 @@ The script will output a Base58 string representing the newly generated address,
 
 ## Rand Seed
 
-The rand seed tool is a CLI script a bit more complete than the previous one. It let you generate in a text file a seed (encoded in base58 and base64), its relative identity and its public key. The execution is still simple:
+## Rand Seed
+
+You can use the `rand-address` tool to generate a text file with the following:
+
+* A [seed](/../tutorials/send_transaction#seed), represented in Base64 and Base58.
+* The seed's relative identity, as a Base58 string. 
+* The relative identity's public, key in Base58.
 
 ```shell
 cd tools/rand-seed

--- a/documentation/docs/tooling/rand_seed_and_rand_address.md
+++ b/documentation/docs/tooling/rand_seed_and_rand_address.md
@@ -31,8 +31,6 @@ The script will output a Base58 string representing the newly generated address,
 
 ## Rand Seed
 
-## Rand Seed
-
 You can use the `rand-address` tool to generate a text file with the following:
 
 * A [seed](/../tutorials/send_transaction#seed), represented in Base64 and Base58.

--- a/documentation/docs/tooling/rand_seed_and_rand_address.md
+++ b/documentation/docs/tooling/rand_seed_and_rand_address.md
@@ -1,0 +1,44 @@
+---
+description: Running these tools let you generate random seeds and addresses through a simple command.
+keywords:
+- address
+- seed
+- public key
+- private key
+- generate
+- generation
+---
+# Rand seed and rand address
+
+## Rand address
+
+Rand address is a tool realized through a Go script that let you generate a random address. Its execution is pretty simple:
+
+```shell
+cd tools/rand-address
+go run main.go
+13n6HnqiLQVaE2sp8BExM51C2z1BLw7SrFjNAUK439YCC
+```
+
+Right after the execution, you will have a new randomly generated address.
+
+## Rand seed
+
+The rand seed tool is a CLI script a bit more complete than the previous one. It let you generate in a text file a seed (encoded in base58 and base64), its relative identity and its public key. The execution is still simple:
+
+```shell
+cd tools/rand-seed
+go run main.go
+```
+
+The script will generate a `.txt` file containing, for example, the following:
+
+```shell
+base64:ri9C8oAT3IPsus2j+IllMbW2B3nOqe4uC56zfr344zY=
+base58:CiwjnjMRwEbCGiATWjNsrVptBTNH13AHrVNmG31KK9cy
+Identity - base58:BCUnRc6c
+Identity - base58:BCUnRc6cv4YVnB3Rw5DDfdsFuVVUW97MyLEBzWxHqfQj
+Public Key - base58:Ht9VR8qAgmruDPzsQbak3AJvXcJY6q6Mxyaz4pDicDEw
+```
+
+These tools are useful if you have to run, for example, a Docker Private Network and you want to setup the exact nodes running in the network.

--- a/documentation/sidebars.js
+++ b/documentation/sidebars.js
@@ -296,6 +296,12 @@ module.exports = {
         label: 'Evil Spammer',
         id: 'tooling/evil_spammer',
       },
+
+      {
+        type: 'doc',
+        label: 'Rand Seed and Rand Address',
+        id: 'tooling/rand_seed_and_rand_address',
+      },
     ],
   },
   {


### PR DESCRIPTION
# Description of change

I added a small documentation about the tools `rand-seed` and `rand-address`. This came up to my mind since when I used GoShimmer for the first time I wasn't unable to find a tool to generate seeds, so I tried to build it through python, but a mod on Discord suggested me these two tools. I thought that just seeing them in the documentation would have saved me some time.

## Type of change

- Documentation Fix

## How the change has been tested

I did a grammar check of the added text.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
