### PR TITLE
Reduce the pruning treshhold of the retainer to half a day

### DIFF
--- a/deploy/ansible/roles/goshimmer-node/templates/docker-compose-goshimmer.yml.j2
+++ b/deploy/ansible/roles/goshimmer-node/templates/docker-compose-goshimmer.yml.j2
@@ -81,3 +81,4 @@ services:
       --metrics.goMetrics=true
       --metrics.processMetrics=true
       --profilingRecorder.outputPath=/profiles
+      --retainer.pruningThreshold=4320

--- a/deploy/ansible/roles/goshimmer-node/templates/docker-compose-public-node.yml.j2
+++ b/deploy/ansible/roles/goshimmer-node/templates/docker-compose-public-node.yml.j2
@@ -58,3 +58,4 @@ services:
       --metrics.goMetrics=true
       --metrics.processMetrics=true
       --profilingRecorder.outputPath=/profiles
+      --retainer.pruningThreshold=4320


### PR DESCRIPTION
The nodes in the feature net crashed with `No space left on device` before they could prune. Lets reduce the treshhold to half a day for now.