### PR TITLE
Improve db size metrics

### DIFF
--- a/deploy/ansible/roles/metrics/files/grafana/provisioning/dashboards/local_dashboard.json
+++ b/deploy/ansible/roles/metrics/files/grafana/provisioning/dashboards/local_dashboard.json
@@ -25,6 +25,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
+  "id": 7,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -357,10 +358,16 @@
       "pluginVersion": "9.2.6",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
           "exemplar": true,
-          "expr": "irate(tangle_blocks_per_component_count{component=\"Store\",instance=\"$instance\"}[5m])",
+          "expr": "irate(tangle_blocks_per_component_count{component=\"Attached\",instance=\"$instance\"}[5m])",
           "interval": "",
           "legendFormat": "Total BPS",
+          "range": true,
           "refId": "A"
         }
       ],
@@ -489,12 +496,10 @@
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
       },
-      "description": "Current CPU usage of the node.",
+      "description": "Size of the ledger database.",
       "fieldConfig": {
         "defaults": {
           "mappings": [],
-          "max": 100,
-          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -508,7 +513,7 @@
               }
             ]
           },
-          "unit": "percent"
+          "unit": "decmbytes"
         },
         "overrides": []
       },
@@ -518,7 +523,7 @@
         "x": 16,
         "y": 1
       },
-      "id": 53,
+      "id": 58,
       "options": {
         "colorMode": "value",
         "graphMode": "none",
@@ -537,13 +542,19 @@
       "pluginVersion": "9.2.6",
       "targets": [
         {
-          "expr": "process_cpu_usage{instance=\"$instance\"}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum(db_size{instance=\"$instance\"}) /1024/1024",
           "interval": "",
           "legendFormat": "",
+          "range": true,
           "refId": "A"
         }
       ],
-      "title": "CPU Usage",
+      "title": "Total Database Size",
       "type": "stat"
     },
     {
@@ -578,119 +589,7 @@
         "x": 18,
         "y": 1
       },
-      "id": 58,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.2.6",
-      "targets": [
-        {
-          "expr": "db_size_bytes{instance=\"$instance\"}/1024/1024",
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "title": "Database Size",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
-      "description": "Memory consumed by the node.",
-      "fieldConfig": {
-        "defaults": {
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "decmbytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 2,
-        "w": 2,
-        "x": 20,
-        "y": 1
-      },
-      "id": 20,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.2.6",
-      "targets": [
-        {
-          "expr": "process_mem_usage_bytes{instance=\"$instance\"}/1024/1024",
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "title": "Memory Consumption",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
-      "description": "Memory consumed by the node.",
-      "fieldConfig": {
-        "defaults": {
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 2,
-        "w": 2,
-        "x": 22,
-        "y": 1
-      },
-      "id": 150,
+      "id": 162,
       "options": {
         "colorMode": "value",
         "graphMode": "none",
@@ -713,14 +612,147 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "exemplar": true,
-          "expr": "up{instance=\"$instance\"}",
+          "editorMode": "code",
+          "expr": "sum(db_size{type=\"storage_permanent\", instance=\"$instance\"}) /1024/1024",
           "interval": "",
           "legendFormat": "",
+          "range": true,
           "refId": "A"
         }
       ],
-      "title": "Node up",
+      "title": "Permanent DB Size",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "Size of the ledger database.",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decmbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 20,
+        "y": 1
+      },
+      "id": 164,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.2.6",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum(db_size{type=\"storage_prunable\", instance=\"$instance\"}) /1024/1024",
+          "interval": "",
+          "legendFormat": "",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Prunable DB size",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "Size of the ledger database.",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decmbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 22,
+        "y": 1
+      },
+      "id": 163,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.2.6",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum(db_size{instance=\"$instance\", type=\"retainer\"}) /1024/1024",
+          "interval": "",
+          "legendFormat": "",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Retainer DB size",
       "type": "stat"
     },
     {
@@ -758,7 +790,7 @@
             "h": 11,
             "w": 11,
             "x": 0,
-            "y": 28
+            "y": 4
           },
           "hiddenSeries": false,
           "id": 32,
@@ -848,7 +880,7 @@
             "h": 11,
             "w": 13,
             "x": 11,
-            "y": 28
+            "y": 4
           },
           "hiddenSeries": false,
           "id": 111,
@@ -938,7 +970,7 @@
             "h": 10,
             "w": 11,
             "x": 0,
-            "y": 39
+            "y": 15
           },
           "hiddenSeries": false,
           "id": 52,
@@ -1025,7 +1057,7 @@
             "h": 8,
             "w": 13,
             "x": 11,
-            "y": 39
+            "y": 15
           },
           "hiddenSeries": false,
           "id": 4,
@@ -1117,7 +1149,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -1132,7 +1165,7 @@
             "h": 3,
             "w": 3,
             "x": 11,
-            "y": 47
+            "y": 23
           },
           "id": 6,
           "options": {
@@ -1150,7 +1183,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "expr": "autopeering_neighbor_connections_count{instance=\"$instance\"} - autopeering_neighbor_drop_count{instance=\"$instance\"}",
@@ -1175,7 +1208,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -1187,7 +1221,7 @@
             "h": 3,
             "w": 4,
             "x": 14,
-            "y": 47
+            "y": 23
           },
           "id": 2,
           "options": {
@@ -1205,7 +1239,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "expr": "autopeering_avg_neighbor_connection_lifetime{instance=\"$instance\"}",
@@ -1230,7 +1264,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -1245,7 +1280,7 @@
             "h": 3,
             "w": 3,
             "x": 18,
-            "y": 47
+            "y": 23
           },
           "id": 8,
           "options": {
@@ -1263,7 +1298,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "expr": "autopeering_neighbor_connections_count{instance=\"$instance\"}",
@@ -1288,7 +1323,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -1303,7 +1339,7 @@
             "h": 3,
             "w": 3,
             "x": 21,
-            "y": 47
+            "y": 23
           },
           "id": 10,
           "options": {
@@ -1321,7 +1357,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "expr": "autopeering_neighbor_drop_count{instance=\"$instance\"}",
@@ -1355,7 +1391,7 @@
             "h": 8,
             "w": 5,
             "x": 0,
-            "y": 49
+            "y": 25
           },
           "hiddenSeries": false,
           "id": 77,
@@ -1375,7 +1411,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.2.6",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1444,7 +1480,7 @@
             "h": 8,
             "w": 6,
             "x": 5,
-            "y": 49
+            "y": 25
           },
           "hiddenSeries": false,
           "id": 148,
@@ -1464,7 +1500,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.2.6",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1512,565 +1548,279 @@
           }
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
           "fieldConfig": {
             "defaults": {
-              "links": []
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "decbytes"
             },
             "overrides": []
           },
-          "fill": 1,
-          "fillGradient": 0,
           "gridPos": {
-            "h": 9,
-            "w": 7,
+            "h": 2,
+            "w": 2,
             "x": 11,
-            "y": 50
+            "y": 26
           },
-          "hiddenSeries": false,
-          "id": 16,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
+          "id": 59,
           "options": {
-            "alertThreshold": true
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "auto"
           },
-          "percentage": false,
-          "pluginVersion": "8.3.3",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
+          "pluginVersion": "9.2.6",
           "targets": [
             {
-              "expr": "process_cpu_usage{instance=\"$instance\"}",
-              "interval": "",
-              "legendFormat": "CPU Usage",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeRegions": [],
-          "title": "CPU Usage",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "percent",
-              "label": "",
-              "logBase": 1,
-              "max": "100",
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "links": []
-            },
-            "overrides": []
-          },
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 9,
-            "w": 6,
-            "x": 18,
-            "y": 50
-          },
-          "hiddenSeries": false,
-          "id": 18,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "8.3.3",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "process_mem_usage_bytes{instance=\"$instance\"}/1024/1024",
-              "interval": "",
-              "legendFormat": "Memory Consumption",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeRegions": [],
-          "title": "Memory Consumption",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "decmbytes",
-              "label": "",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "description": "Number of blocks in missingBlockStore. These are the block the node knows it doesn't have and tries to requests them.",
-          "fieldConfig": {
-            "defaults": {
-              "links": []
-            },
-            "overrides": []
-          },
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 8,
-            "w": 11,
-            "x": 0,
-            "y": 57
-          },
-          "hiddenSeries": false,
-          "id": 147,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "8.3.3",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "tangle_block_missing_count_db{instance=\"$instance\"}",
-              "interval": "",
-              "legendFormat": "Missing Blocks",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeRegions": [],
-          "title": "Missing Blocks",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "description": "Describes the amount of total, solid and not solid blocks in the node's database.",
-          "fieldConfig": {
-            "defaults": {
-              "links": []
-            },
-            "overrides": []
-          },
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 10,
-            "w": 13,
-            "x": 11,
-            "y": 59
-          },
-          "hiddenSeries": false,
-          "id": 73,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "8.3.3",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "exemplar": true,
-              "expr": "tangle_blocks_per_component_count{component=\"Solidifier\",instance=\"$instance\"}",
-              "interval": "",
-              "legendFormat": "Solid Blocks in DB",
-              "refId": "A"
-            },
-            {
-              "exemplar": true,
-              "expr": "tangle_blocks_per_component_count{component=\"Store\",instance=\"$instance\"} - tangle_blocks_per_component_count{component=\"Solidifier\",instance=\"$instance\"}",
-              "interval": "",
-              "legendFormat": "Not Solid Blocks in DB",
-              "refId": "B"
-            },
-            {
-              "exemplar": true,
-              "expr": "tangle_blocks_per_component_count{component=\"Store\",instance=\"$instance\"}",
-              "interval": "",
-              "legendFormat": "Total Blocks in DB",
-              "refId": "C"
-            }
-          ],
-          "thresholds": [],
-          "timeRegions": [],
-          "title": "Blocks in Database",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "description": "Number of blocks currently requested by the block tangle.",
-          "fieldConfig": {
-            "defaults": {
-              "links": []
-            },
-            "overrides": []
-          },
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 8,
-            "w": 11,
-            "x": 0,
-            "y": 65
-          },
-          "hiddenSeries": false,
-          "id": 69,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "8.3.3",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "exemplar": true,
-              "expr": "tangle_block_request_queue_size{instance=\"$instance\"}",
-              "interval": "",
-              "legendFormat": "Block Request Queue Size",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeRegions": [],
-          "title": "Block Request Queue Size",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "min": "0",
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "description": "Average time it takes to solidify blocks.",
-          "fieldConfig": {
-            "defaults": {
-              "links": [],
-              "unit": "ms"
-            },
-            "overrides": []
-          },
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 9,
-            "w": 13,
-            "x": 11,
-            "y": 69
-          },
-          "hiddenSeries": false,
-          "id": 75,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "8.3.3",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "exemplar": true,
-              "expr": "rate(tangle_block_total_time_since_received{component=\"Solidifier\",instance=\"$instance\"}[5m])/rate(tangle_blocks_per_component_count{component=\"Solidifier\",instance=\"$instance\"}[5m])",
-              "interval": "",
-              "legendFormat": "Avg Solidification Time",
-              "refId": "A"
-            },
-            {
-              "exemplar": true,
-              "expr": "",
-              "hide": false,
+              "expr": "traffic_analysis_outbound_bytes{instance=\"$instance\"}",
               "interval": "",
               "legendFormat": "",
-              "refId": "B"
+              "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
-          "title": "Average Solidification Time",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
+          "title": "Analysis",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
           },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "ms",
-              "logBase": 1,
-              "show": true
+          "fieldConfig": {
+            "defaults": {
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "decbytes"
             },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 2,
+            "w": 2,
+            "x": 13,
+            "y": 26
+          },
+          "id": 67,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.2.6",
+          "targets": [
             {
-              "format": "short",
-              "logBase": 1,
-              "show": true
+              "expr": "traffic_gossip_outbound_packets{instance=\"$instance\"}",
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
             }
           ],
-          "yaxis": {
-            "align": false
-          }
+          "title": "Gossip TX",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 2,
+            "w": 3,
+            "x": 15,
+            "y": 26
+          },
+          "id": 66,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.2.6",
+          "targets": [
+            {
+              "expr": "traffic_gossip_inbound_packets{instance=\"$instance\"}",
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Gossip RX",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 2,
+            "w": 3,
+            "x": 18,
+            "y": 26
+          },
+          "id": 63,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.2.6",
+          "targets": [
+            {
+              "expr": "traffic_autopeering_outbound_bytes{instance=\"$instance\"}",
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Autopeering TX",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 2,
+            "w": 3,
+            "x": 21,
+            "y": 26
+          },
+          "id": 62,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.2.6",
+          "targets": [
+            {
+              "expr": "traffic_autopeering_inbound_bytes{instance=\"$instance\"}",
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Autopeering RX",
+          "type": "stat"
         },
         {
           "aliasColors": {},
@@ -2091,9 +1841,9 @@
           "fillGradient": 0,
           "gridPos": {
             "h": 7,
-            "w": 11,
-            "x": 0,
-            "y": 73
+            "w": 13,
+            "x": 11,
+            "y": 28
           },
           "hiddenSeries": false,
           "id": 26,
@@ -2113,7 +1863,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.2.6",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2196,274 +1946,387 @@
           }
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
+          "description": "Number of blocks in missingBlockStore. These are the block the node knows it doesn't have and tries to requests them.",
           "fieldConfig": {
             "defaults": {
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  }
-                ]
-              },
-              "unit": "decbytes"
+              "links": []
             },
             "overrides": []
           },
+          "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
-            "h": 2,
-            "w": 2,
+            "h": 8,
+            "w": 11,
+            "x": 0,
+            "y": 33
+          },
+          "hiddenSeries": false,
+          "id": 147,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "9.2.6",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "tangle_block_missing_count_db{instance=\"$instance\"}",
+              "interval": "",
+              "legendFormat": "Missing Blocks",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Missing Blocks",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "description": "Describes the amount of total, solid and not solid blocks in the node's database.",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 13,
             "x": 11,
-            "y": 78
+            "y": 35
           },
-          "id": 59,
+          "hiddenSeries": false,
+          "id": 73,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {},
-            "textMode": "auto"
+            "alertThreshold": true
           },
-          "pluginVersion": "8.3.3",
+          "percentage": false,
+          "pluginVersion": "9.2.6",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
           "targets": [
             {
-              "expr": "traffic_analysis_outbound_bytes{instance=\"$instance\"}",
+              "exemplar": true,
+              "expr": "tangle_blocks_per_component_count{component=\"Solidifier\",instance=\"$instance\"}",
               "interval": "",
-              "legendFormat": "",
+              "legendFormat": "Solid Blocks in DB",
               "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "tangle_blocks_per_component_count{component=\"Store\",instance=\"$instance\"} - tangle_blocks_per_component_count{component=\"Solidifier\",instance=\"$instance\"}",
+              "interval": "",
+              "legendFormat": "Not Solid Blocks in DB",
+              "refId": "B"
+            },
+            {
+              "exemplar": true,
+              "expr": "tangle_blocks_per_component_count{component=\"Store\",instance=\"$instance\"}",
+              "interval": "",
+              "legendFormat": "Total Blocks in DB",
+              "refId": "C"
             }
           ],
-          "title": "Analysis",
-          "type": "stat"
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Blocks in Database",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "logBase": 1,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
+          "description": "Number of blocks currently requested by the block tangle.",
           "fieldConfig": {
             "defaults": {
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  }
-                ]
-              },
-              "unit": "decbytes"
+              "links": []
             },
             "overrides": []
           },
+          "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
-            "h": 2,
-            "w": 2,
-            "x": 13,
-            "y": 78
+            "h": 9,
+            "w": 11,
+            "x": 0,
+            "y": 41
           },
-          "id": 67,
+          "hiddenSeries": false,
+          "id": 69,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {},
-            "textMode": "auto"
+            "alertThreshold": true
           },
-          "pluginVersion": "8.3.3",
+          "percentage": false,
+          "pluginVersion": "9.2.6",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
           "targets": [
             {
-              "expr": "traffic_gossip_outbound_packets{instance=\"$instance\"}",
+              "exemplar": true,
+              "expr": "tangle_block_request_queue_size{instance=\"$instance\"}",
               "interval": "",
-              "legendFormat": "",
+              "legendFormat": "Block Request Queue Size",
               "refId": "A"
             }
           ],
-          "title": "Gossip TX",
-          "type": "stat"
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Block Request Queue Size",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "logBase": 1,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "min": "0",
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
+          "description": "Average time it takes to solidify blocks.",
           "fieldConfig": {
             "defaults": {
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  }
-                ]
-              },
-              "unit": "decbytes"
+              "links": [],
+              "unit": "ms"
             },
             "overrides": []
           },
+          "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
-            "h": 2,
-            "w": 3,
-            "x": 15,
-            "y": 78
+            "h": 8,
+            "w": 13,
+            "x": 11,
+            "y": 42
           },
-          "id": 66,
+          "hiddenSeries": false,
+          "id": 75,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {},
-            "textMode": "auto"
+            "alertThreshold": true
           },
-          "pluginVersion": "8.3.3",
+          "percentage": false,
+          "pluginVersion": "9.2.6",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
           "targets": [
             {
-              "expr": "traffic_gossip_inbound_packets{instance=\"$instance\"}",
+              "exemplar": true,
+              "expr": "rate(tangle_block_total_time_since_received{component=\"Solidifier\",instance=\"$instance\"}[5m])/rate(tangle_blocks_per_component_count{component=\"Solidifier\",instance=\"$instance\"}[5m])",
               "interval": "",
-              "legendFormat": "",
+              "legendFormat": "Avg Solidification Time",
               "refId": "A"
-            }
-          ],
-          "title": "Gossip RX",
-          "type": "stat"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  }
-                ]
-              },
-              "unit": "decbytes"
             },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 2,
-            "w": 3,
-            "x": 18,
-            "y": 78
-          },
-          "id": 63,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {},
-            "textMode": "auto"
-          },
-          "pluginVersion": "8.3.3",
-          "targets": [
             {
-              "expr": "traffic_autopeering_outbound_bytes{instance=\"$instance\"}",
+              "exemplar": true,
+              "expr": "",
+              "hide": false,
               "interval": "",
               "legendFormat": "",
-              "refId": "A"
+              "refId": "B"
             }
           ],
-          "title": "Autopeering TX",
-          "type": "stat"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Average Solidification Time",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
           },
-          "fieldConfig": {
-            "defaults": {
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  }
-                ]
-              },
-              "unit": "decbytes"
-            },
-            "overrides": []
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
           },
-          "gridPos": {
-            "h": 2,
-            "w": 3,
-            "x": 21,
-            "y": 78
-          },
-          "id": 62,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {},
-            "textMode": "auto"
-          },
-          "pluginVersion": "8.3.3",
-          "targets": [
+          "yaxes": [
             {
-              "expr": "traffic_autopeering_inbound_bytes{instance=\"$instance\"}",
-              "interval": "",
-              "legendFormat": "",
-              "refId": "A"
+              "format": "ms",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": true
             }
           ],
-          "title": "Autopeering RX",
-          "type": "stat"
+          "yaxis": {
+            "align": false
+          }
         }
       ],
       "title": "BPS, Autopeering, Traffic, Resources",
@@ -2496,7 +2359,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -2508,7 +2372,7 @@
             "h": 3,
             "w": 4,
             "x": 0,
-            "y": 89
+            "y": 5
           },
           "id": 85,
           "options": {
@@ -2526,7 +2390,7 @@
             "text": {},
             "textMode": "value_and_name"
           },
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "exemplar": true,
@@ -2561,7 +2425,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -2577,7 +2442,7 @@
             "h": 3,
             "w": 3,
             "x": 4,
-            "y": 89
+            "y": 5
           },
           "id": 101,
           "options": {
@@ -2595,7 +2460,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "exemplar": true,
@@ -2627,7 +2492,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -2639,7 +2505,7 @@
             "h": 3,
             "w": 4,
             "x": 7,
-            "y": 89
+            "y": 5
           },
           "id": 95,
           "options": {
@@ -2657,7 +2523,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "expr": "avg(mana_access{instance=\"$instance\"})",
@@ -2688,7 +2554,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -2700,7 +2567,7 @@
             "h": 3,
             "w": 3,
             "x": 11,
-            "y": 89
+            "y": 5
           },
           "id": 96,
           "options": {
@@ -2718,7 +2585,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "exemplar": true,
@@ -2751,7 +2618,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -2763,7 +2631,7 @@
             "h": 3,
             "w": 4,
             "x": 14,
-            "y": 89
+            "y": 5
           },
           "id": 109,
           "options": {
@@ -2781,7 +2649,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "expr": "mana_average_neighbors_access{instance=\"$instance\"}",
@@ -2823,7 +2691,7 @@
             "h": 15,
             "w": 6,
             "x": 18,
-            "y": 89
+            "y": 5
           },
           "hiddenSeries": false,
           "id": 89,
@@ -2844,7 +2712,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.2.6",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2918,7 +2786,7 @@
             "h": 12,
             "w": 9,
             "x": 0,
-            "y": 92
+            "y": 8
           },
           "hiddenSeries": false,
           "id": 98,
@@ -2940,7 +2808,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.2.6",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -3014,7 +2882,7 @@
             "h": 12,
             "w": 9,
             "x": 9,
-            "y": 92
+            "y": 8
           },
           "hiddenSeries": false,
           "id": 99,
@@ -3036,7 +2904,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.2.6",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -3111,7 +2979,7 @@
             "h": 9,
             "w": 8,
             "x": 0,
-            "y": 104
+            "y": 20
           },
           "hiddenSeries": false,
           "id": 83,
@@ -3133,7 +3001,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.2.6",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -3202,7 +3070,7 @@
             "h": 9,
             "w": 8,
             "x": 8,
-            "y": 104
+            "y": 20
           },
           "hiddenSeries": false,
           "id": 90,
@@ -3226,7 +3094,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.2.6",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -3298,7 +3166,7 @@
             "h": 9,
             "w": 8,
             "x": 16,
-            "y": 104
+            "y": 20
           },
           "id": 92,
           "links": [],
@@ -3320,7 +3188,8 @@
             },
             "text": {},
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "pluginVersion": "7.5.6",
@@ -3359,7 +3228,7 @@
             "h": 9,
             "w": 8,
             "x": 0,
-            "y": 113
+            "y": 29
           },
           "hiddenSeries": false,
           "id": 84,
@@ -3381,7 +3250,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.2.6",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -3450,7 +3319,7 @@
             "h": 9,
             "w": 8,
             "x": 8,
-            "y": 113
+            "y": 29
           },
           "hiddenSeries": false,
           "id": 91,
@@ -3474,7 +3343,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.2.6",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -3547,7 +3416,7 @@
             "h": 9,
             "w": 8,
             "x": 16,
-            "y": 113
+            "y": 29
           },
           "id": 93,
           "links": [],
@@ -3569,7 +3438,8 @@
             },
             "text": {},
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "pluginVersion": "7.1.1",
@@ -3604,9 +3474,9 @@
           "fillGradient": 0,
           "gridPos": {
             "h": 11,
-            "w": 9,
+            "w": 8,
             "x": 0,
-            "y": 122
+            "y": 38
           },
           "hiddenSeries": false,
           "id": 103,
@@ -3628,7 +3498,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.2.6",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -3701,9 +3571,9 @@
           "fillGradient": 0,
           "gridPos": {
             "h": 11,
-            "w": 7,
-            "x": 9,
-            "y": 122
+            "w": 8,
+            "x": 8,
+            "y": 38
           },
           "hiddenSeries": false,
           "id": 107,
@@ -3723,7 +3593,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.2.6",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -3790,9 +3660,9 @@
           "fillGradient": 0,
           "gridPos": {
             "h": 11,
-            "w": 7,
+            "w": 8,
             "x": 16,
-            "y": 122
+            "y": 38
           },
           "hiddenSeries": false,
           "id": 114,
@@ -3812,7 +3682,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.2.6",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -3879,9 +3749,9 @@
           "fillGradient": 0,
           "gridPos": {
             "h": 10,
-            "w": 9,
+            "w": 8,
             "x": 0,
-            "y": 133
+            "y": 49
           },
           "hiddenSeries": false,
           "id": 110,
@@ -3901,7 +3771,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.2.6",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -3988,7 +3858,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 38
+            "y": 106
           },
           "hiddenSeries": false,
           "id": 118,
@@ -4008,7 +3878,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.5.6",
+          "pluginVersion": "9.2.6",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -4080,7 +3950,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 38
+            "y": 106
           },
           "hiddenSeries": false,
           "id": 119,
@@ -4100,7 +3970,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.5.6",
+          "pluginVersion": "9.2.6",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -4159,17 +4029,13 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "fieldConfig": {
-            "defaults": {},
-            "overrides": []
-          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 46
+            "y": 114
           },
           "hiddenSeries": false,
           "id": 121,
@@ -4189,7 +4055,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.5.6",
+          "pluginVersion": "9.2.6",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -4252,7 +4118,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4267,7 +4134,7 @@
             "h": 4,
             "w": 6,
             "x": 12,
-            "y": 46
+            "y": 114
           },
           "id": 123,
           "options": {
@@ -4285,7 +4152,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "7.5.6",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "exemplar": true,
@@ -4314,7 +4181,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4329,7 +4197,7 @@
             "h": 4,
             "w": 6,
             "x": 18,
-            "y": 46
+            "y": 114
           },
           "id": 125,
           "options": {
@@ -4347,7 +4215,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "7.5.6",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "exemplar": true,
@@ -4376,7 +4244,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4391,7 +4260,7 @@
             "h": 4,
             "w": 6,
             "x": 12,
-            "y": 50
+            "y": 118
           },
           "id": 124,
           "options": {
@@ -4409,7 +4278,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "7.5.6",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "exemplar": true,
@@ -4438,7 +4307,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4453,7 +4323,7 @@
             "h": 4,
             "w": 6,
             "x": 18,
-            "y": 50
+            "y": 118
           },
           "id": 126,
           "options": {
@@ -4471,7 +4341,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "7.5.6",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "exemplar": true,
@@ -4519,7 +4389,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -4531,7 +4402,7 @@
             "h": 6,
             "w": 15,
             "x": 0,
-            "y": 39
+            "y": 123
           },
           "id": 146,
           "options": {
@@ -4549,7 +4420,7 @@
             "showUnfilled": true,
             "text": {}
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "exemplar": true,
@@ -4580,7 +4451,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -4592,7 +4464,7 @@
             "h": 3,
             "w": 3,
             "x": 15,
-            "y": 39
+            "y": 123
           },
           "id": 132,
           "options": {
@@ -4610,7 +4482,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "exemplar": true,
@@ -4639,7 +4511,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               }
@@ -4650,7 +4523,7 @@
             "h": 3,
             "w": 3,
             "x": 18,
-            "y": 39
+            "y": 123
           },
           "id": 142,
           "options": {
@@ -4668,7 +4541,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "exemplar": true,
@@ -4699,7 +4572,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               }
@@ -4710,7 +4584,7 @@
             "h": 3,
             "w": 3,
             "x": 21,
-            "y": 39
+            "y": 123
           },
           "id": 149,
           "options": {
@@ -4728,7 +4602,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "exemplar": true,
@@ -4758,7 +4632,8 @@
                 "mode": "percentage",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -4770,7 +4645,7 @@
             "h": 3,
             "w": 3,
             "x": 15,
-            "y": 42
+            "y": 126
           },
           "id": 143,
           "options": {
@@ -4788,7 +4663,7 @@
             "text": {},
             "textMode": "value"
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "exemplar": false,
@@ -4818,7 +4693,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               }
@@ -4829,7 +4705,7 @@
             "h": 3,
             "w": 3,
             "x": 18,
-            "y": 42
+            "y": 126
           },
           "id": 140,
           "options": {
@@ -4847,7 +4723,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "exemplar": true,
@@ -4876,7 +4752,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               }
@@ -4887,7 +4764,7 @@
             "h": 3,
             "w": 3,
             "x": 21,
-            "y": 42
+            "y": 126
           },
           "id": 154,
           "options": {
@@ -4905,7 +4782,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "datasource": {
@@ -4938,7 +4815,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -4950,7 +4828,7 @@
             "h": 6,
             "w": 15,
             "x": 0,
-            "y": 45
+            "y": 129
           },
           "id": 145,
           "options": {
@@ -4968,7 +4846,7 @@
             "showUnfilled": true,
             "text": {}
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "datasource": {
@@ -5005,7 +4883,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -5017,7 +4896,7 @@
             "h": 3,
             "w": 3,
             "x": 15,
-            "y": 45
+            "y": 129
           },
           "id": 130,
           "options": {
@@ -5035,7 +4914,7 @@
             "text": {},
             "textMode": "value"
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "exemplar": false,
@@ -5064,7 +4943,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               }
@@ -5075,7 +4955,7 @@
             "h": 3,
             "w": 3,
             "x": 18,
-            "y": 45
+            "y": 129
           },
           "id": 134,
           "options": {
@@ -5093,7 +4973,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "exemplar": true,
@@ -5122,7 +5002,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -5134,7 +5015,7 @@
             "h": 3,
             "w": 3,
             "x": 21,
-            "y": 45
+            "y": 129
           },
           "id": 153,
           "options": {
@@ -5152,7 +5033,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "datasource": {
@@ -5185,7 +5066,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               }
@@ -5196,7 +5078,7 @@
             "h": 3,
             "w": 3,
             "x": 15,
-            "y": 48
+            "y": 132
           },
           "id": 138,
           "options": {
@@ -5214,7 +5096,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "datasource": {
@@ -5262,7 +5144,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -5274,7 +5157,7 @@
             "h": 3,
             "w": 3,
             "x": 18,
-            "y": 48
+            "y": 132
           },
           "id": 151,
           "options": {
@@ -5292,7 +5175,7 @@
             "text": {},
             "textMode": "value"
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "datasource": {
@@ -5325,7 +5208,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               }
@@ -5336,7 +5220,7 @@
             "h": 3,
             "w": 3,
             "x": 21,
-            "y": 48
+            "y": 132
           },
           "id": 136,
           "options": {
@@ -5354,7 +5238,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "exemplar": true,
@@ -5383,7 +5267,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -5395,7 +5280,7 @@
             "h": 3,
             "w": 3,
             "x": 15,
-            "y": 51
+            "y": 135
           },
           "id": 152,
           "options": {
@@ -5413,7 +5298,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "datasource": {
@@ -5446,7 +5331,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -5458,7 +5344,7 @@
             "h": 3,
             "w": 3,
             "x": 18,
-            "y": 51
+            "y": 135
           },
           "id": 155,
           "options": {
@@ -5476,7 +5362,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "datasource": {
@@ -5499,7 +5385,7 @@
       "type": "row"
     },
     {
-      "collapsed": false,
+      "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -5507,162 +5393,163 @@
         "y": 7
       },
       "id": 157,
-      "panels": [],
-      "title": "Event loop",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 3,
-        "x": 0,
-        "y": 8
-      },
-      "id": 159,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.2.6",
-      "targets": [
+      "panels": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "editorMode": "code",
-          "expr": "workerpool_eventloop_workers{instance=\"$instance\"}",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Event loop workers",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
           },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
+          "gridPos": {
+            "h": 9,
+            "w": 3,
+            "x": 0,
+            "y": 139
+          },
+          "id": 159,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
             },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.2.6",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "workerpool_eventloop_workers{instance=\"$instance\"}",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Event loop workers",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
             },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 21,
+            "x": 3,
+            "y": 139
+          },
+          "id": 161,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
             },
-            "thresholdsStyle": {
-              "mode": "off"
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
             }
           },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
               },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 21,
-        "x": 3,
-        "y": 8
-      },
-      "id": 161,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "editorMode": "code",
-          "expr": "workerpool_eventloop_tasks_pending{instance=\"$instance\"}",
-          "legendFormat": "{{instance}}",
-          "range": true,
-          "refId": "A"
+              "editorMode": "code",
+              "expr": "workerpool_eventloop_tasks_pending{instance=\"$instance\"}",
+              "legendFormat": "{{instance}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Event loop pending tasks",
+          "type": "timeseries"
         }
       ],
-      "title": "Event loop pending tasks",
-      "type": "timeseries"
+      "title": "Event loop",
+      "type": "row"
     }
   ],
   "refresh": "10s",
@@ -5674,8 +5561,8 @@
       {
         "current": {
           "selected": false,
-          "text": "node-05.feature.shimmer.iota.cafe:9311",
-          "value": "node-05.feature.shimmer.iota.cafe:9311"
+          "text": "faucet:9311",
+          "value": "faucet:9311"
         },
         "datasource": {
           "type": "prometheus",
@@ -5704,8 +5591,8 @@
       {
         "current": {
           "selected": false,
-          "text": "EUq4re4s",
-          "value": "EUq4re4s"
+          "text": "GbkZ3Coi",
+          "value": "GbkZ3Coi"
         },
         "datasource": {
           "type": "prometheus",
@@ -5753,6 +5640,6 @@
   "timezone": "",
   "title": "GoShimmer Local Metrics",
   "uid": "R-T27yW7k",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }

--- a/packages/app/retainer/retainer.go
+++ b/packages/app/retainer/retainer.go
@@ -89,7 +89,7 @@ func (r *Retainer) Stream(index epoch.Index, callback func(id models.BlockID, me
 	})
 }
 
-// DatabaseSize returns the size of the underlying databases
+// DatabaseSize returns the size of the underlying databases.
 func (r *Retainer) DatabaseSize() int64 {
 	return r.dbManager.TotalStorageSize()
 }

--- a/packages/app/retainer/retainer.go
+++ b/packages/app/retainer/retainer.go
@@ -89,6 +89,11 @@ func (r *Retainer) Stream(index epoch.Index, callback func(id models.BlockID, me
 	})
 }
 
+// DatabaseSize returns the size of the underlying databases
+func (r *Retainer) DatabaseSize() int64 {
+	return r.dbManager.TotalStorageSize()
+}
+
 // PruneUntilEpoch prunes storage epochs less than and equal to the given index.
 func (r *Retainer) PruneUntilEpoch(epochIndex epoch.Index) {
 	r.dbManager.PruneUntilEpoch(epochIndex)

--- a/packages/core/database/manager.go
+++ b/packages/core/database/manager.go
@@ -1,8 +1,7 @@
 package database
 
 import (
-	"io/fs"
-	"io/ioutil"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -392,20 +391,20 @@ type dbInstanceFileInfo struct {
 }
 
 func getSortedDBInstancesFromDisk(baseDir string) (dbInfos []*dbInstanceFileInfo) {
-	files, err := ioutil.ReadDir(baseDir)
+	files, err := os.ReadDir(baseDir)
 	if err != nil {
 		panic(err)
 	}
 
-	files = lo.Filter(files, func(f fs.FileInfo) bool { return f.IsDir() })
-	dbInfos = lo.Map(files, func(f fs.FileInfo) *dbInstanceFileInfo {
-		atoi, convErr := strconv.Atoi(f.Name())
+	files = lo.Filter(files, func(e os.DirEntry) bool { return e.IsDir() })
+	dbInfos = lo.Map(files, func(e os.DirEntry) *dbInstanceFileInfo {
+		atoi, convErr := strconv.Atoi(e.Name())
 		if convErr != nil {
 			return nil
 		}
 		return &dbInstanceFileInfo{
 			baseIndex: epoch.Index(atoi),
-			path:      filepath.Join(baseDir, f.Name()),
+			path:      filepath.Join(baseDir, e.Name()),
 		}
 	})
 	dbInfos = lo.Filter(dbInfos, func(info *dbInstanceFileInfo) bool { return info != nil })

--- a/packages/core/database/manager.go
+++ b/packages/core/database/manager.go
@@ -234,10 +234,12 @@ func (m *Manager) Shutdown() {
 	}
 }
 
+// TotalStorageSize returns the combined size of the permanent and prunable storage.
 func (m *Manager) TotalStorageSize() int64 {
 	return m.PermanentStorageSize() + m.PrunableStorageSize()
 }
 
+// PermanentStorageSize returns the size of the permanent storage.
 func (m *Manager) PermanentStorageSize() int64 {
 	size, err := dbDirectorySize(m.permanentBaseDir)
 	if err != nil {
@@ -247,6 +249,7 @@ func (m *Manager) PermanentStorageSize() int64 {
 	return size
 }
 
+// PrunableStorageSize returns the size of the prunable storage containing all db instances.
 func (m *Manager) PrunableStorageSize() int64 {
 	m.openDBsMutex.Lock()
 	defer m.openDBsMutex.Unlock()

--- a/packages/core/database/manager.go
+++ b/packages/core/database/manager.go
@@ -14,6 +14,7 @@ import (
 	"github.com/iotaledger/hive.go/core/byteutils"
 	"github.com/iotaledger/hive.go/core/generics/lo"
 	"github.com/iotaledger/hive.go/core/generics/options"
+	"github.com/iotaledger/hive.go/core/generics/shrinkingmap"
 	"github.com/iotaledger/hive.go/core/kvstore"
 
 	"github.com/iotaledger/goshimmer/packages/core/epoch"
@@ -27,6 +28,7 @@ type Manager struct {
 
 	openDBs         *cache.Cache[epoch.Index, *dbInstance]
 	bucketedBaseDir string
+	dbSizes         *shrinkingmap.ShrinkingMap[epoch.Index, int64]
 	openDBsMutex    sync.Mutex
 
 	maxPruned      epoch.Index
@@ -61,7 +63,15 @@ func NewManager(version Version, opts ...options.Option[Manager]) *Manager {
 			if err != nil {
 				panic(err)
 			}
+			size, err := dbPrunableDirectorySize(m.bucketedBaseDir, baseIndex)
+			if err != nil {
+				panic(err)
+			}
+
+			m.dbSizes.Set(baseIndex, size)
 		})
+
+		m.dbSizes = shrinkingmap.New[epoch.Index, int64]()
 	})
 
 	if err := m.checkVersion(version); err != nil {
@@ -103,6 +113,14 @@ func (m *Manager) RestoreFromDisk() (latestBucketIndex epoch.Index) {
 	dbInfos := getSortedDBInstancesFromDisk(m.bucketedBaseDir)
 
 	// TODO: what to do if dbInfos is empty? -> start with a fresh DB?
+
+	for _, dbInfo := range dbInfos {
+		size, err := dbPrunableDirectorySize(m.bucketedBaseDir, dbInfo.baseIndex)
+		if err != nil {
+			panic(err)
+		}
+		m.dbSizes.Set(dbInfo.baseIndex, size)
+	}
 
 	m.maxPrunedMutex.Lock()
 	m.maxPruned = dbInfos[len(dbInfos)-1].baseIndex - 1
@@ -216,6 +234,43 @@ func (m *Manager) Shutdown() {
 	}
 }
 
+func (m *Manager) TotalStorageSize() int64 {
+	return m.PermanentStorageSize() + m.PrunableStorageSize()
+}
+
+func (m *Manager) PermanentStorageSize() int64 {
+	size, err := dbDirectorySize(m.permanentBaseDir)
+	if err != nil {
+		fmt.Println("dbDirectorySize failed for", m.permanentBaseDir, ":", err)
+		return 0
+	}
+	return size
+}
+
+func (m *Manager) PrunableStorageSize() int64 {
+	m.openDBsMutex.Lock()
+	defer m.openDBsMutex.Unlock()
+
+	// Sum up all the evicted databases
+	var sum int64
+	m.dbSizes.ForEach(func(index epoch.Index, i int64) bool {
+		sum += i
+		return true
+	})
+
+	// Add up all the open databases
+	m.openDBs.Each(func(key epoch.Index, val *dbInstance) {
+		size, err := dbPrunableDirectorySize(m.bucketedBaseDir, key)
+		if err != nil {
+			fmt.Println("dbPrunableDirectorySize failed for", m.bucketedBaseDir, key, ":", err)
+			return
+		}
+		size += sum
+	})
+
+	return sum
+}
+
 // getDBInstance returns the DB instance for the given baseIndex or creates a new one if it does not yet exist.
 // DBs are created as follows where each db is located in m.basedir/<starting baseIndex>/
 // (assuming a bucket granularity=2):
@@ -231,6 +286,9 @@ func (m *Manager) getDBInstance(index epoch.Index) (db *dbInstance) {
 	db, exists := m.openDBs.Get(baseIndex)
 	if !exists {
 		db = m.createDBInstance(baseIndex)
+
+		// Remove the cached db size since we will open the db
+		m.dbSizes.Delete(baseIndex)
 		m.openDBs.Put(baseIndex, db)
 	}
 
@@ -304,6 +362,9 @@ func (m *Manager) removeDBInstance(dbBaseIndex epoch.Index) {
 	if err := os.RemoveAll(dbPathFromIndex(m.bucketedBaseDir, dbBaseIndex)); err != nil {
 		panic(err)
 	}
+
+	// Delete the db size since we pruned the whole directory
+	m.dbSizes.Delete(dbBaseIndex)
 }
 
 func (m *Manager) removeBucket(bucket kvstore.KVStore) {
@@ -414,6 +475,24 @@ func getSortedDBInstancesFromDisk(baseDir string) (dbInfos []*dbInstanceFileInfo
 	})
 
 	return dbInfos
+}
+
+func dbPrunableDirectorySize(base string, index epoch.Index) (int64, error) {
+	return dbDirectorySize(dbPathFromIndex(base, index))
+}
+
+func dbDirectorySize(path string) (int64, error) {
+	var size int64
+	err := filepath.Walk(path, func(_ string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			size += info.Size()
+		}
+		return err
+	})
+	return size, err
 }
 
 // endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/packages/core/database/manager.go
+++ b/packages/core/database/manager.go
@@ -265,7 +265,7 @@ func (m *Manager) PrunableStorageSize() int64 {
 			fmt.Println("dbPrunableDirectorySize failed for", m.bucketedBaseDir, key, ":", err)
 			return
 		}
-		size += sum
+		sum += size
 	})
 
 	return sum

--- a/packages/core/database/manager_test.go
+++ b/packages/core/database/manager_test.go
@@ -23,6 +23,8 @@ func TestManager_Get(t *testing.T) {
 
 	m := NewManager(1, WithGranularity(granularity), WithDBProvider(NewDB), WithBaseDir(baseDir), WithMaxOpenDBs(2))
 
+	dbSize := m.PrunableStorageSize()
+
 	// Create and write data to buckets.
 	{
 		for i := granularity; i < bucketsCount; i++ {
@@ -41,6 +43,9 @@ func TestManager_Get(t *testing.T) {
 			}
 		}
 	}
+
+	// dbSize should have increased with new buckets
+	assert.Greater(t, m.PrunableStorageSize(), dbSize)
 
 	// Read data from buckets.
 	{
@@ -84,6 +89,8 @@ func TestManager_Get(t *testing.T) {
 		assert.ElementsMatch(t, expected, actual)
 	}
 
+	dbSize = m.PrunableStorageSize()
+
 	// Prune some stuff.
 	expectedFirstBucket := epoch.Index(5) + 1
 	{
@@ -107,6 +114,9 @@ func TestManager_Get(t *testing.T) {
 			}
 		}
 	}
+
+	// After pruning the dbSize should be smaller
+	assert.Less(t, m.PrunableStorageSize(), dbSize)
 
 	// Insert into buckets but DO NOT mark as clean. When restoring from disk they should not be healthy and thus be
 	// deleted.

--- a/packages/protocol/protocol.go
+++ b/packages/protocol/protocol.go
@@ -259,6 +259,7 @@ func (p *Protocol) CandidateEngine() (instance *engine.Engine) {
 	return p.candidateEngine
 }
 
+// MainStorage returns the underlying storage of the main chain.
 func (p *Protocol) MainStorage() (mainStorage *storage.Storage) {
 	return p.storage
 }

--- a/packages/protocol/protocol.go
+++ b/packages/protocol/protocol.go
@@ -259,6 +259,10 @@ func (p *Protocol) CandidateEngine() (instance *engine.Engine) {
 	return p.candidateEngine
 }
 
+func (p *Protocol) MainStorage() (mainStorage *storage.Storage) {
+	return p.storage
+}
+
 func (p *Protocol) CandidateStorage() (chainstorage *storage.Storage) {
 	p.activeEngineMutex.RLock()
 	defer p.activeEngineMutex.RUnlock()

--- a/packages/storage/permanent/commitments.go
+++ b/packages/storage/permanent/commitments.go
@@ -9,7 +9,8 @@ import (
 )
 
 type Commitments struct {
-	slice *storable.Slice[commitment.Commitment, *commitment.Commitment]
+	slice    *storable.Slice[commitment.Commitment, *commitment.Commitment]
+	filePath string
 }
 
 func NewCommitments(path string) (newCommitment *Commitments) {
@@ -19,7 +20,8 @@ func NewCommitments(path string) (newCommitment *Commitments) {
 	}
 
 	return &Commitments{
-		slice: commitmentsSlice,
+		slice:    commitmentsSlice,
+		filePath: path,
 	}
 }
 
@@ -41,4 +43,9 @@ func (c *Commitments) Load(index epoch.Index) (commitment *commitment.Commitment
 
 func (c *Commitments) Close() (err error) {
 	return c.slice.Close()
+}
+
+// FilePath returns the path that this is associated to.
+func (s *Commitments) FilePath() (filePath string) {
+	return s.filePath
 }

--- a/packages/storage/permanent/commitments.go
+++ b/packages/storage/permanent/commitments.go
@@ -46,6 +46,6 @@ func (c *Commitments) Close() (err error) {
 }
 
 // FilePath returns the path that this is associated to.
-func (s *Commitments) FilePath() (filePath string) {
-	return s.filePath
+func (c *Commitments) FilePath() (filePath string) {
+	return c.filePath
 }

--- a/packages/storage/permanent/permanent.go
+++ b/packages/storage/permanent/permanent.go
@@ -34,6 +34,7 @@ func New(disk *diskutil.DiskUtil, database *database.Manager) (p *Permanent) {
 	}
 }
 
+// SettingsAndCommitmentsSize returns the total size of the binary files.
 func (p *Permanent) SettingsAndCommitmentsSize() int64 {
 	var sum int64
 

--- a/packages/storage/permanent/permanent.go
+++ b/packages/storage/permanent/permanent.go
@@ -1,6 +1,8 @@
 package permanent
 
 import (
+	"os"
+
 	"github.com/iotaledger/hive.go/core/generics/lo"
 	"github.com/iotaledger/hive.go/core/kvstore"
 
@@ -30,4 +32,28 @@ func New(disk *diskutil.DiskUtil, database *database.Manager) (p *Permanent) {
 		UnspentOutputIDs: lo.PanicOnErr(database.PermanentStorage().WithRealm([]byte{unspentOutputIDsPrefix})),
 		SybilProtection:  lo.PanicOnErr(database.PermanentStorage().WithRealm([]byte{consensusWeightsPrefix})),
 	}
+}
+
+func (p *Permanent) SettingsAndCommitmentsSize() int64 {
+	var sum int64
+
+	files := []string{p.Settings.FilePath(), p.Commitments.FilePath()}
+	for _, file := range files {
+		size, err := fileSize(file)
+		if err != nil {
+			panic(err)
+		}
+		sum += size
+	}
+
+	return sum
+}
+
+func fileSize(path string) (int64, error) {
+	s, err := os.Stat(path)
+	if err != nil {
+		return 0, err
+	}
+
+	return s.Size(), nil
 }

--- a/packages/storage/storage.go
+++ b/packages/storage/storage.go
@@ -41,7 +41,7 @@ func (s *Storage) PruneUntilEpoch(epochIndex epoch.Index) {
 
 // DatabaseSize returns the size of the underlying databases
 func (s *Storage) DatabaseSize() int64 {
-	return s.databaseManager.TotalStorageSize()
+	return s.Permanent.SettingsAndCommitmentsSize() + s.databaseManager.TotalStorageSize()
 }
 
 // Shutdown shuts down the storage.

--- a/packages/storage/storage.go
+++ b/packages/storage/storage.go
@@ -39,12 +39,12 @@ func (s *Storage) PruneUntilEpoch(epochIndex epoch.Index) {
 	s.databaseManager.PruneUntilEpoch(epochIndex)
 }
 
-// PrunableDatabaseSize returns the size of the underlying prunable databases
+// PrunableDatabaseSize returns the size of the underlying prunable databases.
 func (s *Storage) PrunableDatabaseSize() int64 {
 	return s.databaseManager.PrunableStorageSize()
 }
 
-// PermanentDatabaseSize returns the size of the underlying permanent database and files
+// PermanentDatabaseSize returns the size of the underlying permanent database and files.
 func (s *Storage) PermanentDatabaseSize() int64 {
 	return s.Permanent.SettingsAndCommitmentsSize() + s.databaseManager.PermanentStorageSize()
 }
@@ -53,5 +53,5 @@ func (s *Storage) PermanentDatabaseSize() int64 {
 func (s *Storage) Shutdown() {
 	event.Loop.PendingTasksCounter.WaitIsZero()
 
-	defer s.databaseManager.Shutdown()
+	s.databaseManager.Shutdown()
 }

--- a/packages/storage/storage.go
+++ b/packages/storage/storage.go
@@ -35,13 +35,18 @@ func New(directory string, version database.Version, opts ...options.Option[data
 }
 
 // PruneUntilEpoch prunes storage epochs less than and equal to the given index.
-func (c *Storage) PruneUntilEpoch(epochIndex epoch.Index) {
-	c.databaseManager.PruneUntilEpoch(epochIndex)
+func (s *Storage) PruneUntilEpoch(epochIndex epoch.Index) {
+	s.databaseManager.PruneUntilEpoch(epochIndex)
+}
+
+// DatabaseSize returns the size of the underlying databases
+func (s *Storage) DatabaseSize() int64 {
+	return s.databaseManager.TotalStorageSize()
 }
 
 // Shutdown shuts down the storage.
-func (c *Storage) Shutdown() {
+func (s *Storage) Shutdown() {
 	event.Loop.PendingTasksCounter.WaitIsZero()
 
-	defer c.databaseManager.Shutdown()
+	defer s.databaseManager.Shutdown()
 }

--- a/packages/storage/storage.go
+++ b/packages/storage/storage.go
@@ -39,9 +39,14 @@ func (s *Storage) PruneUntilEpoch(epochIndex epoch.Index) {
 	s.databaseManager.PruneUntilEpoch(epochIndex)
 }
 
-// DatabaseSize returns the size of the underlying databases
-func (s *Storage) DatabaseSize() int64 {
-	return s.Permanent.SettingsAndCommitmentsSize() + s.databaseManager.TotalStorageSize()
+// PrunableDatabaseSize returns the size of the underlying prunable databases
+func (s *Storage) PrunableDatabaseSize() int64 {
+	return s.databaseManager.PrunableStorageSize()
+}
+
+// PermanentDatabaseSize returns the size of the underlying permanent database and files
+func (s *Storage) PermanentDatabaseSize() int64 {
+	return s.Permanent.SettingsAndCommitmentsSize() + s.databaseManager.PermanentStorageSize()
 }
 
 // Shutdown shuts down the storage.

--- a/plugins/prometheus/db_size.go
+++ b/plugins/prometheus/db_size.go
@@ -1,46 +1,35 @@
 package prometheus
 
 import (
-	"os"
-	"path/filepath"
-
 	"github.com/prometheus/client_golang/prometheus"
-
-	"github.com/iotaledger/goshimmer/plugins/protocol"
 )
 
-var dbSize prometheus.Gauge
+var dbSizes *prometheus.GaugeVec
 
 func registerDBMetrics() {
-	dbSize = prometheus.NewGauge(
+	dbSizes = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "db_size_bytes",
-			Help: "DB size in bytes.",
+			Namespace: "db",
+			Name:      "size",
+			Help:      "DB size in bytes.",
+		},
+		[]string{
+			"type",
 		},
 	)
 
-	registry.MustRegister(dbSize)
+	registry.MustRegister(dbSizes)
 
-	addCollect(collectDBSize)
-}
-
-func collectDBSize() {
-	size, err := directorySize(protocol.DatabaseParameters.Directory)
-	if err == nil {
-		dbSize.Set(float64(size))
+	addCollect(collectStorageDBSize)
+	if deps.Retainer != nil {
+		addCollect(collectRetainerDBSize)
 	}
 }
 
-func directorySize(path string) (int64, error) {
-	var size int64
-	err := filepath.Walk(path, func(_ string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if !info.IsDir() {
-			size += info.Size()
-		}
-		return err
-	})
-	return size, err
+func collectStorageDBSize() {
+	dbSizes.WithLabelValues("storage").Set(float64(deps.Protocol.MainStorage().DatabaseSize()))
+}
+
+func collectRetainerDBSize() {
+	dbSizes.WithLabelValues("retainer").Set(float64(deps.Retainer.DatabaseSize()))
 }

--- a/plugins/prometheus/db_size.go
+++ b/plugins/prometheus/db_size.go
@@ -27,7 +27,8 @@ func registerDBMetrics() {
 }
 
 func collectStorageDBSize() {
-	dbSizes.WithLabelValues("storage").Set(float64(deps.Protocol.MainStorage().DatabaseSize()))
+	dbSizes.WithLabelValues("storage_permanent").Set(float64(deps.Protocol.MainStorage().PermanentDatabaseSize()))
+	dbSizes.WithLabelValues("storage_prunable").Set(float64(deps.Protocol.MainStorage().PrunableDatabaseSize()))
 }
 
 func collectRetainerDBSize() {

--- a/plugins/prometheus/plugin.go
+++ b/plugins/prometheus/plugin.go
@@ -17,7 +17,9 @@ import (
 	"go.uber.org/dig"
 
 	"github.com/iotaledger/goshimmer/packages/app/metrics/net"
+	"github.com/iotaledger/goshimmer/packages/app/retainer"
 	"github.com/iotaledger/goshimmer/packages/core/shutdown"
+	"github.com/iotaledger/goshimmer/packages/protocol"
 	"github.com/iotaledger/goshimmer/plugins/metrics"
 )
 
@@ -41,6 +43,8 @@ type dependencies struct {
 	AutopeeringPlugin     *node.Plugin `name:"autopeering" optional:"true"`
 	Local                 *peer.Local
 	AutoPeeringConnMetric *net.ConnMetric `optional:"true"`
+	Protocol              *protocol.Protocol
+	Retainer              *retainer.Retainer `optional:"true"`
 }
 
 func configure(plugin *node.Plugin) {

--- a/tools/docker-network/grafana/dashboards/local_dashboard.json
+++ b/tools/docker-network/grafana/dashboards/local_dashboard.json
@@ -25,6 +25,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
+  "id": 7,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -357,10 +358,16 @@
       "pluginVersion": "9.2.6",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
           "exemplar": true,
-          "expr": "irate(tangle_blocks_per_component_count{component=\"Store\",instance=\"$instance\"}[5m])",
+          "expr": "irate(tangle_blocks_per_component_count{component=\"Attached\",instance=\"$instance\"}[5m])",
           "interval": "",
           "legendFormat": "Total BPS",
+          "range": true,
           "refId": "A"
         }
       ],
@@ -489,12 +496,10 @@
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
       },
-      "description": "Current CPU usage of the node.",
+      "description": "Size of the ledger database.",
       "fieldConfig": {
         "defaults": {
           "mappings": [],
-          "max": 100,
-          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -508,7 +513,7 @@
               }
             ]
           },
-          "unit": "percent"
+          "unit": "decmbytes"
         },
         "overrides": []
       },
@@ -518,7 +523,7 @@
         "x": 16,
         "y": 1
       },
-      "id": 53,
+      "id": 58,
       "options": {
         "colorMode": "value",
         "graphMode": "none",
@@ -537,13 +542,19 @@
       "pluginVersion": "9.2.6",
       "targets": [
         {
-          "expr": "process_cpu_usage{instance=\"$instance\"}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum(db_size{instance=\"$instance\"}) /1024/1024",
           "interval": "",
           "legendFormat": "",
+          "range": true,
           "refId": "A"
         }
       ],
-      "title": "CPU Usage",
+      "title": "Total Database Size",
       "type": "stat"
     },
     {
@@ -578,119 +589,7 @@
         "x": 18,
         "y": 1
       },
-      "id": 58,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.2.6",
-      "targets": [
-        {
-          "expr": "db_size_bytes{instance=\"$instance\"}/1024/1024",
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "title": "Database Size",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
-      "description": "Memory consumed by the node.",
-      "fieldConfig": {
-        "defaults": {
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "decmbytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 2,
-        "w": 2,
-        "x": 20,
-        "y": 1
-      },
-      "id": 20,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.2.6",
-      "targets": [
-        {
-          "expr": "process_mem_usage_bytes{instance=\"$instance\"}/1024/1024",
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "title": "Memory Consumption",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
-      "description": "Memory consumed by the node.",
-      "fieldConfig": {
-        "defaults": {
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 2,
-        "w": 2,
-        "x": 22,
-        "y": 1
-      },
-      "id": 150,
+      "id": 162,
       "options": {
         "colorMode": "value",
         "graphMode": "none",
@@ -713,14 +612,147 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "exemplar": true,
-          "expr": "up{instance=\"$instance\"}",
+          "editorMode": "code",
+          "expr": "sum(db_size{type=\"storage_permanent\", instance=\"$instance\"}) /1024/1024",
           "interval": "",
           "legendFormat": "",
+          "range": true,
           "refId": "A"
         }
       ],
-      "title": "Node up",
+      "title": "Permanent DB Size",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "Size of the ledger database.",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decmbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 20,
+        "y": 1
+      },
+      "id": 164,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.2.6",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum(db_size{type=\"storage_prunable\", instance=\"$instance\"}) /1024/1024",
+          "interval": "",
+          "legendFormat": "",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Prunable DB size",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "Size of the ledger database.",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decmbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 22,
+        "y": 1
+      },
+      "id": 163,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.2.6",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum(db_size{instance=\"$instance\", type=\"retainer\"}) /1024/1024",
+          "interval": "",
+          "legendFormat": "",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Retainer DB size",
       "type": "stat"
     },
     {
@@ -758,7 +790,7 @@
             "h": 11,
             "w": 11,
             "x": 0,
-            "y": 28
+            "y": 4
           },
           "hiddenSeries": false,
           "id": 32,
@@ -848,7 +880,7 @@
             "h": 11,
             "w": 13,
             "x": 11,
-            "y": 28
+            "y": 4
           },
           "hiddenSeries": false,
           "id": 111,
@@ -938,7 +970,7 @@
             "h": 10,
             "w": 11,
             "x": 0,
-            "y": 39
+            "y": 15
           },
           "hiddenSeries": false,
           "id": 52,
@@ -1025,7 +1057,7 @@
             "h": 8,
             "w": 13,
             "x": 11,
-            "y": 39
+            "y": 15
           },
           "hiddenSeries": false,
           "id": 4,
@@ -1117,7 +1149,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -1132,7 +1165,7 @@
             "h": 3,
             "w": 3,
             "x": 11,
-            "y": 47
+            "y": 23
           },
           "id": 6,
           "options": {
@@ -1150,7 +1183,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "expr": "autopeering_neighbor_connections_count{instance=\"$instance\"} - autopeering_neighbor_drop_count{instance=\"$instance\"}",
@@ -1175,7 +1208,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -1187,7 +1221,7 @@
             "h": 3,
             "w": 4,
             "x": 14,
-            "y": 47
+            "y": 23
           },
           "id": 2,
           "options": {
@@ -1205,7 +1239,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "expr": "autopeering_avg_neighbor_connection_lifetime{instance=\"$instance\"}",
@@ -1230,7 +1264,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -1245,7 +1280,7 @@
             "h": 3,
             "w": 3,
             "x": 18,
-            "y": 47
+            "y": 23
           },
           "id": 8,
           "options": {
@@ -1263,7 +1298,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "expr": "autopeering_neighbor_connections_count{instance=\"$instance\"}",
@@ -1288,7 +1323,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -1303,7 +1339,7 @@
             "h": 3,
             "w": 3,
             "x": 21,
-            "y": 47
+            "y": 23
           },
           "id": 10,
           "options": {
@@ -1321,7 +1357,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "expr": "autopeering_neighbor_drop_count{instance=\"$instance\"}",
@@ -1355,7 +1391,7 @@
             "h": 8,
             "w": 5,
             "x": 0,
-            "y": 49
+            "y": 25
           },
           "hiddenSeries": false,
           "id": 77,
@@ -1375,7 +1411,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.2.6",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1444,7 +1480,7 @@
             "h": 8,
             "w": 6,
             "x": 5,
-            "y": 49
+            "y": 25
           },
           "hiddenSeries": false,
           "id": 148,
@@ -1464,7 +1500,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.2.6",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -1512,565 +1548,279 @@
           }
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
           "fieldConfig": {
             "defaults": {
-              "links": []
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "decbytes"
             },
             "overrides": []
           },
-          "fill": 1,
-          "fillGradient": 0,
           "gridPos": {
-            "h": 9,
-            "w": 7,
+            "h": 2,
+            "w": 2,
             "x": 11,
-            "y": 50
+            "y": 26
           },
-          "hiddenSeries": false,
-          "id": 16,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
+          "id": 59,
           "options": {
-            "alertThreshold": true
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "auto"
           },
-          "percentage": false,
-          "pluginVersion": "8.3.3",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
+          "pluginVersion": "9.2.6",
           "targets": [
             {
-              "expr": "process_cpu_usage{instance=\"$instance\"}",
-              "interval": "",
-              "legendFormat": "CPU Usage",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeRegions": [],
-          "title": "CPU Usage",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "percent",
-              "label": "",
-              "logBase": 1,
-              "max": "100",
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "links": []
-            },
-            "overrides": []
-          },
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 9,
-            "w": 6,
-            "x": 18,
-            "y": 50
-          },
-          "hiddenSeries": false,
-          "id": 18,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "8.3.3",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "process_mem_usage_bytes{instance=\"$instance\"}/1024/1024",
-              "interval": "",
-              "legendFormat": "Memory Consumption",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeRegions": [],
-          "title": "Memory Consumption",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "decmbytes",
-              "label": "",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "description": "Number of blocks in missingBlockStore. These are the block the node knows it doesn't have and tries to requests them.",
-          "fieldConfig": {
-            "defaults": {
-              "links": []
-            },
-            "overrides": []
-          },
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 8,
-            "w": 11,
-            "x": 0,
-            "y": 57
-          },
-          "hiddenSeries": false,
-          "id": 147,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "8.3.3",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "tangle_block_missing_count_db{instance=\"$instance\"}",
-              "interval": "",
-              "legendFormat": "Missing Blocks",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeRegions": [],
-          "title": "Missing Blocks",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "description": "Describes the amount of total, solid and not solid blocks in the node's database.",
-          "fieldConfig": {
-            "defaults": {
-              "links": []
-            },
-            "overrides": []
-          },
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 10,
-            "w": 13,
-            "x": 11,
-            "y": 59
-          },
-          "hiddenSeries": false,
-          "id": 73,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "8.3.3",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "exemplar": true,
-              "expr": "tangle_blocks_per_component_count{component=\"Solidifier\",instance=\"$instance\"}",
-              "interval": "",
-              "legendFormat": "Solid Blocks in DB",
-              "refId": "A"
-            },
-            {
-              "exemplar": true,
-              "expr": "tangle_blocks_per_component_count{component=\"Store\",instance=\"$instance\"} - tangle_blocks_per_component_count{component=\"Solidifier\",instance=\"$instance\"}",
-              "interval": "",
-              "legendFormat": "Not Solid Blocks in DB",
-              "refId": "B"
-            },
-            {
-              "exemplar": true,
-              "expr": "tangle_blocks_per_component_count{component=\"Store\",instance=\"$instance\"}",
-              "interval": "",
-              "legendFormat": "Total Blocks in DB",
-              "refId": "C"
-            }
-          ],
-          "thresholds": [],
-          "timeRegions": [],
-          "title": "Blocks in Database",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "description": "Number of blocks currently requested by the block tangle.",
-          "fieldConfig": {
-            "defaults": {
-              "links": []
-            },
-            "overrides": []
-          },
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 8,
-            "w": 11,
-            "x": 0,
-            "y": 65
-          },
-          "hiddenSeries": false,
-          "id": 69,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "8.3.3",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "exemplar": true,
-              "expr": "tangle_block_request_queue_size{instance=\"$instance\"}",
-              "interval": "",
-              "legendFormat": "Block Request Queue Size",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeRegions": [],
-          "title": "Block Request Queue Size",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "logBase": 1,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "logBase": 1,
-              "min": "0",
-              "show": false
-            }
-          ],
-          "yaxis": {
-            "align": false
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "description": "Average time it takes to solidify blocks.",
-          "fieldConfig": {
-            "defaults": {
-              "links": [],
-              "unit": "ms"
-            },
-            "overrides": []
-          },
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 9,
-            "w": 13,
-            "x": 11,
-            "y": 69
-          },
-          "hiddenSeries": false,
-          "id": 75,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "8.3.3",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "exemplar": true,
-              "expr": "rate(tangle_block_total_time_since_received{component=\"Solidifier\",instance=\"$instance\"}[5m])/rate(tangle_blocks_per_component_count{component=\"Solidifier\",instance=\"$instance\"}[5m])",
-              "interval": "",
-              "legendFormat": "Avg Solidification Time",
-              "refId": "A"
-            },
-            {
-              "exemplar": true,
-              "expr": "",
-              "hide": false,
+              "expr": "traffic_analysis_outbound_bytes{instance=\"$instance\"}",
               "interval": "",
               "legendFormat": "",
-              "refId": "B"
+              "refId": "A"
             }
           ],
-          "thresholds": [],
-          "timeRegions": [],
-          "title": "Average Solidification Time",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
+          "title": "Analysis",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
           },
-          "type": "graph",
-          "xaxis": {
-            "mode": "time",
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "ms",
-              "logBase": 1,
-              "show": true
+          "fieldConfig": {
+            "defaults": {
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "decbytes"
             },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 2,
+            "w": 2,
+            "x": 13,
+            "y": 26
+          },
+          "id": 67,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.2.6",
+          "targets": [
             {
-              "format": "short",
-              "logBase": 1,
-              "show": true
+              "expr": "traffic_gossip_outbound_packets{instance=\"$instance\"}",
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
             }
           ],
-          "yaxis": {
-            "align": false
-          }
+          "title": "Gossip TX",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 2,
+            "w": 3,
+            "x": 15,
+            "y": 26
+          },
+          "id": 66,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.2.6",
+          "targets": [
+            {
+              "expr": "traffic_gossip_inbound_packets{instance=\"$instance\"}",
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Gossip RX",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 2,
+            "w": 3,
+            "x": 18,
+            "y": 26
+          },
+          "id": 63,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.2.6",
+          "targets": [
+            {
+              "expr": "traffic_autopeering_outbound_bytes{instance=\"$instance\"}",
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Autopeering TX",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 2,
+            "w": 3,
+            "x": 21,
+            "y": 26
+          },
+          "id": 62,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.2.6",
+          "targets": [
+            {
+              "expr": "traffic_autopeering_inbound_bytes{instance=\"$instance\"}",
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Autopeering RX",
+          "type": "stat"
         },
         {
           "aliasColors": {},
@@ -2091,9 +1841,9 @@
           "fillGradient": 0,
           "gridPos": {
             "h": 7,
-            "w": 11,
-            "x": 0,
-            "y": 73
+            "w": 13,
+            "x": 11,
+            "y": 28
           },
           "hiddenSeries": false,
           "id": 26,
@@ -2113,7 +1863,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.2.6",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2196,274 +1946,387 @@
           }
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
+          "description": "Number of blocks in missingBlockStore. These are the block the node knows it doesn't have and tries to requests them.",
           "fieldConfig": {
             "defaults": {
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  }
-                ]
-              },
-              "unit": "decbytes"
+              "links": []
             },
             "overrides": []
           },
+          "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
-            "h": 2,
-            "w": 2,
+            "h": 8,
+            "w": 11,
+            "x": 0,
+            "y": 33
+          },
+          "hiddenSeries": false,
+          "id": 147,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "9.2.6",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "tangle_block_missing_count_db{instance=\"$instance\"}",
+              "interval": "",
+              "legendFormat": "Missing Blocks",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Missing Blocks",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "description": "Describes the amount of total, solid and not solid blocks in the node's database.",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 13,
             "x": 11,
-            "y": 78
+            "y": 35
           },
-          "id": 59,
+          "hiddenSeries": false,
+          "id": 73,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {},
-            "textMode": "auto"
+            "alertThreshold": true
           },
-          "pluginVersion": "8.3.3",
+          "percentage": false,
+          "pluginVersion": "9.2.6",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
           "targets": [
             {
-              "expr": "traffic_analysis_outbound_bytes{instance=\"$instance\"}",
+              "exemplar": true,
+              "expr": "tangle_blocks_per_component_count{component=\"Solidifier\",instance=\"$instance\"}",
               "interval": "",
-              "legendFormat": "",
+              "legendFormat": "Solid Blocks in DB",
               "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "tangle_blocks_per_component_count{component=\"Store\",instance=\"$instance\"} - tangle_blocks_per_component_count{component=\"Solidifier\",instance=\"$instance\"}",
+              "interval": "",
+              "legendFormat": "Not Solid Blocks in DB",
+              "refId": "B"
+            },
+            {
+              "exemplar": true,
+              "expr": "tangle_blocks_per_component_count{component=\"Store\",instance=\"$instance\"}",
+              "interval": "",
+              "legendFormat": "Total Blocks in DB",
+              "refId": "C"
             }
           ],
-          "title": "Analysis",
-          "type": "stat"
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Blocks in Database",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "logBase": 1,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
+          "description": "Number of blocks currently requested by the block tangle.",
           "fieldConfig": {
             "defaults": {
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  }
-                ]
-              },
-              "unit": "decbytes"
+              "links": []
             },
             "overrides": []
           },
+          "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
-            "h": 2,
-            "w": 2,
-            "x": 13,
-            "y": 78
+            "h": 9,
+            "w": 11,
+            "x": 0,
+            "y": 41
           },
-          "id": 67,
+          "hiddenSeries": false,
+          "id": 69,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {},
-            "textMode": "auto"
+            "alertThreshold": true
           },
-          "pluginVersion": "8.3.3",
+          "percentage": false,
+          "pluginVersion": "9.2.6",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
           "targets": [
             {
-              "expr": "traffic_gossip_outbound_packets{instance=\"$instance\"}",
+              "exemplar": true,
+              "expr": "tangle_block_request_queue_size{instance=\"$instance\"}",
               "interval": "",
-              "legendFormat": "",
+              "legendFormat": "Block Request Queue Size",
               "refId": "A"
             }
           ],
-          "title": "Gossip TX",
-          "type": "stat"
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Block Request Queue Size",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "logBase": 1,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "min": "0",
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": {
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
+          "description": "Average time it takes to solidify blocks.",
           "fieldConfig": {
             "defaults": {
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  }
-                ]
-              },
-              "unit": "decbytes"
+              "links": [],
+              "unit": "ms"
             },
             "overrides": []
           },
+          "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
-            "h": 2,
-            "w": 3,
-            "x": 15,
-            "y": 78
+            "h": 8,
+            "w": 13,
+            "x": 11,
+            "y": 42
           },
-          "id": 66,
+          "hiddenSeries": false,
+          "id": 75,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {},
-            "textMode": "auto"
+            "alertThreshold": true
           },
-          "pluginVersion": "8.3.3",
+          "percentage": false,
+          "pluginVersion": "9.2.6",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
           "targets": [
             {
-              "expr": "traffic_gossip_inbound_packets{instance=\"$instance\"}",
+              "exemplar": true,
+              "expr": "rate(tangle_block_total_time_since_received{component=\"Solidifier\",instance=\"$instance\"}[5m])/rate(tangle_blocks_per_component_count{component=\"Solidifier\",instance=\"$instance\"}[5m])",
               "interval": "",
-              "legendFormat": "",
+              "legendFormat": "Avg Solidification Time",
               "refId": "A"
-            }
-          ],
-          "title": "Gossip RX",
-          "type": "stat"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  }
-                ]
-              },
-              "unit": "decbytes"
             },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 2,
-            "w": 3,
-            "x": 18,
-            "y": 78
-          },
-          "id": 63,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {},
-            "textMode": "auto"
-          },
-          "pluginVersion": "8.3.3",
-          "targets": [
             {
-              "expr": "traffic_autopeering_outbound_bytes{instance=\"$instance\"}",
+              "exemplar": true,
+              "expr": "",
+              "hide": false,
               "interval": "",
               "legendFormat": "",
-              "refId": "A"
+              "refId": "B"
             }
           ],
-          "title": "Autopeering TX",
-          "type": "stat"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Average Solidification Time",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
           },
-          "fieldConfig": {
-            "defaults": {
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  }
-                ]
-              },
-              "unit": "decbytes"
-            },
-            "overrides": []
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
           },
-          "gridPos": {
-            "h": 2,
-            "w": 3,
-            "x": 21,
-            "y": 78
-          },
-          "id": 62,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "text": {},
-            "textMode": "auto"
-          },
-          "pluginVersion": "8.3.3",
-          "targets": [
+          "yaxes": [
             {
-              "expr": "traffic_autopeering_inbound_bytes{instance=\"$instance\"}",
-              "interval": "",
-              "legendFormat": "",
-              "refId": "A"
+              "format": "ms",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": true
             }
           ],
-          "title": "Autopeering RX",
-          "type": "stat"
+          "yaxis": {
+            "align": false
+          }
         }
       ],
       "title": "BPS, Autopeering, Traffic, Resources",
@@ -2496,7 +2359,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -2508,7 +2372,7 @@
             "h": 3,
             "w": 4,
             "x": 0,
-            "y": 89
+            "y": 5
           },
           "id": 85,
           "options": {
@@ -2526,7 +2390,7 @@
             "text": {},
             "textMode": "value_and_name"
           },
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "exemplar": true,
@@ -2561,7 +2425,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -2577,7 +2442,7 @@
             "h": 3,
             "w": 3,
             "x": 4,
-            "y": 89
+            "y": 5
           },
           "id": 101,
           "options": {
@@ -2595,7 +2460,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "exemplar": true,
@@ -2627,7 +2492,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -2639,7 +2505,7 @@
             "h": 3,
             "w": 4,
             "x": 7,
-            "y": 89
+            "y": 5
           },
           "id": 95,
           "options": {
@@ -2657,7 +2523,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "expr": "avg(mana_access{instance=\"$instance\"})",
@@ -2688,7 +2554,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -2700,7 +2567,7 @@
             "h": 3,
             "w": 3,
             "x": 11,
-            "y": 89
+            "y": 5
           },
           "id": 96,
           "options": {
@@ -2718,7 +2585,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "exemplar": true,
@@ -2751,7 +2618,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -2763,7 +2631,7 @@
             "h": 3,
             "w": 4,
             "x": 14,
-            "y": 89
+            "y": 5
           },
           "id": 109,
           "options": {
@@ -2781,7 +2649,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "expr": "mana_average_neighbors_access{instance=\"$instance\"}",
@@ -2823,7 +2691,7 @@
             "h": 15,
             "w": 6,
             "x": 18,
-            "y": 89
+            "y": 5
           },
           "hiddenSeries": false,
           "id": 89,
@@ -2844,7 +2712,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.2.6",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -2918,7 +2786,7 @@
             "h": 12,
             "w": 9,
             "x": 0,
-            "y": 92
+            "y": 8
           },
           "hiddenSeries": false,
           "id": 98,
@@ -2940,7 +2808,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.2.6",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -3014,7 +2882,7 @@
             "h": 12,
             "w": 9,
             "x": 9,
-            "y": 92
+            "y": 8
           },
           "hiddenSeries": false,
           "id": 99,
@@ -3036,7 +2904,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.2.6",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -3111,7 +2979,7 @@
             "h": 9,
             "w": 8,
             "x": 0,
-            "y": 104
+            "y": 20
           },
           "hiddenSeries": false,
           "id": 83,
@@ -3133,7 +3001,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.2.6",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -3202,7 +3070,7 @@
             "h": 9,
             "w": 8,
             "x": 8,
-            "y": 104
+            "y": 20
           },
           "hiddenSeries": false,
           "id": 90,
@@ -3226,7 +3094,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.2.6",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -3298,7 +3166,7 @@
             "h": 9,
             "w": 8,
             "x": 16,
-            "y": 104
+            "y": 20
           },
           "id": 92,
           "links": [],
@@ -3320,7 +3188,8 @@
             },
             "text": {},
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "pluginVersion": "7.5.6",
@@ -3359,7 +3228,7 @@
             "h": 9,
             "w": 8,
             "x": 0,
-            "y": 113
+            "y": 29
           },
           "hiddenSeries": false,
           "id": 84,
@@ -3381,7 +3250,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.2.6",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -3450,7 +3319,7 @@
             "h": 9,
             "w": 8,
             "x": 8,
-            "y": 113
+            "y": 29
           },
           "hiddenSeries": false,
           "id": 91,
@@ -3474,7 +3343,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.2.6",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -3547,7 +3416,7 @@
             "h": 9,
             "w": 8,
             "x": 16,
-            "y": 113
+            "y": 29
           },
           "id": 93,
           "links": [],
@@ -3569,7 +3438,8 @@
             },
             "text": {},
             "tooltip": {
-              "mode": "single"
+              "mode": "single",
+              "sort": "none"
             }
           },
           "pluginVersion": "7.1.1",
@@ -3604,9 +3474,9 @@
           "fillGradient": 0,
           "gridPos": {
             "h": 11,
-            "w": 9,
+            "w": 8,
             "x": 0,
-            "y": 122
+            "y": 38
           },
           "hiddenSeries": false,
           "id": 103,
@@ -3628,7 +3498,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.2.6",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -3701,9 +3571,9 @@
           "fillGradient": 0,
           "gridPos": {
             "h": 11,
-            "w": 7,
-            "x": 9,
-            "y": 122
+            "w": 8,
+            "x": 8,
+            "y": 38
           },
           "hiddenSeries": false,
           "id": 107,
@@ -3723,7 +3593,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.2.6",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -3790,9 +3660,9 @@
           "fillGradient": 0,
           "gridPos": {
             "h": 11,
-            "w": 7,
+            "w": 8,
             "x": 16,
-            "y": 122
+            "y": 38
           },
           "hiddenSeries": false,
           "id": 114,
@@ -3812,7 +3682,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.2.6",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -3879,9 +3749,9 @@
           "fillGradient": 0,
           "gridPos": {
             "h": 10,
-            "w": 9,
+            "w": 8,
             "x": 0,
-            "y": 133
+            "y": 49
           },
           "hiddenSeries": false,
           "id": 110,
@@ -3901,7 +3771,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "8.3.3",
+          "pluginVersion": "9.2.6",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -3988,7 +3858,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 38
+            "y": 106
           },
           "hiddenSeries": false,
           "id": 118,
@@ -4008,7 +3878,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.5.6",
+          "pluginVersion": "9.2.6",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -4080,7 +3950,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 38
+            "y": 106
           },
           "hiddenSeries": false,
           "id": 119,
@@ -4100,7 +3970,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.5.6",
+          "pluginVersion": "9.2.6",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -4159,17 +4029,13 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "fieldConfig": {
-            "defaults": {},
-            "overrides": []
-          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 46
+            "y": 114
           },
           "hiddenSeries": false,
           "id": 121,
@@ -4189,7 +4055,7 @@
             "alertThreshold": true
           },
           "percentage": false,
-          "pluginVersion": "7.5.6",
+          "pluginVersion": "9.2.6",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -4252,7 +4118,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4267,7 +4134,7 @@
             "h": 4,
             "w": 6,
             "x": 12,
-            "y": 46
+            "y": 114
           },
           "id": 123,
           "options": {
@@ -4285,7 +4152,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "7.5.6",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "exemplar": true,
@@ -4314,7 +4181,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4329,7 +4197,7 @@
             "h": 4,
             "w": 6,
             "x": 18,
-            "y": 46
+            "y": 114
           },
           "id": 125,
           "options": {
@@ -4347,7 +4215,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "7.5.6",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "exemplar": true,
@@ -4376,7 +4244,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4391,7 +4260,7 @@
             "h": 4,
             "w": 6,
             "x": 12,
-            "y": 50
+            "y": 118
           },
           "id": 124,
           "options": {
@@ -4409,7 +4278,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "7.5.6",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "exemplar": true,
@@ -4438,7 +4307,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -4453,7 +4323,7 @@
             "h": 4,
             "w": 6,
             "x": 18,
-            "y": 50
+            "y": 118
           },
           "id": 126,
           "options": {
@@ -4471,7 +4341,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "7.5.6",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "exemplar": true,
@@ -4519,7 +4389,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -4531,7 +4402,7 @@
             "h": 6,
             "w": 15,
             "x": 0,
-            "y": 39
+            "y": 123
           },
           "id": 146,
           "options": {
@@ -4549,7 +4420,7 @@
             "showUnfilled": true,
             "text": {}
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "exemplar": true,
@@ -4580,7 +4451,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -4592,7 +4464,7 @@
             "h": 3,
             "w": 3,
             "x": 15,
-            "y": 39
+            "y": 123
           },
           "id": 132,
           "options": {
@@ -4610,7 +4482,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "exemplar": true,
@@ -4639,7 +4511,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               }
@@ -4650,7 +4523,7 @@
             "h": 3,
             "w": 3,
             "x": 18,
-            "y": 39
+            "y": 123
           },
           "id": 142,
           "options": {
@@ -4668,7 +4541,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "exemplar": true,
@@ -4699,7 +4572,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               }
@@ -4710,7 +4584,7 @@
             "h": 3,
             "w": 3,
             "x": 21,
-            "y": 39
+            "y": 123
           },
           "id": 149,
           "options": {
@@ -4728,7 +4602,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "exemplar": true,
@@ -4758,7 +4632,8 @@
                 "mode": "percentage",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -4770,7 +4645,7 @@
             "h": 3,
             "w": 3,
             "x": 15,
-            "y": 42
+            "y": 126
           },
           "id": 143,
           "options": {
@@ -4788,7 +4663,7 @@
             "text": {},
             "textMode": "value"
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "exemplar": false,
@@ -4818,7 +4693,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               }
@@ -4829,7 +4705,7 @@
             "h": 3,
             "w": 3,
             "x": 18,
-            "y": 42
+            "y": 126
           },
           "id": 140,
           "options": {
@@ -4847,7 +4723,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "exemplar": true,
@@ -4876,7 +4752,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               }
@@ -4887,7 +4764,7 @@
             "h": 3,
             "w": 3,
             "x": 21,
-            "y": 42
+            "y": 126
           },
           "id": 154,
           "options": {
@@ -4905,7 +4782,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "datasource": {
@@ -4938,7 +4815,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -4950,7 +4828,7 @@
             "h": 6,
             "w": 15,
             "x": 0,
-            "y": 45
+            "y": 129
           },
           "id": 145,
           "options": {
@@ -4968,7 +4846,7 @@
             "showUnfilled": true,
             "text": {}
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "datasource": {
@@ -5005,7 +4883,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -5017,7 +4896,7 @@
             "h": 3,
             "w": 3,
             "x": 15,
-            "y": 45
+            "y": 129
           },
           "id": 130,
           "options": {
@@ -5035,7 +4914,7 @@
             "text": {},
             "textMode": "value"
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "exemplar": false,
@@ -5064,7 +4943,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               }
@@ -5075,7 +4955,7 @@
             "h": 3,
             "w": 3,
             "x": 18,
-            "y": 45
+            "y": 129
           },
           "id": 134,
           "options": {
@@ -5093,7 +4973,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "exemplar": true,
@@ -5122,7 +5002,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -5134,7 +5015,7 @@
             "h": 3,
             "w": 3,
             "x": 21,
-            "y": 45
+            "y": 129
           },
           "id": 153,
           "options": {
@@ -5152,7 +5033,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "datasource": {
@@ -5185,7 +5066,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               }
@@ -5196,7 +5078,7 @@
             "h": 3,
             "w": 3,
             "x": 15,
-            "y": 48
+            "y": 132
           },
           "id": 138,
           "options": {
@@ -5214,7 +5096,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "datasource": {
@@ -5262,7 +5144,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -5274,7 +5157,7 @@
             "h": 3,
             "w": 3,
             "x": 18,
-            "y": 48
+            "y": 132
           },
           "id": 151,
           "options": {
@@ -5292,7 +5175,7 @@
             "text": {},
             "textMode": "value"
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "datasource": {
@@ -5325,7 +5208,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               }
@@ -5336,7 +5220,7 @@
             "h": 3,
             "w": 3,
             "x": 21,
-            "y": 48
+            "y": 132
           },
           "id": 136,
           "options": {
@@ -5354,7 +5238,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "exemplar": true,
@@ -5383,7 +5267,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -5395,7 +5280,7 @@
             "h": 3,
             "w": 3,
             "x": 15,
-            "y": 51
+            "y": 135
           },
           "id": 152,
           "options": {
@@ -5413,7 +5298,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "datasource": {
@@ -5446,7 +5331,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -5458,7 +5344,7 @@
             "h": 3,
             "w": 3,
             "x": 18,
-            "y": 51
+            "y": 135
           },
           "id": 155,
           "options": {
@@ -5476,7 +5362,7 @@
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.5.3",
+          "pluginVersion": "9.2.6",
           "targets": [
             {
               "datasource": {
@@ -5499,7 +5385,7 @@
       "type": "row"
     },
     {
-      "collapsed": false,
+      "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -5507,162 +5393,163 @@
         "y": 7
       },
       "id": 157,
-      "panels": [],
-      "title": "Event loop",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 3,
-        "x": 0,
-        "y": 8
-      },
-      "id": 159,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.2.6",
-      "targets": [
+      "panels": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "editorMode": "code",
-          "expr": "workerpool_eventloop_workers{instance=\"$instance\"}",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Event loop workers",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
           },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
+          "gridPos": {
+            "h": 9,
+            "w": 3,
+            "x": 0,
+            "y": 139
+          },
+          "id": 159,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
             },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.2.6",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "workerpool_eventloop_workers{instance=\"$instance\"}",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Event loop workers",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
             },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 21,
+            "x": 3,
+            "y": 139
+          },
+          "id": 161,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
             },
-            "thresholdsStyle": {
-              "mode": "off"
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
             }
           },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
               },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 21,
-        "x": 3,
-        "y": 8
-      },
-      "id": 161,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "editorMode": "code",
-          "expr": "workerpool_eventloop_tasks_pending{instance=\"$instance\"}",
-          "legendFormat": "{{instance}}",
-          "range": true,
-          "refId": "A"
+              "editorMode": "code",
+              "expr": "workerpool_eventloop_tasks_pending{instance=\"$instance\"}",
+              "legendFormat": "{{instance}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Event loop pending tasks",
+          "type": "timeseries"
         }
       ],
-      "title": "Event loop pending tasks",
-      "type": "timeseries"
+      "title": "Event loop",
+      "type": "row"
     }
   ],
   "refresh": "10s",
@@ -5674,8 +5561,8 @@
       {
         "current": {
           "selected": false,
-          "text": "node-05.feature.shimmer.iota.cafe:9311",
-          "value": "node-05.feature.shimmer.iota.cafe:9311"
+          "text": "faucet:9311",
+          "value": "faucet:9311"
         },
         "datasource": {
           "type": "prometheus",
@@ -5704,8 +5591,8 @@
       {
         "current": {
           "selected": false,
-          "text": "EUq4re4s",
-          "value": "EUq4re4s"
+          "text": "GbkZ3Coi",
+          "value": "GbkZ3Coi"
         },
         "datasource": {
           "type": "prometheus",
@@ -5753,6 +5640,6 @@
   "timezone": "",
   "title": "GoShimmer Local Metrics",
   "uid": "R-T27yW7k",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }


### PR DESCRIPTION
- This adds logic into the database manager to cache the sizes of closed databases so that we don't need to walk the whole filesystem every time we want to measure the size of the database. Only open databases are walked
- This also improves the metrics exposed by prometheus to show the sizes of both the storage and the retainer:
```
db_size{type="retainer"} 27712
db_size{type="storage_permanent"} 27980
db_size{type="storage_prunable"} 778947
```

Note: the grafana boards will need an update, but that is part of the whole metrics refactor