### PR TITLE
Fix race condition with future blocks and solidifier

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,6 @@ require (
 	github.com/jellydator/ttlcache/v2 v2.11.1
 	github.com/labstack/echo/v4 v4.10.0
 	github.com/libp2p/go-libp2p v0.25.1
-	github.com/magiconair/properties v1.8.6
 	github.com/mr-tron/base58 v1.2.0
 	github.com/multiformats/go-multiaddr v0.8.0
 	github.com/multiformats/go-varint v0.0.7
@@ -111,6 +110,7 @@ require (
 	github.com/libp2p/go-netroute v0.2.1 // indirect
 	github.com/libp2p/go-reuseport v0.2.0 // indirect
 	github.com/libp2p/go-yamux/v4 v4.0.0 // indirect
+	github.com/magiconair/properties v1.8.6 // indirect
 	github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.16 // indirect

--- a/packages/core/memstorage/storage.go
+++ b/packages/core/memstorage/storage.go
@@ -1,0 +1,135 @@
+package memstorage
+
+import (
+	"sync"
+
+	"github.com/iotaledger/hive.go/ds/shrinkingmap"
+	"github.com/iotaledger/hive.go/lo"
+)
+
+type Storage[K comparable, V any] struct {
+	storage *shrinkingmap.ShrinkingMap[K, V]
+	sync.RWMutex
+}
+
+func New[K comparable, V any]() *Storage[K, V] {
+	return &Storage[K, V]{
+		storage: shrinkingmap.New[K, V](),
+	}
+}
+
+func (s *Storage[K, V]) Get(key K) (value V, exists bool) {
+	s.RLock()
+	defer s.RUnlock()
+
+	return s.storage.Get(key)
+}
+
+func (s *Storage[K, V]) Has(key K) (has bool) {
+	s.RLock()
+	defer s.RUnlock()
+
+	return lo.Return2(s.storage.Get(key))
+}
+
+func (s *Storage[K, V]) Delete(key K) (deleted bool) {
+	s.Lock()
+	defer s.Unlock()
+
+	return s.storage.Delete(key)
+}
+
+func (s *Storage[K, V]) RetrieveOrCreate(key K, defaultValueFunc func() V) (value V, created bool) {
+	s.Lock()
+	defer s.Unlock()
+
+	if existingValue, exists := s.storage.Get(key); exists {
+		return existingValue, false
+	}
+
+	value = defaultValueFunc()
+	s.storage.Set(key, value)
+
+	return value, true
+}
+
+// ForEachKey iterates through the map and calls the consumer for every element.
+// Returning false from this function indicates to abort the iteration.
+func (s *Storage[K, V]) ForEachKey(callback func(K) bool) {
+	s.RLock()
+	defer s.RUnlock()
+
+	s.storage.ForEachKey(callback)
+}
+
+// ForEach iterates through the map and calls the consumer for every element.
+// Returning false from this function indicates to abort the iteration.
+func (s *Storage[K, V]) ForEach(callback func(K, V) bool) {
+	s.RLock()
+	defer s.RUnlock()
+
+	s.storage.ForEach(callback)
+}
+
+func (s *Storage[K, V]) First() (key K, value V) {
+	s.RLock()
+	defer s.RUnlock()
+
+	s.storage.ForEach(func(k K, v V) bool {
+		key = k
+		value = v
+
+		return false
+	})
+
+	return
+}
+
+func (s *Storage[K, V]) Set(key K, value V) (created bool) {
+	s.Lock()
+	defer s.Unlock()
+
+	return s.storage.Set(key, value)
+}
+
+func (s *Storage[K, V]) ExecuteIfAbsent(key K, callback func()) {
+	s.RLock()
+	defer s.RUnlock()
+
+	if _, exists := s.storage.Get(key); exists {
+		return
+	}
+
+	callback()
+}
+
+func (s *Storage[K, V]) StoreIfAbsent(key K, value V) (stored bool) {
+	s.Lock()
+	defer s.Unlock()
+
+	if _, exists := s.storage.Get(key); exists {
+		return false
+	}
+
+	s.storage.Set(key, value)
+
+	return true
+}
+
+func (s *Storage[K, V]) Size() (size int) {
+	s.RLock()
+	defer s.RUnlock()
+
+	return s.storage.Size()
+}
+
+func (s *Storage[K, V]) IsEmpty() (isEmpty bool) {
+	return s.Size() == 0
+}
+
+func (s *Storage[K, V]) AsMap() map[K]V {
+	s.RLock()
+	defer s.RUnlock()
+
+	return s.storage.AsMap()
+}

--- a/packages/protocol/engine/engine.go
+++ b/packages/protocol/engine/engine.go
@@ -283,6 +283,10 @@ func (e *Engine) initTangle() {
 		}
 	}, event.WithWorkerPool(e.Workers.CreatePool("Tangle.Attach", 2)))
 
+	e.Events.NotarizationManager.EpochCommitted.Hook(func(evt *notarization.EpochCommittedDetails) {
+		e.Tangle.BlockDAG.PromoteFutureBlocksUntil(evt.Commitment.Index())
+	}, event.WithWorkerPool(e.Workers.CreatePool("Tangle.PromoteFutureBlocksUntil", 1)))
+
 	e.Events.Tangle.LinkTo(e.Tangle.Events)
 }
 

--- a/packages/protocol/engine/tangle/blockdag/block.go
+++ b/packages/protocol/engine/tangle/blockdag/block.go
@@ -21,6 +21,7 @@ type Block struct {
 	solid                bool
 	invalid              bool
 	orphaned             bool
+	future               bool
 	strongChildren       []*Block
 	weakChildren         []*Block
 	likedInsteadChildren []*Block
@@ -75,6 +76,27 @@ func (b *Block) IsInvalid() (isInvalid bool) {
 	defer b.mutex.RUnlock()
 
 	return b.invalid
+}
+
+// IsFuture returns true if the Block is a future Block (we haven't committed to its commitment epoch yet).
+func (b *Block) IsFuture() (isFuture bool) {
+	b.mutex.RLock()
+	defer b.mutex.RUnlock()
+
+	return b.future
+}
+
+// setFuture marks the Block as future block.
+func (b *Block) setFuture() (wasUpdated bool) {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
+	if b.future {
+		return false
+	}
+
+	b.future = true
+	return true
 }
 
 // IsOrphaned returns true if the Block is orphaned (either due to being marked as orphaned itself or because it has

--- a/packages/protocol/engine/tangle/blockdag/blockdag.go
+++ b/packages/protocol/engine/tangle/blockdag/blockdag.go
@@ -142,29 +142,36 @@ func (b *BlockDAG) SetOrphaned(block *Block, orphaned bool) (updated bool) {
 func (b *BlockDAG) evictEpoch(index epoch.Index) {
 	b.solidifier.EvictUntil(index)
 
-	b.evictionMutex.Lock()
-	defer b.evictionMutex.Unlock()
-
+	// TODO: this should happen when we commit to an epoch, not on eviction as this is delayed!
 	// We want to deal with the synchronous BlockSolid events in a separate goroutine.
 	b.workerPool.Submit(func() {
 		b.promoteFutureBlocksUntil(index)
 	})
 
+	b.evictionMutex.Lock()
+	defer b.evictionMutex.Unlock()
+
 	b.memStorage.Evict(index)
 }
 
 func (b *BlockDAG) markSolid(block *Block) (err error) {
-	if err := b.checkParents(block); err != nil {
-		return err
+	// Future blocks already have passed these checks, as they are revisited again at a later point in time.
+	if !block.IsFuture() {
+		if err := b.checkParents(block); err != nil {
+			return err
+		}
+
+		if b.isFutureBlock(block) {
+			return
+		}
 	}
 
+	// It is important to only set the block as solid when it was not "parked" as a future block.
+	// Future blocks are queued for solidification again when the epoch is committed.
 	block.setSolid()
 
-	if b.isFutureBlock(block) {
-		return
-	}
-
-	b.promoteFutureBlocksUntil(block.Commitment().Index())
+	// TODO: this should be removed
+	//  b.promoteFutureBlocksUntil(block.Commitment().Index())
 
 	b.Events.BlockSolid.Trigger(block)
 
@@ -177,17 +184,17 @@ func (b *BlockDAG) isFutureBlock(block *Block) (isFutureBlock bool) {
 
 	// If we are not able to load the commitment for the block, it means we haven't committed this epoch yet.
 	if _, err := b.commitmentFunc(block.Commitment().Index()); err != nil {
-		b.storeFutureBlock(block)
+		// We set the block as future block so that we can skip some checks when revisiting it later in markSolid via the solidifier.
+		block.setFuture()
+
+		// TODO: no need for an advancedset anymore since we establish the order with the causal order.
+		lo.Return1(b.futureBlocks.Get(block.Commitment().Index(), true).GetOrCreate(block.Commitment().ID(), func() *advancedset.AdvancedSet[*Block] {
+			return advancedset.NewAdvancedSet[*Block]()
+		})).Add(block)
 		return true
 	}
 
 	return false
-}
-
-func (b *BlockDAG) storeFutureBlock(block *Block) {
-	lo.Return1(b.futureBlocks.Get(block.Commitment().Index(), true).GetOrCreate(block.Commitment().ID(), func() *advancedset.AdvancedSet[*Block] {
-		return advancedset.NewAdvancedSet[*Block]()
-	})).Add(block)
 }
 
 func (b *BlockDAG) promoteFutureBlocksUntil(index epoch.Index) {
@@ -204,7 +211,8 @@ func (b *BlockDAG) promoteFutureBlocksUntil(index epoch.Index) {
 				// Rely on the ordered nature of the underlying map: we need, in fact, to make sure we
 				// trigger the parents before the children.
 				_ = blocksStorage.ForEach(func(block *Block) (err error) {
-					b.Events.BlockSolid.Trigger(block)
+					fmt.Println("promoting future block", block.ID())
+					b.solidifier.Queue(block)
 					return nil
 				})
 			}
@@ -237,7 +245,7 @@ func (b *BlockDAG) checkParents(block *Block) (err error) {
 }
 
 func (b *BlockDAG) markInvalid(block *Block, reason error) {
-	b.SetInvalid(block, reason)
+	b.SetInvalid(block, errors.Wrap(reason, "block marked as invalid in BlockDAG"))
 }
 
 // attach tries to attach the given Block to the BlockDAG.

--- a/packages/protocol/engine/tangle/booker/booker.go
+++ b/packages/protocol/engine/tangle/booker/booker.go
@@ -308,7 +308,7 @@ func (b *Booker) book(block *virtualvoting.Block) (inheritingErr error) {
 }
 
 func (b *Booker) markInvalid(block *virtualvoting.Block, reason error) {
-	b.BlockDAG.SetInvalid(block.Block, reason)
+	b.BlockDAG.SetInvalid(block.Block, errors.Wrap(reason, "block marked as invalid in Booker"))
 }
 
 func (b *Booker) inheritConflictIDs(block *virtualvoting.Block) (inheritedConflictIDs utxo.TransactionIDs, err error) {


### PR DESCRIPTION
This PR fixes a relatively rare race condition where a future block is not yet available in the booker while one of its children is solidified via causal orderer (see figure below).

<img width="929" alt="image" src="https://user-images.githubusercontent.com/4181434/220987175-a4484cff-a032-475a-8a5b-283b5787e7cd.png">


The solution is to not mark future blocks as solid and enqueue future blocks again to the causal orderer once they can get promoted. Along with this there are some minor optimizations (checks that don't need to be executed multiple times).