### PR TITLE
Fix global worker pool contention

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/go-playground/assert/v2 v2.0.1
 	github.com/go-resty/resty/v2 v2.6.0
 	github.com/gorilla/websocket v1.5.0
-	github.com/iotaledger/hive.go/core v1.0.0-rc.1.0.20221215123443-a3f702c8d714
+	github.com/iotaledger/hive.go/core v1.0.0-rc.2.0.20230110152711-02063266eb24
 	github.com/iotaledger/hive.go/serializer/v2 v2.0.0-rc.1
 	github.com/labstack/echo v3.3.10+incompatible
 	github.com/libp2p/go-libp2p v0.23.4

--- a/go.mod
+++ b/go.mod
@@ -84,7 +84,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
-	github.com/emirpasic/gods v1.18.1 // indirect
+	github.com/emirpasic/gods v1.18.1
 	github.com/ethereum/go-ethereum v1.10.26 // indirect
 	github.com/fatih/structs v1.1.0 // indirect
 	github.com/flynn/noise v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -442,6 +442,16 @@ github.com/iotaledger/grocksdb v1.7.5-0.20221128103803-fcdb79760195 h1:W5v+7oSXt
 github.com/iotaledger/grocksdb v1.7.5-0.20221128103803-fcdb79760195/go.mod h1:AoAM7v6lyWRQzrmmegOEq759o1PgvvKvn2bEe1A1mc8=
 github.com/iotaledger/hive.go/core v1.0.0-rc.1.0.20221215123443-a3f702c8d714 h1:g0rFqA8gg3znz5f8B/f8ki1rmNGY3d55F06T+YtaZts=
 github.com/iotaledger/hive.go/core v1.0.0-rc.1.0.20221215123443-a3f702c8d714/go.mod h1:POmRNWlS/NWFCrMowt+CcE4H8GAVe1BotWLN9QD6FLE=
+github.com/iotaledger/hive.go/core v1.0.0-rc.2.0.20230109211700-3b15d1b50090 h1:kyVmeTy/Fwq8JS7b1TPmKpsTPaIS9/zQRmEtzzBMhjE=
+github.com/iotaledger/hive.go/core v1.0.0-rc.2.0.20230109211700-3b15d1b50090/go.mod h1:POmRNWlS/NWFCrMowt+CcE4H8GAVe1BotWLN9QD6FLE=
+github.com/iotaledger/hive.go/core v1.0.0-rc.2.0.20230109220442-664d266570fa h1:nHNswxKRkoyFYemNoMvUo0FUxBGfcoy94Auj+XwWbco=
+github.com/iotaledger/hive.go/core v1.0.0-rc.2.0.20230109220442-664d266570fa/go.mod h1:POmRNWlS/NWFCrMowt+CcE4H8GAVe1BotWLN9QD6FLE=
+github.com/iotaledger/hive.go/core v1.0.0-rc.2.0.20230109222935-43ff516b6805 h1:K0JGAGFXFtB+nwYlk7GXH6Od5BxR8m+Vh3WbbKNPVO0=
+github.com/iotaledger/hive.go/core v1.0.0-rc.2.0.20230109222935-43ff516b6805/go.mod h1:POmRNWlS/NWFCrMowt+CcE4H8GAVe1BotWLN9QD6FLE=
+github.com/iotaledger/hive.go/core v1.0.0-rc.2.0.20230110143444-02276c9236b2 h1:Yd+foS26+FEGkaOPM2YvnHbc1AahHBt3HnTASHA/eFU=
+github.com/iotaledger/hive.go/core v1.0.0-rc.2.0.20230110143444-02276c9236b2/go.mod h1:POmRNWlS/NWFCrMowt+CcE4H8GAVe1BotWLN9QD6FLE=
+github.com/iotaledger/hive.go/core v1.0.0-rc.2.0.20230110152711-02063266eb24 h1:HiZNj4cCgqiCNolYk6qCF9FaYdUcTThufV/O9h+gTqI=
+github.com/iotaledger/hive.go/core v1.0.0-rc.2.0.20230110152711-02063266eb24/go.mod h1:POmRNWlS/NWFCrMowt+CcE4H8GAVe1BotWLN9QD6FLE=
 github.com/iotaledger/hive.go/serializer/v2 v2.0.0-rc.1 h1:x3xsI32h+1wTIzLWInC+AcwrUyk9/l7z2RFMQiuua2E=
 github.com/iotaledger/hive.go/serializer/v2 v2.0.0-rc.1/go.mod h1:jkV//O5d+HHm32qDmTy6AWZUgxuZaXazTUVqox+5z4g=
 github.com/ipfs/go-cid v0.3.2 h1:OGgOd+JCFM+y1DjWPmVH+2/4POtpDzwcr7VgnB7mZXc=

--- a/go.sum
+++ b/go.sum
@@ -440,16 +440,6 @@ github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/C
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/iotaledger/grocksdb v1.7.5-0.20221128103803-fcdb79760195 h1:W5v+7oSXtSq2OSadYPyaAbPjTJW10T2bOgMDGZcyVOc=
 github.com/iotaledger/grocksdb v1.7.5-0.20221128103803-fcdb79760195/go.mod h1:AoAM7v6lyWRQzrmmegOEq759o1PgvvKvn2bEe1A1mc8=
-github.com/iotaledger/hive.go/core v1.0.0-rc.1.0.20221215123443-a3f702c8d714 h1:g0rFqA8gg3znz5f8B/f8ki1rmNGY3d55F06T+YtaZts=
-github.com/iotaledger/hive.go/core v1.0.0-rc.1.0.20221215123443-a3f702c8d714/go.mod h1:POmRNWlS/NWFCrMowt+CcE4H8GAVe1BotWLN9QD6FLE=
-github.com/iotaledger/hive.go/core v1.0.0-rc.2.0.20230109211700-3b15d1b50090 h1:kyVmeTy/Fwq8JS7b1TPmKpsTPaIS9/zQRmEtzzBMhjE=
-github.com/iotaledger/hive.go/core v1.0.0-rc.2.0.20230109211700-3b15d1b50090/go.mod h1:POmRNWlS/NWFCrMowt+CcE4H8GAVe1BotWLN9QD6FLE=
-github.com/iotaledger/hive.go/core v1.0.0-rc.2.0.20230109220442-664d266570fa h1:nHNswxKRkoyFYemNoMvUo0FUxBGfcoy94Auj+XwWbco=
-github.com/iotaledger/hive.go/core v1.0.0-rc.2.0.20230109220442-664d266570fa/go.mod h1:POmRNWlS/NWFCrMowt+CcE4H8GAVe1BotWLN9QD6FLE=
-github.com/iotaledger/hive.go/core v1.0.0-rc.2.0.20230109222935-43ff516b6805 h1:K0JGAGFXFtB+nwYlk7GXH6Od5BxR8m+Vh3WbbKNPVO0=
-github.com/iotaledger/hive.go/core v1.0.0-rc.2.0.20230109222935-43ff516b6805/go.mod h1:POmRNWlS/NWFCrMowt+CcE4H8GAVe1BotWLN9QD6FLE=
-github.com/iotaledger/hive.go/core v1.0.0-rc.2.0.20230110143444-02276c9236b2 h1:Yd+foS26+FEGkaOPM2YvnHbc1AahHBt3HnTASHA/eFU=
-github.com/iotaledger/hive.go/core v1.0.0-rc.2.0.20230110143444-02276c9236b2/go.mod h1:POmRNWlS/NWFCrMowt+CcE4H8GAVe1BotWLN9QD6FLE=
 github.com/iotaledger/hive.go/core v1.0.0-rc.2.0.20230110152711-02063266eb24 h1:HiZNj4cCgqiCNolYk6qCF9FaYdUcTThufV/O9h+gTqI=
 github.com/iotaledger/hive.go/core v1.0.0-rc.2.0.20230110152711-02063266eb24/go.mod h1:POmRNWlS/NWFCrMowt+CcE4H8GAVe1BotWLN9QD6FLE=
 github.com/iotaledger/hive.go/serializer/v2 v2.0.0-rc.1 h1:x3xsI32h+1wTIzLWInC+AcwrUyk9/l7z2RFMQiuua2E=

--- a/packages/app/retainer/retainer.go
+++ b/packages/app/retainer/retainer.go
@@ -3,6 +3,7 @@ package retainer
 import (
 	"github.com/cockroachdb/errors"
 	"github.com/iotaledger/hive.go/core/syncutils"
+	"github.com/iotaledger/hive.go/core/workerpool"
 
 	"github.com/iotaledger/hive.go/core/generics/event"
 	"github.com/iotaledger/hive.go/core/generics/options"
@@ -23,6 +24,7 @@ import (
 )
 
 type Retainer struct {
+	workerPool     *workerpool.UnboundedWorkerPool
 	cachedMetadata *memstorage.EpochStorage[models.BlockID, *cachedMetadata]
 	blockStorage   *database.PersistentEpochStorage[models.BlockID, BlockMetadata, *models.BlockID, *BlockMetadata]
 
@@ -35,6 +37,7 @@ type Retainer struct {
 
 func NewRetainer(protocol *protocol.Protocol, dbManager *database.Manager, opts ...options.Option[Retainer]) (r *Retainer) {
 	return options.Apply(&Retainer{
+		workerPool:     workerpool.NewUnboundedWorkerPool(2),
 		cachedMetadata: memstorage.NewEpochStorage[models.BlockID, *cachedMetadata](),
 		protocol:       protocol,
 		dbManager:      dbManager,
@@ -105,62 +108,69 @@ func (r *Retainer) DatabaseSize() int64 {
 	return r.dbManager.TotalStorageSize()
 }
 
+// WorkerPool returns the worker pool of the retainer.
+func (r *Retainer) WorkerPool() *workerpool.UnboundedWorkerPool {
+	return r.workerPool
+}
+
 // PruneUntilEpoch prunes storage epochs less than and equal to the given index.
 func (r *Retainer) PruneUntilEpoch(epochIndex epoch.Index) {
 	r.dbManager.PruneUntilEpoch(epochIndex)
 }
 
 func (r *Retainer) setupEvents() {
-	r.protocol.Events.Engine.Tangle.BlockDAG.BlockAttached.Attach(event.NewClosure(func(block *blockdag.Block) {
+	r.workerPool.Start()
+
+	r.protocol.Events.Engine.Tangle.BlockDAG.BlockAttached.AttachWithWorkerPool(event.NewClosure(func(block *blockdag.Block) {
 		if cm := r.createOrGetCachedMetadata(block.ID()); cm != nil {
 			cm.setBlockDAGBlock(block)
 		}
-	}))
+	}), r.workerPool)
 
 	// TODO: missing blocks make the node fail due to empty strong parents
-	//r.protocol.Events.Engine.Tangle.BlockDAG.BlockMissing.Attach(event.NewClosure(func(block *blockdag.Block) {
+	// r.protocol.Events.Engine.Tangle.BlockDAG.BlockMissing.AttachWithWorkerPool(event.NewClosure(func(block *blockdag.Block) {
 	//	cm := r.createOrGetCachedMetadata(block.ID())
 	//	cm.setBlockDAGBlock(block)
-	//}))
+	// }))
 
-	r.protocol.Events.Engine.Tangle.BlockDAG.BlockSolid.Attach(event.NewClosure(func(block *blockdag.Block) {
+	r.protocol.Events.Engine.Tangle.BlockDAG.BlockSolid.AttachWithWorkerPool(event.NewClosure(func(block *blockdag.Block) {
 		if cm := r.createOrGetCachedMetadata(block.ID()); cm != nil {
 			cm.setBlockDAGBlock(block)
 		}
-	}))
+	}), r.workerPool)
 
-	r.protocol.Events.Engine.Tangle.Booker.BlockBooked.Attach(event.NewClosure(func(block *booker.Block) {
+	r.protocol.Events.Engine.Tangle.Booker.BlockBooked.AttachWithWorkerPool(event.NewClosure(func(block *booker.Block) {
 		if cm := r.createOrGetCachedMetadata(block.ID()); cm != nil {
 			cm.setBookerBlock(block)
 			cm.ConflictIDs = r.protocol.Engine().Tangle.BlockConflicts(block)
 		}
-	}))
+	}), r.workerPool)
 
-	r.protocol.Events.Engine.Tangle.VirtualVoting.BlockTracked.Attach(event.NewClosure(func(block *virtualvoting.Block) {
+	r.protocol.Events.Engine.Tangle.VirtualVoting.BlockTracked.AttachWithWorkerPool(event.NewClosure(func(block *virtualvoting.Block) {
 		if cm := r.createOrGetCachedMetadata(block.ID()); cm != nil {
 			cm.setVirtualVotingBlock(block)
 		}
-	}))
+	}), r.workerPool)
 
 	congestionControlClosure := event.NewClosure(func(block *scheduler.Block) {
 		if cm := r.createOrGetCachedMetadata(block.ID()); cm != nil {
 			cm.setSchedulerBlock(block)
 		}
 	})
-	r.protocol.Events.CongestionControl.Scheduler.BlockScheduled.Attach(congestionControlClosure)
-	r.protocol.Events.CongestionControl.Scheduler.BlockDropped.Attach(congestionControlClosure)
-	r.protocol.Events.CongestionControl.Scheduler.BlockSkipped.Attach(congestionControlClosure)
+	r.protocol.Events.CongestionControl.Scheduler.BlockScheduled.AttachWithWorkerPool(congestionControlClosure, r.workerPool)
+	r.protocol.Events.CongestionControl.Scheduler.BlockDropped.AttachWithWorkerPool(congestionControlClosure, r.workerPool)
+	r.protocol.Events.CongestionControl.Scheduler.BlockSkipped.AttachWithWorkerPool(congestionControlClosure, r.workerPool)
 
-	r.protocol.Events.Engine.Consensus.BlockGadget.BlockAccepted.Attach(event.NewClosure(func(block *blockgadget.Block) {
+	r.protocol.Events.Engine.Consensus.BlockGadget.BlockAccepted.AttachWithWorkerPool(event.NewClosure(func(block *blockgadget.Block) {
 		cm := r.createOrGetCachedMetadata(block.ID())
 		cm.setAcceptanceBlock(block)
-	}))
+	}), r.workerPool)
 
-	r.protocol.Events.Engine.Consensus.BlockGadget.BlockConfirmed.Attach(event.NewClosure(func(block *blockgadget.Block) {
+	r.protocol.Events.Engine.Consensus.BlockGadget.BlockConfirmed.AttachWithWorkerPool(event.NewClosure(func(block *blockgadget.Block) {
 		if cm := r.createOrGetCachedMetadata(block.ID()); cm != nil {
 			cm.setConfirmationBlock(block)
 		}
-	}))
+	}), r.workerPool)
 
 	r.protocol.Events.Engine.EvictionState.EpochEvicted.Hook(event.NewClosure(r.storeAndEvictEpoch))
 }

--- a/packages/protocol/congestioncontrol/congestioncontrol.go
+++ b/packages/protocol/congestioncontrol/congestioncontrol.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/iotaledger/hive.go/core/generics/event"
 	"github.com/iotaledger/hive.go/core/generics/options"
+	"github.com/iotaledger/hive.go/core/workerpool"
 
 	"github.com/iotaledger/goshimmer/packages/protocol/congestioncontrol/icca/scheduler"
 	"github.com/iotaledger/goshimmer/packages/protocol/engine"
@@ -14,6 +15,7 @@ import (
 type CongestionControl struct {
 	Events *Events
 
+	workerPool     *workerpool.UnboundedWorkerPool
 	scheduler      *scheduler.Scheduler
 	schedulerMutex sync.RWMutex
 
@@ -21,9 +23,14 @@ type CongestionControl struct {
 }
 
 func New(opts ...options.Option[CongestionControl]) (congestionControl *CongestionControl) {
-	return options.Apply(&CongestionControl{
-		Events: NewEvents(),
+	congestionControl = options.Apply(&CongestionControl{
+		Events:     NewEvents(),
+		workerPool: workerpool.NewUnboundedWorkerPool(1),
 	}, opts)
+
+	congestionControl.workerPool.Start()
+
+	return congestionControl
 }
 
 func (c *CongestionControl) LinkTo(engine *engine.Engine) {
@@ -41,8 +48,7 @@ func (c *CongestionControl) LinkTo(engine *engine.Engine) {
 		engine.ThroughputQuota.TotalBalance,
 		c.optsSchedulerOptions...,
 	)
-
-	engine.Tangle.Events.VirtualVoting.BlockTracked.Attach(event.NewClosure(c.scheduler.AddBlock))
+	engine.Tangle.Events.VirtualVoting.BlockTracked.AttachWithWorkerPool(event.NewClosure(c.scheduler.AddBlock), c.workerPool)
 	// engine.Tangle.Events.VirtualVoting.BlockTracked.Attach(event.NewClosure(func(block *virtualvoting.Block) {
 	//	registerBlock, err := c.scheduler.GetOrRegisterBlock(block)
 	//	if err != nil {
@@ -50,12 +56,19 @@ func (c *CongestionControl) LinkTo(engine *engine.Engine) {
 	//	}
 	//	c.Events.Scheduler.BlockScheduled.Trigger(registerBlock)
 	// }))
-	engine.Tangle.Events.BlockDAG.BlockOrphaned.Attach(event.NewClosure(c.scheduler.HandleOrphanedBlock))
-	engine.Consensus.Events.BlockGadget.BlockAccepted.Attach(event.NewClosure(c.scheduler.HandleAcceptedBlock))
+	engine.Tangle.Events.BlockDAG.BlockOrphaned.AttachWithWorkerPool(event.NewClosure(c.scheduler.HandleOrphanedBlock), c.workerPool)
+	engine.Consensus.Events.BlockGadget.BlockAccepted.AttachWithWorkerPool(event.NewClosure(c.scheduler.HandleAcceptedBlock), c.workerPool)
 
 	c.Events.Scheduler.LinkTo(c.scheduler.Events)
 
 	c.scheduler.Start()
+}
+
+func (c *CongestionControl) WorkerPool() *workerpool.UnboundedWorkerPool {
+	c.schedulerMutex.RLock()
+	defer c.schedulerMutex.RUnlock()
+
+	return c.workerPool
 }
 
 func (c *CongestionControl) Scheduler() *scheduler.Scheduler {

--- a/packages/protocol/engine/clock/clock.go
+++ b/packages/protocol/engine/clock/clock.go
@@ -1,7 +1,6 @@
 package clock
 
 import (
-	"fmt"
 	"time"
 )
 
@@ -9,29 +8,29 @@ import (
 type Clock struct {
 	Events *Events
 
-	lastAccepted  timeUpdate
-	lastConfirmed timeUpdate
+	lastAccepted  *timeUpdate
+	lastConfirmed *timeUpdate
 }
 
 // New creates a new Clock with the given genesisTime.
 func New() (clock *Clock) {
 	return &Clock{
+		lastAccepted:  &timeUpdate{},
+		lastConfirmed: &timeUpdate{},
+
 		Events: NewEvents(),
 	}
 }
 
 // AcceptedTime returns the Time of the last accepted Block.
 func (c *Clock) AcceptedTime() (acceptedTime time.Time) {
-	c.lastAccepted.RLock()
-	defer c.lastAccepted.RUnlock()
-
-	return c.lastAccepted.Time
+	return c.lastAccepted.Time()
 }
 
 // SetAcceptedTime sets the Time of the last accepted Block.
 func (c *Clock) SetAcceptedTime(acceptedTime time.Time) (updated bool) {
 	now := time.Now()
-	if updated = c.updateTime(&c.lastAccepted, now, acceptedTime); updated {
+	if updated = c.lastAccepted.Update(now, acceptedTime); updated {
 		c.Events.AcceptanceTimeUpdated.Trigger(&TimeUpdateEvent{
 			NewTime:    acceptedTime,
 			UpdateTime: now,
@@ -43,24 +42,18 @@ func (c *Clock) SetAcceptedTime(acceptedTime time.Time) (updated bool) {
 
 // RelativeAcceptedTime returns the real-Time adjusted version of the Time of the last accepted Block.
 func (c *Clock) RelativeAcceptedTime() (relativeAcceptedTime time.Time) {
-	c.lastAccepted.RLock()
-	defer c.lastAccepted.RUnlock()
-
-	return c.lastAccepted.Time.Add(time.Since(c.lastAccepted.Updated))
+	return c.lastAccepted.RelativeTime()
 }
 
 // ConfirmedTime returns the Time of the last confirmed Block.
 func (c *Clock) ConfirmedTime() (confirmedTime time.Time) {
-	c.lastConfirmed.RLock()
-	defer c.lastConfirmed.RUnlock()
-
-	return c.lastConfirmed.Time
+	return c.lastConfirmed.Time()
 }
 
 // SetConfirmedTime sets the Time of the last confirmed Block.
 func (c *Clock) SetConfirmedTime(confirmedTime time.Time) (updated bool) {
 	now := time.Now()
-	if updated = c.updateTime(&c.lastConfirmed, now, confirmedTime); updated {
+	if updated = c.lastConfirmed.Update(now, confirmedTime); updated {
 		c.Events.ConfirmedTimeUpdated.Trigger(&TimeUpdateEvent{
 			NewTime:    confirmedTime,
 			UpdateTime: now,
@@ -72,27 +65,5 @@ func (c *Clock) SetConfirmedTime(confirmedTime time.Time) (updated bool) {
 
 // RelativeConfirmedTime returns the real-Time adjusted version of the Time of the last confirmed Block.
 func (c *Clock) RelativeConfirmedTime() (relativeConfirmedTime time.Time) {
-	c.lastConfirmed.RLock()
-	defer c.lastConfirmed.RUnlock()
-
-	return c.lastConfirmed.Time.Add(time.Since(c.lastConfirmed.Updated))
-}
-
-// updateTime updates the given Time parameter if the given Time larger than the current Time.
-func (c *Clock) updateTime(t *timeUpdate, now, newTime time.Time) (updated bool) {
-	t.Lock()
-	defer t.Unlock()
-
-	// the local wall clock should never be before the accepted Time unless we are eclipsed by malicious actors or our
-	// own Time is clearly in the past
-	if now.Before(newTime) {
-		panic(fmt.Sprintf("tried to set Time is in the future. now: %s, newTime: %s", now.String(), newTime.String()))
-	}
-
-	if updated = newTime.Unix() > t.Time.Unix(); updated {
-		t.Time = newTime
-		t.Updated = now
-	}
-
-	return
+	return c.lastConfirmed.RelativeTime()
 }

--- a/packages/protocol/engine/clock/timeupdate.go
+++ b/packages/protocol/engine/clock/timeupdate.go
@@ -1,0 +1,12 @@
+package clock
+
+import (
+	"sync"
+	"time"
+)
+
+type timeUpdate struct {
+	Time    time.Time
+	Updated time.Time
+	sync.RWMutex
+}

--- a/packages/protocol/engine/clock/timeupdate.go
+++ b/packages/protocol/engine/clock/timeupdate.go
@@ -1,12 +1,46 @@
 package clock
 
 import (
+	"fmt"
 	"sync"
 	"time"
 )
 
 type timeUpdate struct {
-	Time    time.Time
-	Updated time.Time
-	sync.RWMutex
+	time    time.Time
+	updated time.Time
+	mutex   sync.RWMutex
+}
+
+func (c *timeUpdate) Time() time.Time {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	return c.time
+}
+
+func (c *timeUpdate) RelativeTime() time.Time {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	return c.time.Add(time.Since(c.updated))
+}
+
+// Update updates the given Time parameter if the given Time larger than the current Time.
+func (c *timeUpdate) Update(now, newTime time.Time) (updated bool) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	// the local wall clock should never be before the accepted Time unless we are eclipsed by malicious actors or our
+	// own Time is clearly in the past
+	if now.Before(newTime) {
+		panic(fmt.Sprintf("tried to set Time is in the future. now: %s, newTime: %s", now.String(), newTime.String()))
+	}
+
+	if updated = newTime.Unix() > c.time.Unix(); updated {
+		c.time = newTime
+		c.updated = now
+	}
+
+	return
 }

--- a/packages/protocol/engine/engine.go
+++ b/packages/protocol/engine/engine.go
@@ -10,6 +10,7 @@ import (
 	"github.com/iotaledger/hive.go/core/generics/event"
 	"github.com/iotaledger/hive.go/core/generics/options"
 	"github.com/iotaledger/hive.go/core/identity"
+	"github.com/iotaledger/hive.go/core/workerpool"
 
 	"github.com/iotaledger/goshimmer/packages/core/epoch"
 	"github.com/iotaledger/goshimmer/packages/core/eventticker"
@@ -53,6 +54,8 @@ type Engine struct {
 	TSCManager          *tsc.Manager
 	Clock               *clock.Clock
 
+	workerPools map[string]*workerpool.UnboundedWorkerPool
+
 	isBootstrapped      bool
 	isBootstrappedMutex sync.Mutex
 
@@ -83,6 +86,8 @@ func New(
 			Storage:       storageInstance,
 			Constructable: traits.NewConstructable(),
 			Stoppable:     traits.NewStoppable(),
+
+			workerPools: map[string]*workerpool.UnboundedWorkerPool{},
 
 			optsBootstrappedThreshold: 10 * time.Second,
 			optsSnapshotDepth:         5,
@@ -118,6 +123,10 @@ func New(
 			e.TriggerConstructed()
 		},
 	)
+}
+
+func (e *Engine) WorkerPools() map[string]*workerpool.UnboundedWorkerPool {
+	return e.workerPools
 }
 
 func (e *Engine) ProcessBlockFromPeer(block *models.Block, source identity.ID) {
@@ -306,13 +315,13 @@ func (e *Engine) initConsensus() {
 }
 
 func (e *Engine) initClock() {
-	e.Events.Consensus.BlockGadget.BlockAccepted.Attach(event.NewClosure(func(block *blockgadget.Block) {
+	e.workerPools["Clock.SetAcceptedTime"] = e.Events.Consensus.BlockGadget.BlockAccepted.AttachWithNewWorkerPool(event.NewClosure(func(block *blockgadget.Block) {
 		e.Clock.SetAcceptedTime(block.IssuingTime())
-	}))
+	}), 1)
 
-	e.Events.Consensus.BlockGadget.BlockConfirmed.Attach(event.NewClosure(func(block *blockgadget.Block) {
+	e.workerPools["Clock.SetConfirmedTime"] = e.Events.Consensus.BlockGadget.BlockConfirmed.AttachWithNewWorkerPool(event.NewClosure(func(block *blockgadget.Block) {
 		e.Clock.SetConfirmedTime(block.IssuingTime())
-	}))
+	}), 1)
 
 	e.Events.Consensus.EpochGadget.EpochConfirmed.Attach(event.NewClosure(func(epochIndex epoch.Index) {
 		e.Clock.SetConfirmedTime(epochIndex.EndTime())
@@ -346,17 +355,19 @@ func (e *Engine) initBlockStorage() {
 }
 
 func (e *Engine) initNotarizationManager() {
-	e.Consensus.BlockGadget.Events.BlockAccepted.Attach(event.NewClosure(func(block *blockgadget.Block) {
+	wp := e.Consensus.BlockGadget.Events.BlockAccepted.AttachWithNewWorkerPool(event.NewClosure(func(block *blockgadget.Block) {
 		if err := e.NotarizationManager.NotarizeAcceptedBlock(block.ModelsBlock); err != nil {
 			e.Events.Error.Trigger(errors.Errorf("failed to add accepted block %s to epoch: %w", block.ID(), err))
 		}
-	}))
-	e.Tangle.Events.BlockDAG.BlockOrphaned.Attach(event.NewClosure(func(block *blockdag.Block) {
+	}), 1)
+	e.Tangle.Events.BlockDAG.BlockOrphaned.AttachWithWorkerPool(event.NewClosure(func(block *blockdag.Block) {
 		if err := e.NotarizationManager.NotarizeOrphanedBlock(block.ModelsBlock); err != nil {
 			e.Events.Error.Trigger(errors.Errorf("failed to remove orphaned block %s from epoch: %w", block.ID(), err))
 		}
-	}))
+	}), wp)
+	e.workerPools["NotarizationManager.Blocks"] = wp
 
+	// TODO: Why is it hooked?
 	e.Ledger.Events.TransactionAccepted.Hook(event.NewClosure(func(event *ledger.TransactionEvent) {
 		if err := e.NotarizationManager.EpochMutations.AddAcceptedTransaction(event.Metadata); err != nil {
 			e.Events.Error.Trigger(errors.Errorf("failed to add accepted transaction %s to epoch: %w", event.Metadata.ID(), err))
@@ -369,20 +380,21 @@ func (e *Engine) initNotarizationManager() {
 	}))
 	// TODO: add transaction orphaned event
 
-	e.Ledger.ConflictDAG.Events.ConflictCreated.Hook(event.NewClosure(func(event *conflictdag.ConflictCreatedEvent[utxo.TransactionID, utxo.OutputID]) {
-		e.NotarizationManager.IncreaseConflictsCounter(epoch.IndexFromTime(e.Tangle.GetEarliestAttachment(event.ID).IssuingTime()))
-	}))
-	e.Ledger.ConflictDAG.Events.ConflictAccepted.Hook(event.NewClosure(func(conflictID utxo.TransactionID) {
-		e.NotarizationManager.DecreaseConflictsCounter(epoch.IndexFromTime(e.Tangle.GetEarliestAttachment(conflictID).IssuingTime()))
-	}))
-	e.Ledger.ConflictDAG.Events.ConflictRejected.Hook(event.NewClosure(func(conflictID utxo.TransactionID) {
-		e.NotarizationManager.DecreaseConflictsCounter(epoch.IndexFromTime(e.Tangle.GetEarliestAttachment(conflictID).IssuingTime()))
-	}))
-
 	// Epochs are committed whenever ATT advances, start committing only when bootstrapped.
-	e.Clock.Events.AcceptanceTimeUpdated.Attach(event.NewClosure(func(event *clock.TimeUpdateEvent) {
+	wp = e.Clock.Events.AcceptanceTimeUpdated.AttachWithNewWorkerPool(event.NewClosure(func(event *clock.TimeUpdateEvent) {
 		e.NotarizationManager.SetAcceptanceTime(event.NewTime)
-	}))
+	}), 1)
+
+	e.Ledger.ConflictDAG.Events.ConflictCreated.AttachWithWorkerPool(event.NewClosure(func(event *conflictdag.ConflictCreatedEvent[utxo.TransactionID, utxo.OutputID]) {
+		e.NotarizationManager.IncreaseConflictsCounter(epoch.IndexFromTime(e.Tangle.GetEarliestAttachment(event.ID).IssuingTime()))
+	}), wp)
+	e.Ledger.ConflictDAG.Events.ConflictAccepted.AttachWithWorkerPool(event.NewClosure(func(conflictID utxo.TransactionID) {
+		e.NotarizationManager.DecreaseConflictsCounter(epoch.IndexFromTime(e.Tangle.GetEarliestAttachment(conflictID).IssuingTime()))
+	}), wp)
+	e.Ledger.ConflictDAG.Events.ConflictRejected.AttachWithWorkerPool(event.NewClosure(func(conflictID utxo.TransactionID) {
+		e.NotarizationManager.DecreaseConflictsCounter(epoch.IndexFromTime(e.Tangle.GetEarliestAttachment(conflictID).IssuingTime()))
+	}), wp)
+	e.workerPools["NotarizationManager.Commitments"] = wp
 
 	e.Events.NotarizationManager.LinkTo(e.NotarizationManager.Events)
 	e.Events.EpochMutations.LinkTo(e.NotarizationManager.EpochMutations.Events)

--- a/packages/protocol/protocol.go
+++ b/packages/protocol/protocol.go
@@ -5,8 +5,10 @@ import (
 	"sync"
 
 	"github.com/iotaledger/hive.go/core/generics/event"
+	"github.com/iotaledger/hive.go/core/generics/lo"
 	"github.com/iotaledger/hive.go/core/generics/options"
 	"github.com/iotaledger/hive.go/core/identity"
+	"github.com/iotaledger/hive.go/core/workerpool"
 
 	"github.com/iotaledger/goshimmer/packages/core/commitment"
 	"github.com/iotaledger/goshimmer/packages/core/database"
@@ -108,6 +110,12 @@ func (p *Protocol) Shutdown() {
 	if p.candidateStorage != nil {
 		p.candidateStorage.Shutdown()
 	}
+}
+
+func (p *Protocol) WorkerPools() map[string]*workerpool.UnboundedWorkerPool {
+	wps := make(map[string]*workerpool.UnboundedWorkerPool)
+	wps["CongestionControl"] = p.CongestionControl.WorkerPool()
+	return lo.MergeMaps(wps, p.engine.WorkerPools())
 }
 
 func (p *Protocol) initDirectory() {

--- a/plugins/prometheus/workerpool.go
+++ b/plugins/prometheus/workerpool.go
@@ -6,7 +6,6 @@ import (
 )
 
 var (
-	// workerCount  prometheus.Gauge
 	pendingTasks *prometheus.GaugeVec
 	workerCount  *prometheus.GaugeVec
 )

--- a/plugins/prometheus/workerpool.go
+++ b/plugins/prometheus/workerpool.go
@@ -6,35 +6,46 @@ import (
 )
 
 var (
-	workerCount  prometheus.Gauge
-	pendingTasks prometheus.Gauge
+	// workerCount  prometheus.Gauge
+	pendingTasks *prometheus.GaugeVec
+	workerCount  *prometheus.GaugeVec
 )
 
 func registerWorkerPoolMetrics() {
-	workerCount = prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Namespace: "workerpool",
-			Subsystem: "eventloop",
-			Name:      "workers",
-			Help:      "Number of workers in the event loop worker pool.",
-		},
-	)
-	pendingTasks = prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Namespace: "workerpool",
-			Subsystem: "eventloop",
-			Name:      "tasks_pending",
-			Help:      "Number of pending tasks in the event loop worker pool.",
-		},
-	)
+	workerCount = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "workerpool",
+		Name:      "workers",
+		Help:      "Number of workers in the worker pool.",
+	}, []string{"type"})
+
+	pendingTasks = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "workerpool",
+		Name:      "tasks_pending",
+		Help:      "Number of pending tasks in the worker pool..",
+	}, []string{"type"})
 
 	registry.MustRegister(pendingTasks)
 	registry.MustRegister(workerCount)
 
 	addCollect(collectWorkerPoolMetrics)
+	if deps.Retainer != nil {
+		addCollect(collectRetainerWorkerPoolMetric)
+	}
 }
 
 func collectWorkerPoolMetrics() {
-	workerCount.Set(float64(event.Loop.WorkerCount()))
-	pendingTasks.Set(float64(event.Loop.PendingTasksCounter.Value()))
+	workerCount.WithLabelValues("eventloop").Set(float64(event.Loop.WorkerCount()))
+	pendingTasks.WithLabelValues("eventloop").Set(float64(event.Loop.PendingTasksCounter.Value()))
+
+	if deps.Protocol != nil {
+		for name, wp := range deps.Protocol.WorkerPools() {
+			workerCount.WithLabelValues(name).Set(float64(wp.WorkerCount()))
+			pendingTasks.WithLabelValues(name).Set(float64(wp.PendingTasksCounter.Value()))
+		}
+	}
+}
+
+func collectRetainerWorkerPoolMetric() {
+	workerCount.WithLabelValues("retainer").Set(float64(deps.Retainer.WorkerPool().WorkerCount()))
+	pendingTasks.WithLabelValues("retainer").Set(float64(deps.Retainer.WorkerPool().PendingTasksCounter.Value()))
 }

--- a/plugins/retainer/plugin.go
+++ b/plugins/retainer/plugin.go
@@ -39,9 +39,9 @@ func init() {
 }
 
 func configure(*node.Plugin) {
-	deps.Protocol.Events.Engine.Consensus.EpochGadget.EpochConfirmed.Attach(event.NewClosure(func(epochIndex epoch.Index) {
+	deps.Protocol.Events.Engine.Consensus.EpochGadget.EpochConfirmed.AttachWithWorkerPool(event.NewClosure(func(epochIndex epoch.Index) {
 		deps.Retainer.PruneUntilEpoch(epochIndex - epoch.Index(Parameters.PruningThreshold))
-	}))
+	}), deps.Retainer.WorkerPool())
 }
 
 func createRetainer(p *protocol.Protocol) *retainer.Retainer {

--- a/tools/docker-network/grafana/dashboards/local_dashboard.json
+++ b/tools/docker-network/grafana/dashboards/local_dashboard.json
@@ -25,7 +25,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 7,
+  "id": 4,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -93,7 +93,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "9.2.6",
+      "pluginVersion": "9.2.0",
       "targets": [
         {
           "expr": "iota_info_app{instance=\"$instance\"}",
@@ -158,7 +158,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "9.2.6",
+      "pluginVersion": "9.2.0",
       "targets": [
         {
           "exemplar": true,
@@ -225,7 +225,7 @@
         "text": {},
         "textMode": "value"
       },
-      "pluginVersion": "9.2.6",
+      "pluginVersion": "9.2.0",
       "targets": [
         {
           "exemplar": true,
@@ -294,7 +294,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "9.2.6",
+      "pluginVersion": "9.2.0",
       "targets": [
         {
           "expr": "tangleTimeSynced{instance=\"$instance\"}",
@@ -355,7 +355,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "9.2.6",
+      "pluginVersion": "9.2.0",
       "targets": [
         {
           "datasource": {
@@ -418,7 +418,7 @@
         "text": {},
         "textMode": "value"
       },
-      "pluginVersion": "9.2.6",
+      "pluginVersion": "9.2.0",
       "targets": [
         {
           "expr": "mana_access{instance=\"$instance\",nodeID=\"$NodeID\"}",
@@ -474,7 +474,7 @@
         "text": {},
         "textMode": "value"
       },
-      "pluginVersion": "9.2.6",
+      "pluginVersion": "9.2.0",
       "targets": [
         {
           "datasource": {
@@ -539,7 +539,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "9.2.6",
+      "pluginVersion": "9.2.0",
       "targets": [
         {
           "datasource": {
@@ -605,7 +605,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "9.2.6",
+      "pluginVersion": "9.2.0",
       "targets": [
         {
           "datasource": {
@@ -671,7 +671,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "9.2.6",
+      "pluginVersion": "9.2.0",
       "targets": [
         {
           "datasource": {
@@ -737,7 +737,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "9.2.6",
+      "pluginVersion": "9.2.0",
       "targets": [
         {
           "datasource": {
@@ -1149,8 +1149,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -1208,8 +1207,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   }
                 ]
               },
@@ -1264,8 +1262,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -1323,8 +1320,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -1559,8 +1555,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   }
                 ]
               },
@@ -1614,8 +1609,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   }
                 ]
               },
@@ -1669,8 +1663,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   }
                 ]
               },
@@ -1724,8 +1717,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   }
                 ]
               },
@@ -1779,8 +1771,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   }
                 ]
               },
@@ -2359,8 +2350,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   }
                 ]
               },
@@ -2425,8 +2415,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -2492,8 +2481,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   }
                 ]
               },
@@ -2554,8 +2542,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   }
                 ]
               },
@@ -2618,8 +2605,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   }
                 ]
               },
@@ -4118,8 +4104,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4181,8 +4166,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4244,8 +4228,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4307,8 +4290,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4389,8 +4371,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   }
                 ]
               },
@@ -4451,8 +4432,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   }
                 ]
               },
@@ -4511,8 +4491,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   }
                 ]
               }
@@ -4572,8 +4551,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   }
                 ]
               }
@@ -4632,8 +4610,7 @@
                 "mode": "percentage",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   }
                 ]
               },
@@ -4693,8 +4670,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   }
                 ]
               }
@@ -4752,8 +4728,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   }
                 ]
               }
@@ -4815,8 +4790,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   }
                 ]
               },
@@ -4883,8 +4857,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   }
                 ]
               },
@@ -4943,8 +4916,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   }
                 ]
               }
@@ -5002,8 +4974,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   }
                 ]
               },
@@ -5066,8 +5037,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   }
                 ]
               }
@@ -5144,8 +5114,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   }
                 ]
               },
@@ -5208,8 +5177,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   }
                 ]
               }
@@ -5267,8 +5235,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   }
                 ]
               },
@@ -5331,8 +5298,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   }
                 ]
               },
@@ -5385,7 +5351,7 @@
       "type": "row"
     },
     {
-      "collapsed": true,
+      "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -5393,163 +5359,162 @@
         "y": 7
       },
       "id": 157,
-      "panels": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+      "panels": [],
+      "title": "Workerpools",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
           },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  }
-                ]
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
               }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 9,
-            "w": 3,
-            "x": 0,
-            "y": 139
-          },
-          "id": 159,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto"
-          },
-          "pluginVersion": "9.2.6",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
-              },
-              "editorMode": "code",
-              "expr": "workerpool_eventloop_workers{instance=\"$instance\"}",
-              "legendFormat": "__auto",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Event loop workers",
-          "type": "stat"
+            ]
+          }
         },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 3,
+        "x": 0,
+        "y": 8
+      },
+      "id": 159,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.2.0",
+      "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 9,
-            "w": 21,
-            "x": 3,
-            "y": 139
-          },
-          "id": 161,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
-              },
-              "editorMode": "code",
-              "expr": "workerpool_eventloop_tasks_pending{instance=\"$instance\"}",
-              "legendFormat": "{{instance}}",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Event loop pending tasks",
-          "type": "timeseries"
+          "editorMode": "code",
+          "expr": "workerpool_workers{instance=\"$instance\"}",
+          "legendFormat": "{{type}}",
+          "range": true,
+          "refId": "A"
         }
       ],
-      "title": "Event loop",
-      "type": "row"
+      "title": "Workers",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 21,
+        "x": 3,
+        "y": 8
+      },
+      "id": 161,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "workerpool_tasks_pending{instance=\"$instance\"}",
+          "legendFormat": "{{type}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Pending Tasks",
+      "type": "timeseries"
     }
   ],
   "refresh": "10s",
@@ -5591,8 +5556,8 @@
       {
         "current": {
           "selected": false,
-          "text": "GbkZ3Coi",
-          "value": "GbkZ3Coi"
+          "text": "FZ6xmPZX",
+          "value": "FZ6xmPZX"
         },
         "datasource": {
           "type": "prometheus",


### PR DESCRIPTION
# Description of change

This PR solves the global worker pools contention problem, where all/many workers of the global event loop/worker pool were competing for the same lock. This is done by adding separate consumers to tasks that are prone to create contention. In code this reflects via specifying a distinct worker pool when attaching to an event.

It updates the Grafana dashboard `GoShimmer Local Metrics` to show all worker pools
<img width="1639" alt="image" src="https://user-images.githubusercontent.com/4181434/211621263-3e9911a2-e33c-468a-9988-f6cc7e285d4a.png">

Fixes #2507

