### PR TITLE
Fix WeightedSet memory leaks

### DIFF
--- a/packages/core/votes/sequencetracker/testframework.go
+++ b/packages/core/votes/sequencetracker/testframework.go
@@ -66,6 +66,7 @@ func (t *TestFramework[VotePowerType]) ValidateStructureDetailsVoters(expectedVo
 		assert.Equal(t.test, markerAlias, fmt.Sprintf("%d,%d", t.StructureDetails(markerAlias).PastMarkers().Marker().SequenceID(), t.StructureDetails(markerAlias).PastMarkers().Marker().Index()))
 
 		voters := t.SequenceTracker.Voters(t.StructureDetails(markerAlias).PastMarkers().Marker())
+		defer voters.Detach()
 
 		assert.True(t.test, expectedVotersOfMarker.Equal(voters.Members()), "marker %s expected %d voters but got %d", markerAlias, expectedVotersOfMarker.Size(), voters.Members().Size())
 	}

--- a/packages/protocol/engine/consensus/blockgadget/gadget.go
+++ b/packages/protocol/engine/consensus/blockgadget/gadget.go
@@ -200,12 +200,12 @@ func (a *Gadget) RefreshSequence(sequenceID markers.SequenceID, newMaxSupportedI
 // Acceptance and Confirmation use the same threshold if confirmation is possible.
 // If there is not enough online weight to achieve confirmation, then acceptance condition is evaluated based on total active weight.
 func (a *Gadget) tryConfirmOrAccept(totalWeight int64, marker markers.Marker) (blocksToAccept, blocksToConfirm []*Block) {
-	markerVoters := a.tangle.VirtualVoting.MarkerVoters(marker)
+	markerTotalWeight := a.tangle.VirtualVoting.MarkerVotersTotalWeight(marker)
 
 	// check if enough weight is online to confirm based on total weight
 	if IsThresholdReached(totalWeight, a.tangle.Validators.TotalWeight(), a.optsMarkerConfirmationThreshold) {
 		// check if marker weight has enough weight to be confirmed
-		if IsThresholdReached(totalWeight, markerVoters.TotalWeight(), a.optsMarkerConfirmationThreshold) {
+		if IsThresholdReached(totalWeight, markerTotalWeight, a.optsMarkerConfirmationThreshold) {
 			// need to mark outside 'if' statement, otherwise only the first condition would be executed due to lazy evaluation
 			markerAccepted := a.setMarkerAccepted(marker)
 			markerConfirmed := a.setMarkerConfirmed(marker)
@@ -213,7 +213,7 @@ func (a *Gadget) tryConfirmOrAccept(totalWeight int64, marker markers.Marker) (b
 				return a.propagateAcceptanceConfirmation(marker, true)
 			}
 		}
-	} else if IsThresholdReached(a.tangle.Validators.TotalWeight(), markerVoters.TotalWeight(), a.optsMarkerAcceptanceThreshold) && a.setMarkerAccepted(marker) {
+	} else if IsThresholdReached(a.tangle.Validators.TotalWeight(), markerTotalWeight, a.optsMarkerAcceptanceThreshold) && a.setMarkerAccepted(marker) {
 		return a.propagateAcceptanceConfirmation(marker, false)
 	}
 
@@ -421,8 +421,7 @@ func (a *Gadget) registerBlock(virtualVotingBlock *virtualvoting.Block) (block *
 // region Conflict Acceptance //////////////////////////////////////////////////////////////////////////////////////////
 
 func (a *Gadget) RefreshConflictAcceptance(conflictID utxo.TransactionID) {
-	conflictVoters := a.tangle.VirtualVoting.ConflictVoters(conflictID)
-	conflictWeight := conflictVoters.TotalWeight()
+	conflictWeight := a.tangle.VirtualVoting.ConflictVotersTotalWeight(conflictID)
 
 	if !IsThresholdReached(a.tangle.Validators.TotalWeight(), conflictWeight, a.optsConflictAcceptanceThreshold) {
 		return
@@ -439,10 +438,10 @@ func (a *Gadget) RefreshConflictAcceptance(conflictID utxo.TransactionID) {
 			otherAcceptedConflict = conflictingConflictID
 		}
 
-		conflictingConflictVoters := a.tangle.VirtualVoting.ConflictVoters(conflictingConflictID)
+		conflictingConflictWeight := a.tangle.VirtualVoting.ConflictVotersTotalWeight(conflictingConflictID)
 
 		// if the conflict is less than 66% ahead, then don't mark as accepted
-		if conflictingConflictWeight := conflictingConflictVoters.TotalWeight(); !IsThresholdReached(a.tangle.Validators.TotalWeight(), conflictWeight-conflictingConflictWeight, a.optsConflictAcceptanceThreshold) {
+		if !IsThresholdReached(a.tangle.Validators.TotalWeight(), conflictWeight-conflictingConflictWeight, a.optsConflictAcceptanceThreshold) {
 			markAsAccepted = false
 		}
 

--- a/packages/protocol/engine/consensus/consensus.go
+++ b/packages/protocol/engine/consensus/consensus.go
@@ -9,7 +9,6 @@ import (
 	"github.com/iotaledger/goshimmer/packages/protocol/engine/consensus/epochgadget"
 	"github.com/iotaledger/goshimmer/packages/protocol/engine/eviction"
 	"github.com/iotaledger/goshimmer/packages/protocol/engine/tangle"
-	"github.com/iotaledger/goshimmer/packages/protocol/ledger/utxo"
 )
 
 // region Consensus ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -29,9 +28,7 @@ func New(tangleInstance *tangle.Tangle, evictionState *eviction.State, lastConfi
 	return options.Apply(new(Consensus), opts, func(c *Consensus) {
 		c.BlockGadget = blockgadget.New(tangleInstance, evictionState, totalWeightCallback, c.optsAcceptanceGadget...)
 		c.EpochGadget = epochgadget.New(tangleInstance, lastConfirmedEpoch, totalWeightCallback, c.optsEpochConfirmationGadget...)
-		c.ConflictResolver = conflictresolver.New(tangleInstance.Ledger.ConflictDAG, func(conflictID utxo.TransactionID) (weight int64) {
-			return tangleInstance.VirtualVoting.ConflictVoters(conflictID).TotalWeight()
-		})
+		c.ConflictResolver = conflictresolver.New(tangleInstance.Ledger.ConflictDAG, tangleInstance.VirtualVoting.ConflictVotersTotalWeight)
 
 		c.Events = NewEvents()
 		c.Events.BlockGadget = c.BlockGadget.Events

--- a/packages/protocol/engine/consensus/epochgadget/gadget.go
+++ b/packages/protocol/engine/consensus/epochgadget/gadget.go
@@ -44,7 +44,7 @@ func (g *Gadget) LastConfirmedEpoch() epoch.Index {
 }
 
 func (g *Gadget) setup() {
-	g.tangle.VirtualVoting.Events.EpochTracker.VotersUpdated.Attach(event.NewClosure[*epochtracker.VoterUpdatedEvent](func(evt *epochtracker.VoterUpdatedEvent) {
+	g.tangle.VirtualVoting.Events.EpochTracker.VotersUpdated.Attach(event.NewClosure(func(evt *epochtracker.VoterUpdatedEvent) {
 		g.refreshEpochConfirmation(evt.PrevLatestEpochIndex, evt.NewLatestEpochIndex)
 	}))
 }
@@ -55,7 +55,7 @@ func (g *Gadget) refreshEpochConfirmation(previousLatestEpochIndex epoch.Index, 
 	totalWeight := g.totalWeightCallback()
 
 	for i := lo.Max(g.lastConfirmedEpoch, previousLatestEpochIndex) + 1; i <= newLatestEpochIndex; i++ {
-		if !IsThresholdReached(totalWeight, g.tangle.VirtualVoting.EpochVoters(i).TotalWeight(), g.optsEpochConfirmationThreshold) {
+		if !IsThresholdReached(totalWeight, g.tangle.VirtualVoting.EpochVotersTotalWeight(i), g.optsEpochConfirmationThreshold) {
 			break
 		}
 		g.lastConfirmedEpoch = i

--- a/packages/protocol/engine/tangle/virtualvoting/testframewok.go
+++ b/packages/protocol/engine/tangle/virtualvoting/testframewok.go
@@ -117,6 +117,7 @@ func (t *TestFramework) Identities(aliases ...string) (identities *set.AdvancedS
 func (t *TestFramework) ValidateMarkerVoters(expectedVoters map[markers.Marker]*set.AdvancedSet[identity.ID]) {
 	for marker, expectedVotersOfMarker := range expectedVoters {
 		voters := t.SequenceTracker.Voters(marker)
+		defer voters.Detach()
 
 		assert.True(t.test, expectedVotersOfMarker.Equal(voters.Members()), "marker %s expected %d voters but got %d", marker, expectedVotersOfMarker.Size(), voters.Members().Size())
 	}
@@ -125,6 +126,7 @@ func (t *TestFramework) ValidateMarkerVoters(expectedVoters map[markers.Marker]*
 func (t *TestFramework) ValidateConflictVoters(expectedVoters map[utxo.TransactionID]*set.AdvancedSet[identity.ID]) {
 	for conflictID, expectedVotersOfMarker := range expectedVoters {
 		voters := t.ConflictTracker.Voters(conflictID)
+		voters.Detach()
 
 		assert.True(t.test, expectedVotersOfMarker.Equal(voters.Members()), "conflict %s expected %d voters but got %d", conflictID, expectedVotersOfMarker.Size(), voters.Members().Size())
 	}

--- a/plugins/dagsvisualizer/visualizer.go
+++ b/plugins/dagsvisualizer/visualizer.go
@@ -206,12 +206,11 @@ func registerConflictEvents() {
 
 	conflictWeightChangedClosure := event.NewClosure(func(e *conflicttracker.VoterEvent[utxo.TransactionID]) {
 		conflictConfirmationState := deps.Protocol.Engine().Ledger.ConflictDAG.ConfirmationState(utxo.NewTransactionIDs(e.ConflictID))
-		voters := deps.Protocol.Engine().Tangle.VirtualVoting.ConflictVoters(e.ConflictID)
 		wsBlk := &wsBlock{
 			Type: BlkTypeConflictWeightChanged,
 			Data: &conflictWeightChanged{
 				ID:                e.ConflictID.Base58(),
-				Weight:            voters.TotalWeight(),
+				Weight:            deps.Protocol.Engine().Tangle.VirtualVoting.ConflictVotersTotalWeight(e.ConflictID),
 				ConfirmationState: conflictConfirmationState.String(),
 			},
 		}
@@ -390,7 +389,7 @@ func newConflictVertex(conflictID utxo.TransactionID) (ret *conflictVertex) {
 			Conflicts:         jsonmodels.NewGetConflictConflictsResponse(conflict.ID(), conflicts),
 			IsConfirmed:       confirmationState.IsAccepted(),
 			ConfirmationState: confirmationState.String(),
-			AW:                deps.Protocol.Engine().Tangle.VirtualVoting.ConflictVoters(conflictID).TotalWeight(),
+			AW:                deps.Protocol.Engine().Tangle.VirtualVoting.ConflictVotersTotalWeight(conflictID),
 		}
 	})
 	return

--- a/plugins/webapi/ledgerstate/plugin.go
+++ b/plugins/webapi/ledgerstate/plugin.go
@@ -277,7 +277,7 @@ func GetConflict(c echo.Context) (err error) {
 	}
 
 	if deps.Protocol.Engine().Ledger.ConflictDAG.Storage.CachedConflict(conflictID).Consume(func(conflict *conflictdag.Conflict[utxo.TransactionID, utxo.OutputID]) {
-		err = c.JSON(http.StatusOK, jsonmodels.NewConflictWeight(conflict, conflict.ConfirmationState(), deps.Protocol.Engine().Tangle.ConflictVoters(conflictID).TotalWeight()))
+		err = c.JSON(http.StatusOK, jsonmodels.NewConflictWeight(conflict, conflict.ConfirmationState(), deps.Protocol.Engine().Tangle.ConflictVotersTotalWeight(conflictID)))
 	}) {
 		return
 	}
@@ -342,7 +342,10 @@ func GetConflictVoters(c echo.Context) (err error) {
 		return c.JSON(http.StatusBadRequest, jsonmodels.NewErrorResponse(err))
 	}
 
-	return c.JSON(http.StatusOK, jsonmodels.NewGetConflictVotersResponse(conflictID, deps.Protocol.Engine().Tangle.ConflictVoters(conflictID)))
+	voters := deps.Protocol.Engine().Tangle.ConflictVoters(conflictID)
+	defer voters.Detach()
+
+	return c.JSON(http.StatusOK, jsonmodels.NewGetConflictVotersResponse(conflictID, voters))
 }
 
 // endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
# Description of change

Every time a new WeightedSet is returned, we have to make sure we call Detach() before the object falls out of scope to avoid memory leaks.