### PR TITLE
Fix calculation of Epoch's end time

### DIFF
--- a/packages/core/epoch/epoch.go
+++ b/packages/core/epoch/epoch.go
@@ -67,7 +67,9 @@ func (i Index) StartTime() time.Time {
 
 // EndTime returns the latest possible timestamp for an Epoch. Anything with higher timestamp will belong to the next epoch.
 func (i Index) EndTime() time.Time {
-	return i.StartTime().Add(time.Duration(Duration) * time.Second).Add(-1)
+        endUnix := GenesisTime + int64(i)*Duration
+        // we subtract 1 nanosecond from the next epoch to get the latest possible timestamp for epoch i
+	return time.Unix(endUnix, 0).Add(-1)
 }
 
 // Max returns the maximum of the two given epochs.

--- a/packages/core/epoch/epoch.go
+++ b/packages/core/epoch/epoch.go
@@ -10,7 +10,7 @@ import (
 
 var (
 	// GenesisTime is the time (Unix in seconds) of the genesis.
-	GenesisTime int64 = 1666037699
+	GenesisTime int64 = 1666037700
 
 	// Duration is the default epoch duration in seconds.
 	Duration int64 = 10
@@ -65,10 +65,9 @@ func (i Index) StartTime() time.Time {
 	return time.Unix(startUnix, 0)
 }
 
-// EndTime calculates the end time of the given epoch.
+// EndTime returns the latest possible timestamp for an Epoch. Anything with higher timestamp will belong to the next epoch.
 func (i Index) EndTime() time.Time {
-	endUnix := GenesisTime + int64(i-1)*Duration + Duration - 1
-	return time.Unix(endUnix, 0)
+	return i.StartTime().Add(time.Duration(Duration) * time.Second).Add(-1)
 }
 
 // Max returns the maximum of the two given epochs.

--- a/packages/core/epoch/epoch.go
+++ b/packages/core/epoch/epoch.go
@@ -67,8 +67,8 @@ func (i Index) StartTime() time.Time {
 
 // EndTime returns the latest possible timestamp for an Epoch. Anything with higher timestamp will belong to the next epoch.
 func (i Index) EndTime() time.Time {
-        endUnix := GenesisTime + int64(i)*Duration
-        // we subtract 1 nanosecond from the next epoch to get the latest possible timestamp for epoch i
+	endUnix := GenesisTime + int64(i)*Duration
+	// we subtract 1 nanosecond from the next epoch to get the latest possible timestamp for epoch i
 	return time.Unix(endUnix, 0).Add(-1)
 }
 

--- a/packages/core/epoch/epoch_test.go
+++ b/packages/core/epoch/epoch_test.go
@@ -4,59 +4,67 @@ import (
 	"testing"
 	"time"
 
-	"github.com/magiconair/properties/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestEpoch(t *testing.T) {
 	genesisTime := time.Unix(GenesisTime, 0)
 
 	{
-		// ei = 0
+		endOfEpochTime := genesisTime.Add(time.Duration(Duration) * time.Second).Add(-1)
+
+		assert.Equal(t, Index(1), IndexFromTime(endOfEpochTime))
+		assert.False(t, Index(1).EndTime().Before(endOfEpochTime))
+
+		startOfEpochTime := genesisTime.Add(time.Duration(Duration) * time.Second)
+
+		assert.Equal(t, Index(2), IndexFromTime(startOfEpochTime))
+		assert.False(t, Index(2).StartTime().After(startOfEpochTime))
+	}
+
+	{
 		testTime := genesisTime.Add(5 * time.Second)
-		ei := IndexFromTime(testTime)
-		assert.Equal(t, ei, Index(1))
+		index := IndexFromTime(testTime)
+		assert.Equal(t, index, Index(1))
 
-		startTime := ei.StartTime()
+		startTime := index.StartTime()
 		assert.Equal(t, startTime, time.Unix(genesisTime.Unix(), 0))
-		endTime := ei.EndTime()
-		assert.Equal(t, endTime, time.Unix(genesisTime.Add(9*time.Second).Unix(), 0))
+		endTime := index.EndTime()
+		assert.Equal(t, endTime, (index + 1).StartTime().Add(-1))
 	}
 
 	{
-		// ei = 1
 		testTime := genesisTime.Add(10 * time.Second)
-		ei := IndexFromTime(testTime)
-		assert.Equal(t, ei, Index(2))
+		index := IndexFromTime(testTime)
+		assert.Equal(t, index, Index(2))
 
-		startTime := ei.StartTime()
+		startTime := index.StartTime()
 		assert.Equal(t, startTime, time.Unix(genesisTime.Add(10*time.Second).Unix(), 0))
-		endTime := ei.EndTime()
-		assert.Equal(t, endTime, time.Unix(genesisTime.Add(19*time.Second).Unix(), 0))
+		endTime := index.EndTime()
+		assert.Equal(t, endTime, (index + 1).StartTime().Add(-1))
 	}
 
 	{
-		// ei = 3
 		testTime := genesisTime.Add(35 * time.Second)
-		ei := IndexFromTime(testTime)
-		assert.Equal(t, ei, Index(4))
+		index := IndexFromTime(testTime)
+		assert.Equal(t, index, Index(4))
 
-		startTime := ei.StartTime()
+		startTime := index.StartTime()
 		assert.Equal(t, startTime, time.Unix(genesisTime.Add(30*time.Second).Unix(), 0))
-		endTime := ei.EndTime()
-		assert.Equal(t, endTime, time.Unix(genesisTime.Add(39*time.Second).Unix(), 0))
+		endTime := index.EndTime()
+		assert.Equal(t, endTime, (index + 1).StartTime().Add(-1))
 	}
 
 	{
-		// ei = 4
 		testTime := genesisTime.Add(49 * time.Second)
-		ei := IndexFromTime(testTime)
-		assert.Equal(t, ei, Index(5))
+		index := IndexFromTime(testTime)
+		assert.Equal(t, index, Index(5))
 	}
 
 	{
-		// a time before genesis time, ei = 0
+		// a time before genesis time, index = 0
 		testTime := genesisTime.Add(-10 * time.Second)
-		ei := IndexFromTime(testTime)
-		assert.Equal(t, ei, Index(0))
+		index := IndexFromTime(testTime)
+		assert.Equal(t, index, Index(0))
 	}
 }

--- a/packages/protocol/engine/filter/filter_test.go
+++ b/packages/protocol/engine/filter/filter_test.go
@@ -116,7 +116,7 @@ func TestFilter_WithSignatureValidation(t *testing.T) {
 
 func TestFilter_MinCommittableEpochAge(t *testing.T) {
 	tf := NewTestFramework(t,
-		WithMinCommittableEpochAge(30*time.Second), // 3 epochs
+		WithMinCommittableEpochAge(3),
 		WithSignatureValidation(false),
 	)
 

--- a/packages/protocol/protocol_test.go
+++ b/packages/protocol/protocol_test.go
@@ -724,7 +724,7 @@ func TestProtocol_EngineSwitching(t *testing.T) {
 
 	engineOpts := []options.Option[engine.Engine]{
 		engine.WithNotarizationManagerOptions(
-			notarization.WithMinCommittableEpochAge(10 * time.Second),
+			notarization.WithMinCommittableEpochAge(1),
 		),
 		engine.WithLedgerOptions(ledger.WithVM(ledgerVM)),
 		engine.WithTangleOptions(

--- a/packages/protocol/tipmanager/tipmanager_test.go
+++ b/packages/protocol/tipmanager/tipmanager_test.go
@@ -168,7 +168,7 @@ func TestTipManager_TimeSinceConfirmation_Confirmed(t *testing.T) {
 		WithTipManagerOptions(WithTimeSinceConfirmationThreshold(5*time.Minute)),
 		WithEngineOptions(
 			engine.WithBootstrapThreshold(time.Since(time.Unix(epoch.GenesisTime, 0).Add(30*time.Second))),
-			engine.WithNotarizationManagerOptions(notarization.WithMinCommittableEpochAge(20*time.Minute)),
+			engine.WithNotarizationManagerOptions(notarization.WithMinCommittableEpochAge(20*6)),
 			engine.WithTangleOptions(tangle.WithBookerOptions(booker.WithMarkerManagerOptions(markermanager.WithSequenceManagerOptions[models.BlockID, *virtualvoting.Block](markers.WithMaxPastMarkerDistance(10))))),
 		),
 	)
@@ -228,7 +228,7 @@ func TestTipManager_TimeSinceConfirmation_MultipleParents(t *testing.T) {
 		WithTipManagerOptions(WithTimeSinceConfirmationThreshold(5*time.Minute)),
 		WithEngineOptions(
 			engine.WithBootstrapThreshold(time.Since(time.Unix(epoch.GenesisTime, 0).Add(30*time.Second))),
-			engine.WithNotarizationManagerOptions(notarization.WithMinCommittableEpochAge(20*time.Minute)),
+			engine.WithNotarizationManagerOptions(notarization.WithMinCommittableEpochAge(20*6)),
 			engine.WithTangleOptions(tangle.WithBookerOptions(booker.WithMarkerManagerOptions(markermanager.WithSequenceManagerOptions[models.BlockID, *virtualvoting.Block](markers.WithMaxPastMarkerDistance(10))))),
 		),
 	)
@@ -481,7 +481,7 @@ func TestTipManager_FutureTips(t *testing.T) {
 	workers := workerpool.NewGroup(t.Name())
 	tf := NewTestFramework(t, workers.CreateGroup("TipManagerTestFramework"),
 		WithEngineOptions(
-			engine.WithNotarizationManagerOptions(notarization.WithMinCommittableEpochAge(10*time.Second)),
+			engine.WithNotarizationManagerOptions(notarization.WithMinCommittableEpochAge(1)),
 		),
 	)
 	tf.Engine.EvictionState.AddRootBlock(models.EmptyBlockID)

--- a/plugins/protocol/parameters.go
+++ b/plugins/protocol/parameters.go
@@ -46,7 +46,7 @@ type SchedulerParametersDefinition struct {
 // NotarizationParametersDefinition contains the definition of the parameters used by the notarization plugin.
 type NotarizationParametersDefinition struct {
 	// MinEpochCommittableAge defines the min age of a committable epoch.
-	MinEpochCommittableAge time.Duration `default:"1m" usage:"min age of a committable epoch"`
+	MinEpochCommittableAge int64 `default:"6" usage:"min age of a committable epoch denoted in epochs"`
 }
 
 // DatabaseParametersDefinition contains the definition of configuration parameters used by the storage layer.

--- a/plugins/protocol/plugin.go
+++ b/plugins/protocol/plugin.go
@@ -76,12 +76,12 @@ func provide(n *p2p.Manager) (p *protocol.Protocol) {
 		),
 		protocol.WithEngineOptions(
 			engine.WithFilterOptions(
-				filter.WithMinCommittableEpochAge(NotarizationParameters.MinEpochCommittableAge),
+				filter.WithMinCommittableEpochAge(epoch.Index(NotarizationParameters.MinEpochCommittableAge)),
 				filter.WithMaxAllowedWallClockDrift(Parameters.MaxAllowedClockDrift),
 				filter.WithSignatureValidation(true),
 			),
 			engine.WithNotarizationManagerOptions(
-				notarization.WithMinCommittableEpochAge(NotarizationParameters.MinEpochCommittableAge),
+				notarization.WithMinCommittableEpochAge(epoch.Index(NotarizationParameters.MinEpochCommittableAge)),
 			),
 			engine.WithBootstrapThreshold(Parameters.BootstrapWindow),
 			engine.WithTSCManagerOptions(

--- a/tools/integration-tests/tester/framework/parameters.go
+++ b/tools/integration-tests/tester/framework/parameters.go
@@ -84,7 +84,7 @@ func PeerConfig() config.GoShimmer {
 	c.Protocol.GenesisTime = GenesisTime
 
 	c.Notarization.Enabled = true
-	c.Notarization.MinEpochCommittableAge = 60 * time.Second
+	c.Notarization.MinEpochCommittableAge = 6
 
 	c.BlockIssuer.Enabled = true
 	c.BlockIssuer.RateSetter.Mode = "disabled"


### PR DESCRIPTION
# Description of change

Fix calculation of Epoch's end time.
`MinCommittableEpochAge` is denoted in number of epochs instead of time, which simlifies the checks in NotarizationManager.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation Fix

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [ ] My code follows the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
