### PR TITLE
Fix: Make branches inherit confirmation state of transactions

### DIFF
--- a/packages/protocol/engine/consensus/conflictresolver/conflictresolver_test.go
+++ b/packages/protocol/engine/consensus/conflictresolver/conflictresolver_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/iotaledger/goshimmer/packages/core/confirmation"
 	"github.com/iotaledger/goshimmer/packages/protocol/ledger/conflictdag"
 	"github.com/iotaledger/goshimmer/packages/protocol/ledger/utxo"
 	"github.com/iotaledger/hive.go/core/types"
@@ -910,7 +911,7 @@ func createTestConflict(t *testing.T, conflictDAG *conflictdag.ConflictDAG[utxo.
 	if conflictMeta.ConflictID == utxo.EmptyTransactionID {
 		panic("a conflict must have its ID defined in its ConflictMeta")
 	}
-	newConflictCreated = conflictDAG.CreateConflict(conflictMeta.ConflictID, conflictMeta.ParentConflicts, conflictMeta.Conflicting)
+	newConflictCreated = conflictDAG.CreateConflict(conflictMeta.ConflictID, conflictMeta.ParentConflicts, conflictMeta.Conflicting, confirmation.Pending)
 	require.True(t, newConflictCreated)
 
 	conflictMeta.ConflictID.RegisterAlias(alias)

--- a/packages/protocol/ledger/booker.go
+++ b/packages/protocol/ledger/booker.go
@@ -144,7 +144,7 @@ func (b *booker) determineConflictDetails(txID utxo.TransactionID, inputsMetadat
 	return conflictingInputIDs, consumersToFork
 }
 
-// forkTransaction forks an existing Transaction.
+// forkTransaction forks an existing Transaction and returns the confirmation state of the resulting Branch.
 func (b *booker) forkTransaction(ctx context.Context, txID utxo.TransactionID, outputsSpentByConflictingTx utxo.OutputIDs) (confirmationState confirmation.State) {
 	b.ledger.Utils.WithTransactionAndMetadata(txID, func(tx utxo.Transaction, txMetadata *TransactionMetadata) {
 		b.ledger.mutex.Lock(txID)

--- a/packages/protocol/ledger/booker.go
+++ b/packages/protocol/ledger/booker.go
@@ -6,6 +6,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/iotaledger/goshimmer/packages/core/cerrors"
+	"github.com/iotaledger/goshimmer/packages/core/confirmation"
 	"github.com/iotaledger/goshimmer/packages/protocol/ledger/utxo"
 	"github.com/iotaledger/goshimmer/packages/protocol/ledger/vm/devnetvm"
 	"github.com/iotaledger/hive.go/core/generics/dataflow"
@@ -94,11 +95,14 @@ func (b *booker) inheritConflictIDs(ctx context.Context, txID utxo.TransactionID
 		return parentConflictIDs
 	}
 
-	b.ledger.ConflictDAG.CreateConflict(txID, parentConflictIDs, conflictingInputIDs)
-
+	confirmationState := confirmation.Pending
 	for it := consumersToFork.Iterator(); it.HasNext(); {
-		b.forkTransaction(ctx, it.Next(), conflictingInputIDs)
+		if b.forkTransaction(ctx, it.Next(), conflictingInputIDs).IsAccepted() {
+			confirmationState = confirmation.Rejected
+		}
 	}
+
+	b.ledger.ConflictDAG.CreateConflict(txID, parentConflictIDs, conflictingInputIDs, confirmationState)
 
 	return advancedset.NewAdvancedSet(txID)
 }
@@ -141,14 +145,15 @@ func (b *booker) determineConflictDetails(txID utxo.TransactionID, inputsMetadat
 }
 
 // forkTransaction forks an existing Transaction.
-func (b *booker) forkTransaction(ctx context.Context, txID utxo.TransactionID, outputsSpentByConflictingTx utxo.OutputIDs) {
+func (b *booker) forkTransaction(ctx context.Context, txID utxo.TransactionID, outputsSpentByConflictingTx utxo.OutputIDs) (confirmationState confirmation.State) {
 	b.ledger.Utils.WithTransactionAndMetadata(txID, func(tx utxo.Transaction, txMetadata *TransactionMetadata) {
 		b.ledger.mutex.Lock(txID)
 
+		confirmationState = txMetadata.ConfirmationState()
 		conflictingInputs := b.ledger.Utils.ResolveInputs(tx.Inputs()).Intersect(outputsSpentByConflictingTx)
 		parentConflicts := txMetadata.ConflictIDs()
 
-		if !b.ledger.ConflictDAG.CreateConflict(txID, parentConflicts, conflictingInputs) {
+		if !b.ledger.ConflictDAG.CreateConflict(txID, parentConflicts, conflictingInputs, confirmationState) {
 			b.ledger.ConflictDAG.UpdateConflictingResources(txID, conflictingInputs)
 			b.ledger.mutex.Unlock(txID)
 			return
@@ -162,8 +167,12 @@ func (b *booker) forkTransaction(ctx context.Context, txID utxo.TransactionID, o
 		b.updateConflictsAfterFork(ctx, txMetadata, txID, parentConflicts)
 		b.ledger.mutex.Unlock(txID)
 
-		b.propagateForkedConflictToFutureCone(ctx, txMetadata.OutputIDs(), txID, parentConflicts)
+		if !confirmationState.IsAccepted() {
+			b.propagateForkedConflictToFutureCone(ctx, txMetadata.OutputIDs(), txID, parentConflicts)
+		}
 	})
+
+	return confirmationState
 }
 
 // propagateForkedConflictToFutureCone propagates a newly introduced Conflict to its future cone.

--- a/packages/protocol/ledger/conflictdag/conflictdag.go
+++ b/packages/protocol/ledger/conflictdag/conflictdag.go
@@ -59,12 +59,11 @@ func (c *ConflictDAG[ConflictIDType, ResourceIDType]) conflictSet(resourceID Res
 }
 
 // CreateConflict creates a new Conflict in the ConflictDAG and returns true if the Conflict was created.
-func (c *ConflictDAG[ConflictIDType, ResourceIDType]) CreateConflict(id ConflictIDType, parentIDs *advancedset.AdvancedSet[ConflictIDType], conflictingResourceIDs *advancedset.AdvancedSet[ResourceIDType]) (created bool) {
+func (c *ConflictDAG[ConflictIDType, ResourceIDType]) CreateConflict(id ConflictIDType, parentIDs *advancedset.AdvancedSet[ConflictIDType], conflictingResourceIDs *advancedset.AdvancedSet[ResourceIDType], confirmationState confirmation.State) (created bool) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
 	conflictParents := advancedset.NewAdvancedSet[*Conflict[ConflictIDType, ResourceIDType]]()
-
 	for it := parentIDs.Iterator(); it.HasNext(); {
 		parentID := it.Next()
 		parent, exists := c.conflict(parentID)
@@ -76,7 +75,7 @@ func (c *ConflictDAG[ConflictIDType, ResourceIDType]) CreateConflict(id Conflict
 	}
 
 	conflict, created := c.conflicts.GetOrCreate(id, func() (newConflict *Conflict[ConflictIDType, ResourceIDType]) {
-		newConflict = NewConflict(id, parentIDs, advancedset.NewAdvancedSet[*ConflictSet[ConflictIDType, ResourceIDType]]())
+		newConflict = NewConflict(id, parentIDs, advancedset.NewAdvancedSet[*ConflictSet[ConflictIDType, ResourceIDType]](), confirmationState)
 
 		c.registerConflictWithConflictSet(newConflict, conflictingResourceIDs)
 

--- a/packages/protocol/ledger/conflictdag/conflictdag.go
+++ b/packages/protocol/ledger/conflictdag/conflictdag.go
@@ -271,8 +271,6 @@ func (c *ConflictDAG[ConflictIDType, ResourceIDType]) rejectConflictsWithFutureC
 
 // ConfirmationState returns the ConfirmationState of the given ConflictIDs.
 func (c *ConflictDAG[ConflictIDType, ResourceIDType]) ConfirmationState(conflictIDs *advancedset.AdvancedSet[ConflictIDType]) (confirmationState confirmation.State) {
-	// TODO: simplify this method
-
 	// we are on master reality.
 	if conflictIDs.IsEmpty() {
 		return confirmation.Confirmed
@@ -283,9 +281,8 @@ func (c *ConflictDAG[ConflictIDType, ResourceIDType]) ConfirmationState(conflict
 
 	// we start with Confirmed because state is Aggregated to the lowest state.
 	confirmationState = confirmation.Confirmed
-	for it := conflictIDs.Iterator(); it.HasNext(); {
-		conflictID := it.Next()
-		if confirmationState = confirmationState.Aggregate(c.confirmationState(conflictID)); confirmationState.IsRejected() {
+	for conflictID := conflictIDs.Iterator(); conflictID.HasNext(); {
+		if confirmationState = confirmationState.Aggregate(c.confirmationState(conflictID.Next())); confirmationState.IsRejected() {
 			return confirmation.Rejected
 		}
 	}

--- a/packages/protocol/ledger/conflictdag/models.go
+++ b/packages/protocol/ledger/conflictdag/models.go
@@ -22,13 +22,13 @@ type Conflict[ConflictIDType, ResourceIDType comparable] struct {
 	m sync.RWMutex
 }
 
-func NewConflict[ConflictIDType comparable, ResourceIDType comparable](id ConflictIDType, parents *advancedset.AdvancedSet[ConflictIDType], conflictSets *advancedset.AdvancedSet[*ConflictSet[ConflictIDType, ResourceIDType]]) (c *Conflict[ConflictIDType, ResourceIDType]) {
+func NewConflict[ConflictIDType comparable, ResourceIDType comparable](id ConflictIDType, parents *advancedset.AdvancedSet[ConflictIDType], conflictSets *advancedset.AdvancedSet[*ConflictSet[ConflictIDType, ResourceIDType]], confirmationState confirmation.State) (c *Conflict[ConflictIDType, ResourceIDType]) {
 	c = &Conflict[ConflictIDType, ResourceIDType]{
 		id:                id,
 		parents:           parents,
 		children:          advancedset.NewAdvancedSet[*Conflict[ConflictIDType, ResourceIDType]](),
 		conflictSets:      conflictSets,
-		confirmationState: confirmation.Pending,
+		confirmationState: confirmationState,
 	}
 
 	return c

--- a/packages/protocol/ledger/conflictdag/testframework.go
+++ b/packages/protocol/ledger/conflictdag/testframework.go
@@ -105,7 +105,7 @@ func (t *TestFramework) CreateConflict(conflictAlias string, parentConflictIDs u
 		}
 	}
 
-	t.Instance.CreateConflict(t.ConflictID(conflictAlias), parentConflictIDs, t.ConflictSetIDs(conflictSetAliases...))
+	t.Instance.CreateConflict(t.ConflictID(conflictAlias), parentConflictIDs, t.ConflictSetIDs(conflictSetAliases...), confirmation.Pending)
 }
 
 func (t *TestFramework) UpdateConflictingResources(conflictAlias string, conflictingResourcesAliases ...string) {

--- a/packages/protocol/ledger/ledger_test.go
+++ b/packages/protocol/ledger/ledger_test.go
@@ -35,9 +35,7 @@ func TestLedger_BookInOrder(t *testing.T) {
 	tf.CreateTransaction("TX8", 1, "TX7.0")
 
 	{
-		for _, txAlias := range []string{"G", "TX1", "TX1*", "TX2", "TX2*", "TX3", "TX3*", "TX4", "TX5", "TX6", "TX7", "TX8"} {
-			require.NoError(t, tf.IssueTransactions(txAlias))
-		}
+		require.NoError(t, tf.IssueTransactions("G", "TX1", "TX1*", "TX2", "TX2*", "TX3", "TX3*", "TX4", "TX5", "TX6", "TX7", "TX8"))
 
 		tf.AssertConflictIDs(map[string][]string{
 			"G":    {},
@@ -156,9 +154,7 @@ func TestLedger_SetConflictConfirmed(t *testing.T) {
 
 	// Mark A as Confirmed
 	{
-		for _, txAlias := range []string{"G", "TXA", "TXB", "TXC", "TXD", "TXH", "TXI"} {
-			require.NoError(t, tf.IssueTransactions(txAlias))
-		}
+		require.NoError(t, tf.IssueTransactions("G", "TXA", "TXB", "TXC", "TXD", "TXH", "TXI"))
 		require.True(t, tf.Instance.ConflictDAG.SetConflictAccepted(tf.Transaction("TXA").ID()))
 
 		tf.AssertConflictIDs(map[string][]string{
@@ -222,9 +218,7 @@ func TestLedger_SetConflictConfirmed(t *testing.T) {
 
 	// When creating the first transaction (F) of top layer it should be booked under the Pending parent C
 	{
-		for _, txAlias := range []string{"TXF"} {
-			require.NoError(t, tf.IssueTransactions(txAlias))
-		}
+		require.NoError(t, tf.IssueTransactions("TXF"))
 
 		tf.AssertConflictIDs(map[string][]string{
 			"G":   {},
@@ -257,9 +251,7 @@ func TestLedger_SetConflictConfirmed(t *testing.T) {
 
 	// When creating the conflicting TX (G) of the top layer conflicts F & G are spawned by the fork of G
 	{
-		for _, txAlias := range []string{"TXG"} {
-			require.NoError(t, tf.IssueTransactions(txAlias))
-		}
+		require.NoError(t, tf.IssueTransactions("TXG"))
 
 		tf.AssertConflictIDs(map[string][]string{
 			"G":   {},
@@ -299,9 +291,7 @@ func TestLedger_SetConflictConfirmed(t *testing.T) {
 
 	// TX L combines a child (G) of a Rejected conflict (C) and a pending conflict H, resulting in (G,H)
 	{
-		for _, txAlias := range []string{"TXL"} {
-			require.NoError(t, tf.IssueTransactions(txAlias))
-		}
+		require.NoError(t, tf.IssueTransactions("TXL"))
 
 		tf.AssertConflictIDs(map[string][]string{
 			"G":   {},
@@ -342,9 +332,7 @@ func TestLedger_SetConflictConfirmed(t *testing.T) {
 
 	// The new TX M should be now booked under G, as conflict H confirmed, just G because we don't propagate H further.
 	{
-		for _, txAlias := range []string{"TXM"} {
-			require.NoError(t, tf.IssueTransactions(txAlias))
-		}
+		require.NoError(t, tf.IssueTransactions("TXM"))
 
 		tf.AssertConflictIDs(map[string][]string{
 			"G":   {},
@@ -532,9 +520,7 @@ func TestLedger_ForkAlreadyConflictingTransaction(t *testing.T) {
 	tf.CreateTransaction("TX2", 1, "G.0")
 	tf.CreateTransaction("TX3", 1, "G.1")
 
-	for _, txAlias := range []string{"G", "TX1", "TX2", "TX3"} {
-		require.NoError(t, tf.IssueTransactions(txAlias))
-	}
+	require.NoError(t, tf.IssueTransactions("G", "TX1", "TX2", "TX3"))
 
 	tf.AssertConflictIDs(map[string][]string{
 		"G":   {},
@@ -564,10 +550,7 @@ func TestLedger_TransactionCausallyRelated(t *testing.T) {
 	tf.CreateTransaction("TX2", 1, "TX1.0")
 	tf.CreateTransaction("TX3", 1, "G.0", "TX2.0")
 
-	for _, txAlias := range []string{"G", "TX1", "TX2"} {
-		require.NoError(t, tf.IssueTransactions(txAlias))
-	}
-
+	require.NoError(t, tf.IssueTransactions("G", "TX1", "TX2"))
 	require.EqualError(t, tf.IssueTransactions("TX3"), "TransactionID(TX3) is trying to spend causally related Outputs: transaction invalid")
 }
 

--- a/packages/protocol/ledger/testframework.go
+++ b/packages/protocol/ledger/testframework.go
@@ -90,6 +90,8 @@ func NewTestFramework(test *testing.T, instance *Ledger) *TestFramework {
 		t.Instance.Storage.OutputMetadataStorage.Store(genesisOutputMetadata).Release()
 
 		t.outputIDsByAlias["Genesis"] = genesisOutput.ID()
+		t.ConflictDAG.RegisterConflictIDAlias("Genesis", utxo.EmptyTransactionID)
+		t.ConflictDAG.RegisterConflictSetIDAlias("Genesis", genesisOutput.ID())
 		genesisOutput.ID().RegisterAlias("Genesis")
 	}
 	return t

--- a/packages/protocol/ledger/testframework.go
+++ b/packages/protocol/ledger/testframework.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/xerrors"
 
 	"github.com/iotaledger/goshimmer/packages/core/confirmation"
 	"github.com/iotaledger/goshimmer/packages/protocol/engine/tangle/blockdag"
@@ -173,9 +174,15 @@ func (t *TestFramework) CreateTransaction(txAlias string, outputCount uint16, in
 	return tx
 }
 
-// IssueTransaction issues the transaction given by txAlias.
-func (t *TestFramework) IssueTransaction(txAlias string) (err error) {
-	return t.Instance.StoreAndProcessTransaction(context.Background(), t.Transaction(txAlias))
+// IssueTransactions issues the transaction given by txAlias.
+func (t *TestFramework) IssueTransactions(txAliases ...string) (err error) {
+	for _, txAlias := range txAliases {
+		if err = t.Instance.StoreAndProcessTransaction(context.Background(), t.Transaction(txAlias)); err != nil {
+			return xerrors.Errorf("failed to issue transaction '%s': %w", txAlias, err)
+		}
+	}
+
+	return nil
 }
 
 // MockOutputFromTx creates an utxo.OutputID from a given MockedTransaction and outputIndex.

--- a/packages/protocol/ledger/testframework.go
+++ b/packages/protocol/ledger/testframework.go
@@ -224,6 +224,18 @@ func (t *TestFramework) AssertConflictIDs(expectedConflicts map[string][]string)
 	}
 }
 
+// AssertBranchConfirmationState asserts the confirmation state of the given branch.
+func (t *TestFramework) AssertBranchConfirmationState(txAlias string, validator func(state confirmation.State) bool) {
+	require.True(t.test, validator(t.ConflictDAG.ConfirmationState(txAlias)))
+}
+
+// AssertTransactionConfirmationState asserts the confirmation state of the given transaction.
+func (t *TestFramework) AssertTransactionConfirmationState(txAlias string, validator func(state confirmation.State) bool) {
+	t.ConsumeTransactionMetadata(t.Transaction(txAlias).ID(), func(txMetadata *TransactionMetadata) {
+		require.True(t.test, validator(txMetadata.ConfirmationState()))
+	})
+}
+
 // AssertBooked asserts the booking status of all given transactions.
 func (t *TestFramework) AssertBooked(expectedBookedMap map[string]bool) {
 	for txAlias, expectedBooked := range expectedBookedMap {


### PR DESCRIPTION
# Description of change

This PR fixes a problem where already confirmed Transactions where forked as pending branches, which caused them to have to be confirmed another time.

Fixes #2597 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
