### PR TITLE
ratesetter.Enabled param removed, enable deficit rateSetter on networks

### DIFF
--- a/deploy/ansible/roles/goshimmer-node/templates/docker-compose-goshimmer.yml.j2
+++ b/deploy/ansible/roles/goshimmer-node/templates/docker-compose-goshimmer.yml.j2
@@ -69,7 +69,6 @@ services:
       --logger.disableEvents=false
       --logger.remotelog.serverAddress={{ remoteLoggerHost }}:5213
       --remotemetrics.metricsLevel=0
-      --blockIssuer.rateSetter.enable=false
       {% if bootstrap|default(false) %}
       --blockIssuer.ignoreBootstrappedFlag=true
       {% else %}

--- a/deploy/ansible/roles/goshimmer-node/templates/docker-compose-public-node.yml.j2
+++ b/deploy/ansible/roles/goshimmer-node/templates/docker-compose-public-node.yml.j2
@@ -51,7 +51,6 @@ services:
       --logger.level={{ logLevel }}
       --logger.outputPaths=stdout
       --logger.disableEvents=false
-      --blockIssuer.rateSetter.enable=false
       --logger.remotelog.serverAddress={{ remoteLoggerHost }}:5213
       --remotemetrics.metricsLevel=0
       --blockIssuer.ignoreBootstrappedFlag=false

--- a/tools/docker-network/docker-compose-feature.yml
+++ b/tools/docker-network/docker-compose-feature.yml
@@ -25,7 +25,6 @@ services:
       --config=/run/secrets/goshimmer.config.json
       --database.directory=/app/db
       --protocol.snapshot.path=./snapshot.bin
-      --blockIssuer.rateSetter.enable=false
       --node.peerDBDirectory=/app/peerdb
       --node.disablePlugins=portcheck,Firewall,ManaInitializer,RemoteLog,AnalysisClient
       --node.enablePlugins=metrics,spammer,WebAPIToolsBlockEndpoint,activity
@@ -68,7 +67,6 @@ services:
       --config=/run/secrets/goshimmer.config.json
       --database.directory=/app/db
       --protocol.snapshot.path=./snapshot.bin
-      --blockIssuer.rateSetter.enable=false
       --node.peerDBDirectory=/app/peerdb
       --node.disablePlugins=portcheck,Firewall,ManaInitializer,RemoteLog,AnalysisClient
       --node.enablePlugins=metrics,spammer,WebAPIToolsBlockEndpoint,activity,faucet
@@ -108,7 +106,6 @@ services:
       --config=/run/secrets/goshimmer.config.json
       --database.directory=/app/db
       --protocol.snapshot.path=./snapshot.bin
-      --blockIssuer.rateSetter.enable=false
       --node.peerDBDirectory=/app/peerdb
       --node.disablePlugins=portcheck,Firewall,ManaInitializer,RemoteLog,AnalysisClient
       --node.enablePlugins=metrics,spammer,WebAPIToolsBlockEndpoint,activity
@@ -147,7 +144,6 @@ services:
       --config=/run/secrets/goshimmer.config.json
       --database.directory=/app/db
       --protocol.snapshot.path=./snapshot.bin
-      --blockIssuer.rateSetter.enable=false
       --node.peerDBDirectory=/app/peerdb
       --node.disablePlugins=portcheck,Firewall,ManaInitializer,RemoteLog,AnalysisClient
       --node.enablePlugins=metrics,spammer,WebAPIToolsBlockEndpoint,activity
@@ -185,7 +181,6 @@ services:
       --config=/run/secrets/goshimmer.config.json
       --database.directory=/app/db
       --protocol.snapshot.path=./snapshot.bin
-      --blockIssuer.rateSetter.enable=false
       --node.peerDBDirectory=/app/peerdb
       --node.disablePlugins=portcheck,Firewall,ManaInitializer,RemoteLog,AnalysisClient
       --node.enablePlugins=metrics,spammer,WebAPIToolsBlockEndpoint,activity
@@ -223,7 +218,6 @@ services:
       --config=/run/secrets/goshimmer.config.json
       --database.directory=/app/db
       --protocol.snapshot.path=./snapshot.bin
-      --blockIssuer.rateSetter.enable=false
       --node.peerDBDirectory=/app/peerdb
       --node.disablePlugins=portcheck,Firewall,ManaInitializer,RemoteLog,AnalysisClient
       --node.enablePlugins=metrics,spammer,WebAPIToolsBlockEndpoint,activity
@@ -261,7 +255,6 @@ services:
       --config=/run/secrets/goshimmer.config.json
       --database.directory=/app/db
       --protocol.snapshot.path=./snapshot.bin
-      --blockIssuer.rateSetter.enable=false
       --node.peerDBDirectory=/app/peerdb
       --node.disablePlugins=portcheck,Firewall,ManaInitializer,RemoteLog,AnalysisClient
       --node.enablePlugins=metrics,spammer,WebAPIToolsBlockEndpoint,activity
@@ -299,7 +292,6 @@ services:
       --config=/run/secrets/goshimmer.config.json
       --database.directory=/app/db
       --protocol.snapshot.path=./snapshot.bin
-      --blockIssuer.rateSetter.enable=false
       --node.peerDBDirectory=/app/peerdb
       --node.disablePlugins=portcheck,Firewall,ManaInitializer,RemoteLog,AnalysisClient
       --node.enablePlugins=metrics,spammer,WebAPIToolsBlockEndpoint,activity

--- a/tools/docker-network/docker-compose.yml
+++ b/tools/docker-network/docker-compose.yml
@@ -50,7 +50,6 @@ services:
       --node.disablePlugins=portcheck,Firewall,ManaInitializer,RemoteLog,AnalysisClient
       --node.overwriteStoredSeed=true
       --protocol.snapshot.path=./snapshot.bin
-      --blockIssuer.rateSetter.enable=false
       --metrics.bindAddress=0.0.0.0:9311
       --protocol.genesisTime=${GENESIS_TIME}
       --metrics.processMetrics=true


### PR DESCRIPTION
# Description of change

* rateSetter.Enabled doesn't exist anymore.
* Enable "deficit" rateSetter by default on our networks.