### PR TITLE
Fix protocol not running on node startup

### DIFF
--- a/plugins/protocol/plugin.go
+++ b/plugins/protocol/plugin.go
@@ -168,8 +168,9 @@ func configureLogging(plugin *node.Plugin) {
 }
 
 func run(plugin *node.Plugin) {
+	deps.Protocol.Run()
+
 	if err := daemon.BackgroundWorker("protocol", func(ctx context.Context) {
-		deps.Protocol.Run()
 		<-ctx.Done()
 		plugin.LogInfo("Gracefully shutting down the Protocol...")
 		deps.Protocol.Shutdown()


### PR DESCRIPTION
If not done synchronously there might be a race condition where https://github.com/iotaledger/goshimmer/blob/1cfa01c301f15cdfc7b04ad09109695265a9589c/plugins/metrics/metrics_tangle.go#L77 is nil and the node panics if metrics are enabled