### PR TITLE
Using callbacks between the Neighbor and the Manager instead of triggering Events

### DIFF
--- a/packages/network/p2p/events.go
+++ b/packages/network/p2p/events.go
@@ -2,8 +2,6 @@ package p2p
 
 import (
 	"github.com/iotaledger/hive.go/core/generics/event"
-	"github.com/libp2p/go-libp2p/core/protocol"
-	"google.golang.org/protobuf/proto"
 )
 
 // NeighborGroupEvents is a collection of events specific for a particular neighbors group, e.g "manual" or "auto".
@@ -31,29 +29,4 @@ type NeighborAddedEvent struct {
 // NeighborRemovedEvent holds data about the removed neighbor.
 type NeighborRemovedEvent struct {
 	Neighbor *Neighbor
-}
-
-// NeighborEvents is a collection of events specific to a neighbor.
-type NeighborEvents struct {
-	// Fired when a neighbor disconnects.
-	Disconnected   *event.Event[*NeighborDisconnectedEvent]
-	PacketReceived *event.Event[*NeighborPacketReceivedEvent]
-}
-
-// NewNeighborEvents returns a new instance of NeighborEvents.
-func NewNeighborEvents() (new *NeighborEvents) {
-	return &NeighborEvents{
-		Disconnected:   event.New[*NeighborDisconnectedEvent](),
-		PacketReceived: event.New[*NeighborPacketReceivedEvent](),
-	}
-}
-
-// NeighborDisconnectedEvent holds data about the disconnected neighbor.
-type NeighborDisconnectedEvent struct{}
-
-// NeighborPacketReceivedEvent holds data about a protocol and packet received from a neighbor.
-type NeighborPacketReceivedEvent struct {
-	Neighbor *Neighbor
-	Protocol protocol.ID
-	Packet   proto.Message
 }

--- a/packages/network/p2p/manager.go
+++ b/packages/network/p2p/manager.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/iotaledger/hive.go/core/autopeering/peer"
-	"github.com/iotaledger/hive.go/core/generics/event"
 	"github.com/iotaledger/hive.go/core/identity"
 	"github.com/iotaledger/hive.go/core/logger"
 	"github.com/libp2p/go-libp2p/core/host"
@@ -247,7 +246,21 @@ func (m *Manager) addNeighbor(ctx context.Context, p *peer.Peer, group Neighbors
 	}
 
 	// create and add the neighbor
-	nbr := NewNeighbor(p, group, streams, m.log)
+	nbr := NewNeighbor(p, group, streams, m.log, func(nbr *Neighbor, protocol protocol.ID, packet proto.Message) {
+		m.registeredProtocolsMutex.RLock()
+		defer m.registeredProtocolsMutex.RUnlock()
+
+		protocolHandler, isRegistered := m.registeredProtocols[protocol]
+		if !isRegistered {
+			nbr.Log.Errorw("Can't handle packet as the protocol is not registered", "protocol", protocol, "err", err)
+		}
+		if err := protocolHandler.PacketHandler(nbr.ID(), packet); err != nil {
+			nbr.Log.Debugw("Can't handle packet", "err", err)
+		}
+	}, func(nbr *Neighbor) {
+		m.deleteNeighbor(nbr)
+		m.NeighborGroupEvents(nbr.Group).NeighborRemoved.Trigger(&NeighborRemovedEvent{nbr})
+	})
 	if err := m.setNeighbor(nbr); err != nil {
 		for _, ps := range streams {
 			if resetErr := ps.Close(); resetErr != nil {
@@ -256,22 +269,6 @@ func (m *Manager) addNeighbor(ctx context.Context, p *peer.Peer, group Neighbors
 		}
 		return errors.WithStack(err)
 	}
-	nbr.Events.Disconnected.Hook(event.NewClosure(func(_ *NeighborDisconnectedEvent) {
-		m.deleteNeighbor(nbr)
-		m.NeighborGroupEvents(nbr.Group).NeighborRemoved.Trigger(&NeighborRemovedEvent{nbr})
-	}))
-	nbr.Events.PacketReceived.Attach(event.NewClosure(func(event *NeighborPacketReceivedEvent) {
-		m.registeredProtocolsMutex.RLock()
-		defer m.registeredProtocolsMutex.RUnlock()
-
-		protocolHandler, isRegistered := m.registeredProtocols[event.Protocol]
-		if !isRegistered {
-			nbr.Log.Errorw("Can't handle packet as the protocol is not registered", "protocol", event.Protocol, "err", err)
-		}
-		if err := protocolHandler.PacketHandler(event.Neighbor.ID(), event.Packet); err != nil {
-			nbr.Log.Debugw("Can't handle packet", "err", err)
-		}
-	}))
 	nbr.readLoop()
 	nbr.writeLoop()
 	nbr.Log.Info("Connection established")

--- a/packages/network/p2p/neighbor_test.go
+++ b/packages/network/p2p/neighbor_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/iotaledger/hive.go/core/autopeering/peer"
 	"github.com/iotaledger/hive.go/core/autopeering/peer/service"
 	"github.com/iotaledger/hive.go/core/crypto/ed25519"
-	"github.com/iotaledger/hive.go/core/generics/event"
 	"github.com/iotaledger/hive.go/core/identity"
 	"github.com/iotaledger/hive.go/core/logger"
 	"github.com/libp2p/go-libp2p/core/network"
@@ -51,23 +50,20 @@ func TestNeighborWrite(t *testing.T) {
 	a, b, teardown := libp2ptesting.NewStreamsPipe(t)
 	defer teardown()
 
-	neighborA := newTestNeighbor("A", a)
-	defer neighborA.disconnect()
 	var countA uint32
-	neighborA.Events.PacketReceived.Hook(event.NewClosure(func(event *NeighborPacketReceivedEvent) {
-		_ = event.Packet.(*p2pproto.Negotiation)
+	neighborA := newTestNeighbor("A", a, func(neighbor *Neighbor, protocol protocol.ID, packet proto.Message) {
+		_ = packet.(*p2pproto.Negotiation)
 		atomic.AddUint32(&countA, 1)
-	}))
+	})
+	defer neighborA.disconnect()
 	neighborA.readLoop()
 
-	neighborB := newTestNeighbor("B", b)
-	defer neighborB.disconnect()
-
 	var countB uint32
-	neighborB.Events.PacketReceived.Hook(event.NewClosure(func(event *NeighborPacketReceivedEvent) {
-		_ = event.Packet.(*p2pproto.Negotiation)
+	neighborB := newTestNeighbor("B", b, func(neighbor *Neighbor, protocol protocol.ID, packet proto.Message) {
+		_ = packet.(*p2pproto.Negotiation)
 		atomic.AddUint32(&countB, 1)
-	}))
+	})
+	defer neighborB.disconnect()
 	neighborB.readLoop()
 
 	err := neighborA.protocols[protocolID].WritePacket(testPacket1)
@@ -79,8 +75,16 @@ func TestNeighborWrite(t *testing.T) {
 	assert.Eventually(t, func() bool { return atomic.LoadUint32(&countB) == 1 }, time.Second, 10*time.Millisecond)
 }
 
-func newTestNeighbor(name string, stream network.Stream) *Neighbor {
-	return NewNeighbor(newTestPeer(name), NeighborsGroupAuto, map[protocol.ID]*PacketsStream{protocolID: NewPacketsStream(stream, packetFactory)}, log.Named(name))
+func newTestNeighbor(name string, stream network.Stream, packetReceivedFunc ...PacketReceivedFunc) *Neighbor {
+
+	var packetReceived PacketReceivedFunc
+	if len(packetReceivedFunc) > 0 {
+		packetReceived = packetReceivedFunc[0]
+	} else {
+		packetReceived = func(neighbor *Neighbor, protocol protocol.ID, packet proto.Message) {}
+	}
+
+	return NewNeighbor(newTestPeer(name), NeighborsGroupAuto, map[protocol.ID]*PacketsStream{protocolID: NewPacketsStream(stream, packetFactory)}, log.Named(name), packetReceived, func(neighbor *Neighbor) {})
 }
 
 func packetFactory() proto.Message {


### PR DESCRIPTION
- There is no need to allocate events and tasks for every packet that we receive. Instead use callbacks directly